### PR TITLE
Public API to check a declared attribute type and to check if it is mandatory/optional

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -149,6 +149,42 @@ Helpers
       False
 
 
+.. autofunction:: attr.validators.is_mandatory
+
+   For example:
+
+   .. doctest::
+
+      >>> @attr.s
+      ... class C(object):
+      ...     x = attr.ib(validator=attr.validators.instance_of(int))
+      ...     y = attr.ib(validator=attr.validators.optional(attr.validators.instance_of(int)))
+      >>> attr.validators.is_mandatory(attr.fields(C).x)
+      True
+      >>> attr.validators.is_mandatory(attr.fields(C).y)
+      False
+
+    ..  versionadded:: ??? (to complete)
+
+
+.. autofunction:: attr.validators.guess_type_from_validators
+
+   For example:
+
+   .. doctest::
+
+      >>> @attr.s
+      ... class C(object):
+      ...     x = attr.ib(validator=attr.validators.instance_of(int))
+      ...     y = attr.ib()
+      >>> attr.validators.guess_type_from_validators(attr.fields(C).x)
+      int
+      >>> attr.validators.guess_type_from_validators(attr.fields(C).y) is None
+      True
+
+    ..  versionadded:: ??? (to complete)
+
+
 .. autofunction:: attr.asdict
 
    For example:
@@ -276,6 +312,32 @@ Validators
       TypeError: ("'x' must be <type 'int'> (got '42' that is a <type 'str'>).", Attribute(name='x', default=NOTHING, validator=<instance_of validator for type <type 'int'>>), <type 'int'>, '42')
       >>> C(None)
       C(x=None)
+
+.. autofunction:: attr.validators.chain
+
+    For example:
+
+    .. doctest::
+
+      >>> def custom_validator(instance, attribute, value):
+      ...     allowed = {'+', '*'}
+      ...     if value not in allowed:
+      ...         raise ValueError('\'op\' has to be a string in ' + str(allowed) + '!')
+      >>> @attr.s
+      ... class C(object):
+      ...     x = attr.ib(validator=attr.validators.chain(custom_validator, attr.validators.instance_of(str)))
+      >>> C("+")
+      C(x='+')
+      >>> C("-")
+      Traceback (most recent call last):
+         ...
+      ValueError: 'op' has to be a string in {'+', '*'}!
+      >>> C(None)
+      Traceback (most recent call last):
+         ...
+      ValueError: 'op' has to be a string in {'+', '*'}!
+
+    ..  versionadded:: ??? (to complete)
 
 
 Deprecated APIs

--- a/src/attr/validators.py
+++ b/src/attr/validators.py
@@ -114,9 +114,9 @@ def optional(validator):
     return _OptionalValidator(validator)
 
 
-@attr.s(repr=False, slots=True)
+@attributes(repr=False, slots=True)
 class _AndValidator(object):
-    validators = attr.ib()
+    validators = attr()
 
     def __call__(self, inst, attr, value):
         for v in self.validators:
@@ -144,12 +144,13 @@ def _guess_type_from_validator(validator):
     in order to unpack the validators.
 
     :param validator:
+
     :return: the type of attribute declared in an inner 'instance_of' validator (if any is found, the first one is used)
     or None if no inner 'instance_of' validator is found
     """
     if isinstance(validator, _OptionalValidator):
         # Optional : look inside
-        return _guess_type_from_validator(validator)
+        return _guess_type_from_validator(validator.validator)
 
     elif isinstance(validator, _AndValidator):
         # Sequence : try each of them
@@ -168,23 +169,26 @@ def _guess_type_from_validator(validator):
         return None
 
 
-def guess_type_from_validators(attr):
+def guess_type_from_validators(att):
     """
     Utility method to return the declared type of an attribute or None. It handles _OptionalValidator and _AndValidator
     in order to unpack the validators.
 
-    :param attr:
+    :param att: the attribute for which
+
     :return: the type of attribute declared in an inner 'instance_of' validator (if any is found, the first one is used)
     or None if no inner 'instance_of' validator is found
     """
-    return _guess_type_from_validator(attr.validator)
+    return _guess_type_from_validator(att.validator)
 
 
-def is_mandatory(attr):
+def is_mandatory(att):
     """
     Helper method to find if an attribute is mandatory, by checking if its validator is 'optional' or not.
+    Note that this does not check for the presence of a default value
 
