### PR TITLE
Allow setting an annotation for attr.ib

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -71,7 +71,7 @@ Core
       ... class C(object):
       ...     x = attr.ib()
       >>> C.x
-      Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}))
+      Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), annotation=NOTHING)
 
 
 .. autofunction:: attr.make_class
@@ -127,9 +127,9 @@ Helpers
       ...     x = attr.ib()
       ...     y = attr.ib()
       >>> attr.fields(C)
-      (Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({})), Attribute(name='y', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({})))
+      (Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), annotation=NOTHING), Attribute(name='y', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), annotation=NOTHING))
       >>> attr.fields(C)[1]
-      Attribute(name='y', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}))
+      Attribute(name='y', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), annotation=NOTHING)
       >>> attr.fields(C).y is attr.fields(C)[1]
       True
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -514,7 +514,7 @@ Slot classes are a little different than ordinary, dictionary-backed classes:
     ... class C(object):
     ...     x = attr.ib()
     >>> C.x
-    Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}))
+    Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), annotation=NOTHING)
     >>> @attr.s(slots=True)
     ... class C(object):
     ...     x = attr.ib()

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -17,7 +17,7 @@ So it is fairly simple to build your own decorators on top of ``attrs``:
    ... @attr.s
    ... class C(object):
    ...     a = attr.ib()
-   (Attribute(name='a', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({})),)
+   (Attribute(name='a', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), annotation=NOTHING),)
 
 
 .. warning::

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -50,7 +50,7 @@ Sentinel to indicate the lack of a value when ``None`` is ambiguous.
 
 def attr(default=NOTHING, validator=None,
          repr=True, cmp=True, hash=None, init=True,
-         convert=None, metadata={}):
+         convert=None, metadata={}, annotation=NOTHING):
     """
     Create a new attribute on a class.
 
@@ -108,6 +108,8 @@ def attr(default=NOTHING, validator=None,
         value is converted before being passed to the validator, if any.
     :param metadata: An arbitrary mapping, to be used by third-party
         components.  See :ref:`extending_metadata`.
+    :param annotation: An arbitrary object that will be exposed as a type
+        annotation on a constructed __init__.
 
     ..  versionchanged:: 17.1.0 *validator* can be a ``list`` now.
     ..  versionchanged:: 17.1.0
@@ -126,6 +128,7 @@ def attr(default=NOTHING, validator=None,
         init=init,
         convert=convert,
         metadata=metadata,
+        annotation=annotation,
     )
 
 
@@ -347,6 +350,7 @@ def attributes(maybe_cls=None, these=None, repr_ns=None,
 
         if init is True:
             cls = _add_init(cls, effectively_frozen)
+
         if effectively_frozen is True:
             cls.__setattr__ = _frozen_setattrs
             cls.__delattr__ = _frozen_delattrs
@@ -563,6 +567,16 @@ def _add_init(cls, frozen):
         globs["_cached_setattr"] = _obj_setattr
     eval(bytecode, globs, locs)
     init = locs["__init__"]
+
+    attrs_with_annotations = [a for a in attrs if a.annotation != NOTHING]
+
+    if attrs_with_annotations:
+        try:
+            init.__annotations__
+        except AttributeError:
+            init.__annotations__ = {}
+        for a in attrs_with_annotations:
+            init.__annotations__[a.name] = a.annotation
 
     # In order of debuggers like PDB being able to step through the code,
     # we add a fake linecache entry.
@@ -805,11 +819,11 @@ class Attribute(object):
     """
     __slots__ = (
         "name", "default", "validator", "repr", "cmp", "hash", "init",
-        "convert", "metadata",
+        "convert", "metadata", 'annotation',
     )
 
     def __init__(self, name, default, _validator, repr, cmp, hash, init,
-                 convert=None, metadata=None):
+                 convert=None, metadata=None, annotation=NOTHING):
         # Cache this descriptor here to speed things up later.
         __bound_setattr = _obj_setattr.__get__(self, Attribute)
 
@@ -823,6 +837,7 @@ class Attribute(object):
         __bound_setattr("convert", convert)
         __bound_setattr("metadata", (metadata_proxy(metadata) if metadata
                                      else _empty_metadata_singleton))
+        __bound_setattr("annotation", annotation)
 
     def __setattr__(self, name, value):
         raise FrozenInstanceError()
@@ -875,7 +890,7 @@ class _CountingAttr(object):
     the order in which the attributes have been defined.
     """
     __slots__ = ("counter", "default", "repr", "cmp", "hash", "init",
-                 "metadata", "_validator", "convert")
+                 "metadata", "_validator", "convert", "annotation")
     __attrs_attrs__ = tuple(
         Attribute(name=name, default=NOTHING, _validator=None,
                   repr=True, cmp=True, hash=True, init=True)
@@ -888,7 +903,7 @@ class _CountingAttr(object):
     cls_counter = 0
 
     def __init__(self, default, validator, repr, cmp, hash, init, convert,
-                 metadata):
+                 metadata, annotation):
         _CountingAttr.cls_counter += 1
         self.counter = _CountingAttr.cls_counter
         self.default = default
@@ -903,6 +918,7 @@ class _CountingAttr(object):
         self.init = init
         self.convert = convert
         self.metadata = metadata
+        self.annotation = annotation
 
     def validator(self, meth):
         if not isinstance(self._validator, _AndValidator):

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,43 @@
+"""
+Tests for behaviour of annotations on attributes.
+"""
+
+import attr
+
+try:
+    from typing import get_type_hints
+except ImportError:
+    def get_type_hints(x):
+        return getattr(x, '__annotations__', {})
+
+
+@attr.s()
+class A(object):
+    a = attr.ib(annotation=int)
+    b = attr.ib()
+
+
+@attr.s(init=False)
+class B(object):
+    a = attr.ib(annotation=int)
+    b = attr.ib()
+
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+
+class TestAnnotations(object):
+    def test_propagates_annotations_to_attribute_object(self):
+        assert A.a.annotation == int
+        assert A.b.annotation == attr.NOTHING
+
+    def test_propagates_annotation_to_init_if_requested(self):
+        assert get_type_hints(A.__init__) == {'a': int}
+
+    def test_does_not_annotate_init_if_not_generated(self):
+        assert get_type_hints(B.__init__) == {}
+
+    def test_correctly_annotates_even_without_init(self):
+        assert B.a.annotation == int
+        assert B.b.annotation == attr.NOTHING

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -160,7 +160,7 @@ class TestTransformAttrs(object):
             "default value or factory.  Attribute in question: Attribute"
             "(name='y', default=NOTHING, validator=None, repr=True, "
             "cmp=True, hash=None, init=True, convert=None, "
-            "metadata=mappingproxy({}))",
+            "metadata=mappingproxy({}), annotation=NOTHING)",
         ) == e.value.args
 
     def test_these(self):


### PR DESCRIPTION
This is a somewhat speculative pull request to gauge interest. It adds an additional annotation parameter to attr.ib for use with Python 3 type annotations.

Currently this only has two effects:

* It adds types to \_\_init\_\_
* It exposes the annotation on the attribute object itself

It would be nice to propagate this further, but there isn't apparently a standard way to do that

My use case is that I'm considering how one might make more things easy to generate out of the box, and having annotations on init helps a lot for that.