### PR TITLE
BUG: fix evolve behaviour when a validator fails.

### DIFF
--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -218,8 +218,8 @@ def evolve(inst, **changes):
     except TypeError as exc:
         attr_dict = {attr.name: attr for attr in fields(cls)}
         for name in changes:
-            if not name in attr_dict:
+            if name not in attr_dict:
                 k = exc.args[0].split("'")[1]
                 raise AttrsAttributeNotFoundError(
-                    "{k} is not an attrs attribute on {cl}.".format(k=k, cl=cls))
+                    "{} is not an attrs attribute on {}.".format(k, cls))
         raise

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -201,7 +201,8 @@ def evolve(inst, **changes):
     ..  versionadded:: 17.1.0
     """
     cls = inst.__class__
-    for a in fields(cls):
+    attrs = fields(cls)
+    for a in attrs:
         attr_name = a.name  # To deal with private attributes.
         if attr_name[0] == "_":
             init_name = attr_name[1:]
@@ -216,9 +217,8 @@ def evolve(inst, **changes):
     try:
         return cls(**changes)
     except TypeError as exc:
-        attr_dict = {attr.name: attr for attr in fields(cls)}
         for name in changes:
-            if name not in attr_dict:
+            if getattr(attrs, name, None) is None:
                 k = exc.args[0].split("'")[1]
                 raise AttrsAttributeNotFoundError(
                     "{} is not an attrs attribute on {}.".format(k, cls))

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -216,6 +216,10 @@ def evolve(inst, **changes):
     try:
         return cls(**changes)
     except TypeError as exc:
-        k = exc.args[0].split("'")[1]
-        raise AttrsAttributeNotFoundError(
-            "{k} is not an attrs attribute on {cl}.".format(k=k, cl=cls))
+        attr_dict = {attr.name: attr for attr in fields(cls)}
+        for name in changes:
+            if not name in attr_dict:
+                k = exc.args[0].split("'")[1]
+                raise AttrsAttributeNotFoundError(
+                    "{k} is not an attrs attribute on {cl}.".format(k=k, cl=cls))
+        raise

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -24,6 +24,9 @@ from attr import (
 )
 
 from attr.exceptions import AttrsAttributeNotFoundError
+from attr.validators import instance_of
+from attr._compat import TYPE
+
 
 MAPPING_TYPES = (dict, OrderedDict)
 SEQUENCE_TYPES = (list, tuple)
@@ -464,3 +467,16 @@ class TestEvolve(object):
         assert (
             "aaaa is not an attrs attribute on {cls!r}.".format(cls=C),
         ) == e.value.args
+
+
+    def test_validator_failure(self):
+        """
+        Make sure we don't swallow TypeError when validation fails within evolve
+        """
+        @attributes
+        class C(object):
+            a = attr(validator=instance_of(int))
+
+        with pytest.raises(TypeError) as e:
+            evolve(C(a=1), a="some string")
+        assert e.value.args[0].startswith("'a' must be <{type} 'int'>".format(type=TYPE))


### PR DESCRIPTION
This is a naive solution to #175. TypeError may be coming from many sources, and it is not correct to assume it always comes from a non-existing attr member as the evolve codes now. Instead, we now check specifically for this case when raising a custom error, and just re-raise in other cases.

Fixes #175 