-    :param attr:
-    :return:
+    :param att:
+
+    :return: a boolean indicating if the attribute is mandatory
     """
-    return not isinstance(attr.validator, _OptionalValidator)
+    return not isinstance(att.validator, _OptionalValidator)

--- a/src/attr/validators.py
+++ b/src/attr/validators.py
@@ -112,3 +112,79 @@ def optional(validator):
     :param validator: A validator that is used for non-``None`` values.
     """
     return _OptionalValidator(validator)
+
+
+@attr.s(repr=False, slots=True)
+class _AndValidator(object):
+    validators = attr.ib()
+
+    def __call__(self, inst, attr, value):
+        for v in self.validators:
+            v(inst, attr, value)
+        return
+
+    def __repr__(self):
+        return (
+            "<validator sequence : {seq}>".format(seq=repr(self.validators))
+        )
+
+
+def chain(*validators):
+    """
+    A validator that applies several validators in order
+
+    :param validators: A sequence of validators
+    """
+    return _AndValidator(validators)
+
+
+def _guess_type_from_validator(validator):
+    """
+    Utility method to return the declared type of an attribute or None. It handles _OptionalValidator and _AndValidator
+    in order to unpack the validators.
+
+    :param validator:
+    :return: the type of attribute declared in an inner 'instance_of' validator (if any is found, the first one is used)
+    or None if no inner 'instance_of' validator is found
+    """
+    if isinstance(validator, _OptionalValidator):
+        # Optional : look inside
+        return _guess_type_from_validator(validator)
+
+    elif isinstance(validator, _AndValidator):
+        # Sequence : try each of them
+        for v in validator.validators:
+            typ = _guess_type_from_validator(v)
+            if typ is not None:
+                return typ
+        return None
+
+    elif isinstance(validator, _InstanceOfValidator):
+        # InstanceOf validator : found it !
+        return validator.type
+
+    else:
+        # we could not find the type
+        return None
+
+
+def guess_type_from_validators(attr):
+    """
+    Utility method to return the declared type of an attribute or None. It handles _OptionalValidator and _AndValidator
+    in order to unpack the validators.
+
+    :param attr:
+    :return: the type of attribute declared in an inner 'instance_of' validator (if any is found, the first one is used)
+    or None if no inner 'instance_of' validator is found
+    """
+    return _guess_type_from_validator(attr.validator)
+
+
+def is_mandatory(attr):
+    """
+    Helper method to find if an attribute is mandatory, by checking if its validator is 'optional' or not.
+
+    :param attr:
+    :return:
+    """
+    return not isinstance(attr.validator, _OptionalValidator)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -7,9 +7,8 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import zope.interface
 
-from attr.validators import instance_of, provides, optional
 from attr._compat import TYPE
-
+from attr.validators import instance_of, provides, optional, chain, guess_type_from_validators, is_mandatory
 from .utils import simple_attr
 
 
@@ -154,3 +153,128 @@ class TestOptional(object):
              "<{type} 'int'>> or None>")
             .format(type=TYPE)
         ) == repr(v)
