### PR TITLE
Document another reason why not namedtuples

### DIFF
--- a/docs/why.rst
+++ b/docs/why.rst
@@ -97,6 +97,36 @@ The difference between :func:`collections.namedtuple`\ s and classes decorated b
 
 This can easily lead to surprising and unintended behaviors.
 
+Additionally, ``attrs`` lets you create mutable classes:
+
+.. doctest::
+
+   >>> import attr
+   >>> @attr.s
+   ... class Customer(object):
+   ...     first_name = attr.ib()
+   >>> c1 = Customer(first_name='Kaitlyn')
+   >>> c1.first_name
+   'Kaitlyn'
+   >>> c1.first_name = 'Katelyn'
+   >>> c1.first_name
+   'Katelyn'
+
+
+…while classes created with :func:`collections.namedtuple` inherit from tuple and are therefore immutable:
+
+.. doctest::
+
+   >>> from collections import namedtuple
+   >>> Customer = namedtuple('Customer', 'first_name')
+   >>> c1 = Customer(first_name='Kaitlyn')
+   >>> c1.first_name
+   'Kaitlyn'
+   >>> c1.first_name = 'Katelyn'
+   Traceback (most recent call last):
+     File "<stdin>", line 1, in <module>
+   AttributeError: can't set attribute
+
 Other than that, ``attrs`` also adds nifty features like validators and default values.
 
 .. _tuple: https://docs.python.org/2/tutorial/datastructures.html#tuples-and-sequences

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -97,7 +97,9 @@ The difference between :func:`collections.namedtuple`\ s and classes decorated b
 
 This can easily lead to surprising and unintended behaviors.
 
-Additionally, ``attrs`` lets you create mutable classes:
+Additionally, classes decorated with ``attrs`` can be either mutable or immutable.
+Immutable classes are created by simply passing a ``frozen=True`` argument to the ``attrs`` decorator, as described in the :doc:`api`.
+By default, however, classes created by ``attrs`` are mutable:
 
 .. doctest::
 
@@ -112,8 +114,7 @@ Additionally, ``attrs`` lets you create mutable classes:
    >>> c1.first_name
    'Katelyn'
 
-
-…while classes created with :func:`collections.namedtuple` inherit from tuple and are therefore immutable:
+…while classes created with :func:`collections.namedtuple` inherit from tuple and are therefore always immutable:
 
 .. doctest::
 


### PR DESCRIPTION
Hi,

Just a minor addition to the docs. This was why I opted for attrs vs namedtuples.

Damian