### PR TITLE
update setup.py to permit 'python setup.py develop' workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
-.tox
-.coverage*
-*.pyc
 *.egg-info
+*.pyc
+.cache
+.coverage*
+.eggs
+.hypothesis
+.tox
+dist
 docs/_build/
 htmlcov
-dist
-.cache
-.hypothesis
+venv

--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,28 @@ Never again violate the `single responsibility principle <https://en.wikipedia.o
 
 .. -testimonials-
 
+
+Development
+===========
+
+To prepare a development environment, type::
+
+  pyvenv venv
+  pip install -U pip
+  python setup.py develop
+
+(If you don't have pyvenv installed, consider `virtualenv
+<https://virtualenv.pypa.io/>`__ or `virtualenvwrapper
+<https://virtualenvwrapper.readthedocs.io/>`__ instead.)
+
+And, later::
+
+  python setup.py test
+
+Also, read `CONTRIBUTING
+<https://github.com/python-attrs/attrs/blob/master/CONTRIBUTING.rst>`__.
+
+
 Testimonials
 ============
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 coverage
+hypothesis
+pympler
 pytest
 zope.interface
-pympler
-hypothesis

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,14 @@ CLASSIFIERS = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 INSTALL_REQUIRES = []
+TEST_REQUIRES = [
+    "coverage",
+    "hypothesis",
+    "pympler",
+    "pytest",
+    "zope.interface",
+    ]
+SETUP_REQUIRES = ["pytest-runner"]
 
 ###############################################################################
 
@@ -91,4 +99,6 @@ if __name__ == "__main__":
         zip_safe=False,
         classifiers=CLASSIFIERS,
         install_requires=INSTALL_REQUIRES,
+        tests_require=TEST_REQUIRES,
+        setup_requires=SETUP_REQUIRES,
     )


### PR DESCRIPTION
See README.rst for explanation of changes.

We could use something like `TEST_REQUIRES = open("dev-requirements.txt").readlines()` to lessen duplication, but that file is not in MANIFEST.in, which means that it would fail when built from a package built by setup (I think).