+
+
+class TestChain(object):
+    """
+    Tests for `chain`.
+    """
+    def test_success_with_type(self):
+        """
+        Nothing happens if types match.
+        """
+        v = chain(instance_of(int))
+        v(None, simple_attr("test"), 42)
+
+    def test_fail(self):
+        """
+        Raises `TypeError` on wrong types.
+        """
+        v = chain(instance_of(int))
+        a = simple_attr("test")
+        with pytest.raises(TypeError) as e:
+            v(None, a, "42")
+        assert (
+            "'test' must be <{type} 'int'> (got '42' that is a <{type} "
+            "'str'>).".format(type=TYPE),
+            a, int, "42",
+
+        ) == e.value.args
+
+    def test_repr(self):
+        """
+        Returned validator has a useful `__repr__`.
+        """
+        v = chain(instance_of(int))
+        assert (
+            ("<validator sequence : (<instance_of validator for type "
+             "<{type} 'int'>>,)>")
+            .format(type=TYPE)
+        ) == repr(v)
+
+
+def custom_validator(instance, attribute, value):
+    allowed = {'+', '*'}
+    if value not in allowed:
+        raise ValueError('\'op\' has to be a string in ' + str(allowed) + '!')
+
+
+class TestIsMandatory(object):
+    """
+    Tests for utility method `is_mandatory`.
+    """
+    def test_simple(self):
+        """
+        if validator is a simple instance_of it works
+        """
+        att = simple_attr("test", validator=instance_of(int))
+        assert is_mandatory(att) == True
+
+    def test_optional(self):
+        """
+        if validator is an optional containing is_instance it works
+        """
+        att = simple_attr("test", validator=optional(instance_of(int)))
+        assert is_mandatory(att) == False
+
+
+class TestGuessType(object):
+    """
+    Tests for utility method `guess_type_from_validators`
+    """
+
+    def test_simple(self):
+        """
+        if validator is a simple instance_of it works
+        """
+        att = simple_attr("test", validator=instance_of(int))
+        assert guess_type_from_validators(att) == int
+
+    def test_simple_not_found(self):
+        """
+        if validator is a simple instance_of it works
+        """
+        att = simple_attr("test", validator=custom_validator)
+        assert guess_type_from_validators(att) == None
+
+    def test_optional(self):
+        """
+        if validator is an optional containing is_instance it works
+        """
+        att = simple_attr("test", validator=optional(instance_of(int)))
+        assert guess_type_from_validators(att) == int
+
+    def test_optional_not_found(self):
+        """
+        if validator is a simple instance_of it works
+        """
+        att = simple_attr("test", validator=optional(custom_validator))
+        assert guess_type_from_validators(att) == None
+
+    def test_chain(self):
+        """
+        if validator is a chain containing is_instance it also works
+        """
+        att = simple_attr("test", validator=chain(custom_validator, instance_of(str)))
+        assert guess_type_from_validators(att) == str
+
+    def test_chain_not_found(self):
+        """
+        if validator is a chain containing is_instance it also works
+        """
+        att = simple_attr("test", validator=chain(custom_validator, custom_validator))
+        assert guess_type_from_validators(att) == None
+
+    def test_optional_chain(self):
+        """
+        if validator is an optional containing a chain containing an is_instance it also works
+        """
+        att = simple_attr("test", validator=optional(chain(custom_validator, instance_of(str))))
+        assert guess_type_from_validators(att) == str
+
+    def test_optional_chain_not_found(self):
+        """
+        if validator is an optional containing a chain containing an is_instance it also works
+        """
+        att = simple_attr("test", validator=optional(chain(custom_validator, custom_validator)))
+        assert guess_type_from_validators(att) == None

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -193,12 +193,6 @@ class TestChain(object):
         ) == repr(v)
 
 
-def custom_validator(instance, attribute, value):
-    allowed = {'+', '*'}
-    if value not in allowed:
-        raise ValueError('\'op\' has to be a string in ' + str(allowed) + '!')
-
-
 class TestIsMandatory(object):
     """
     Tests for utility method `is_mandatory`.
@@ -216,6 +210,12 @@ class TestIsMandatory(object):
         """
         att = simple_attr("test", validator=optional(instance_of(int)))
         assert is_mandatory(att) == False
+
+
+def custom_validator(instance, attribute, value):
+    allowed = {'+', '*'}
+    if value not in allowed:
+        raise ValueError('\'op\' has to be a string in ' + str(allowed) + '!')
 
 
 class TestGuessType(object):


### PR DESCRIPTION
Hello everyone,

First of all thanks a lot for this great library ! I am sad I found it only a couple days ago, otherwise I would probably not have spent time writing [classtools-autocode](https://github.com/smarie/python-classtools-autocode). Indeed its main idea was to remove some of the boilerplate and link with [PyContracts](https://andreacensi.github.io/contracts/) for validation.

Anyway, today I make this pull request because in another project of mine currently in development mode, [parsyfiles](https://github.com/smarie/python-parsyfiles/tree/develop), I perform some type introspection to understand what is required to parse an object. I use PEP484 type hints for that, but I wanted to support attrs too so I implemented something that does the job, and now I am proposing it to you.

The proposal is made of two functions : 'guess_type_from_validators', and 'is_mandatory'. Feel free to change the naming, I am not particularly good at finding great names.

For 'is_mandatory': it is simply checking if the validator is an instance of 'optional'.

For 'guess_type_from_validators': type information is extracted from the 'instance_of' validator. In order to help users rely on this validator instead of doing the same type checking in their custom validators, I introduce the 'chain' validator. Note that this might now be useless, since I saw in the source that you allow lists of validators.
In the future if [issue 97](https://github.com/python-attrs/attrs/issues/97) is resolved, the 'guess_type_from_validators' method should be updated to also use the new python 3.6 type hints as an additional source of type hint.

I added some unit tests for all the code, and updated the doc in api.rst.

Let me know what you think.