### PR TITLE
Added `composite` validator.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,8 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
+- Added ``attr.validators.composite()`` allowing the user to combine validators passed in as arguments.
+  `#183 <https://github.com/python-attrs/attrs/pull/183>`_
 - Fix default hashing behavior.
   Now *hash* mirrors the value of *cmp* and classes are unhashable by default.
   `#136`_

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -283,6 +283,31 @@ Validators
       >>> C(None)
       C(x=None)
 
+.. autofunction:: attr.validators.composite
+
+.. versionadded:: 17.1.0
+
+   For example:
+
+   .. doctest::
+
+      >>> def not_empty(instance, attr, value):
+      ...     if len(value) == 0:
+      ...         raise ValueError('Please supply a non empty value')
+      >>> @attr.s
+      ... class C(object):
+      ...     x = attr.ib(validator=attr.validators.composite(attr.validators.instance_of(list), not_empty))
+      >>> C([])
+      Traceback (most recent call last):
+         ...
+      ValueError: Please supply a non empty value
+      >>> C({1})
+      Traceback (most recent call last):
+         ...
+      TypeError: ('x' must be <class 'list'> (got set() that is a <class 'set'>).",...
+      >>> C([1])
+      C(x=[1])
+
 
 Deprecated APIs
 ---------------

--- a/src/attr/validators.py
+++ b/src/attr/validators.py
@@ -111,3 +111,28 @@ def optional(validator):
     :param validator: A validator that is used for non-``None`` values.
     """
     return _OptionalValidator(validator)
+
+
+@attributes(repr=False, slots=True)
+class _CompositeValidator(object):
+    validators = attr()
+
+    def __call__(self, inst, attr, value):
+        for validator in self.validators:
+            validator(inst, attr, value)
+
+    def __repr__(self):
+        return (
+            "<composite validator for validators {!r}>"
+            .format(self.validators)
+        )
+
+
+def composite(*validators):
+    """A validator that executes each validator passed as arguments.
+
+    """
+    if len(validators) < 2:
+        raise TypeError('Composite validator requires at least 2 validators')
+
+    return _CompositeValidator(validators)


### PR DESCRIPTION
Hi there,

first of all thank you for attrs, it's truly a joy to use.

I just wanted to contribute this composite validator I wrote that's been useful for me, hopefully it makes sense for you too.

# Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](http://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/utils.py).
- [x] Updated **documentation** for changed code.
- [x] Documentation in `.rst` files is written using [semantic newlines](http://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [x] Changes (and possible deprecations) are documented in [`CHANGELOG.rst`](https://github.com/python-attrs/attrs/blob/master/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
