### PR TITLE
Add takes_self to Factory and @_CountingAttr.default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,6 +61,12 @@ Changes:
 - Validators can now be defined conveniently inline by using the attribute as a decorator.
   Check out the `examples <http://www.attrs.org/en/stable/examples.html#validators>`_ to see it in action!
   `#143 <https://github.com/python-attrs/attrs/issues/143>`_
+- ``attr.Factory()`` now has a ``takes_self`` argument that makes the initializer to pass the partially initialized instance into the factory.
+  In other words you can define attribute defaults based on other attributes.
+  `#165`_
+- Default factories can now also be defined inline using decorators.
+  They are *always* passed the partially initialized instance.
+  `#165`_
 - Conversion can now be made optional using ``attr.converters.optional()``.
   `#105 <https://github.com/python-attrs/attrs/issues/105>`_
   `#173 <https://github.com/python-attrs/attrs/pull/173>`_
@@ -70,6 +76,7 @@ Changes:
   `#155 <https://github.com/python-attrs/attrs/pull/155>`_
 
 .. _`#136`: https://github.com/python-attrs/attrs/issues/136
+.. _`#165`: https://github.com/python-attrs/attrs/issues/165
 
 
 ----

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -100,13 +100,20 @@ Core
       >>> @attr.s
       ... class C(object):
       ...     x = attr.ib(default=attr.Factory(list))
+      ...     y = attr.ib(default=attr.Factory(
+      ...         lambda self: set(self.x),
+      ...         takes_self=True)
+      ...     )
       >>> C()
-      C(x=[])
+      C(x=[], y=set())
+      >>> C([1, 2, 3])
+      C(x=[1, 2, 3], y={1, 2, 3})
 
 
 .. autoexception:: attr.exceptions.FrozenInstanceError
 .. autoexception:: attr.exceptions.AttrsAttributeNotFoundError
 .. autoexception:: attr.exceptions.NotAnAttrsClassError
+.. autoexception:: attr.exceptions.DefaultAlreadySetError
 
 
 .. _helpers:
@@ -203,11 +210,12 @@ See :ref:`asdict` for examples.
       >>> i1 == i2
       False
 
-    ``evolve`` creates a new instance using ``__init__``. This fact has several implications:
+  ``evolve`` creates a new instance using ``__init__``.
+  This fact has several implications:
 
-    * private attributes should be specified without the leading underscore, just like in ``__init__``.
-    * attributes with ``init=False`` can't be set with ``evolve``.
-    * the usual ``__init__`` validators will validate the new values.
+  * private attributes should be specified without the leading underscore, just like in ``__init__``.
+  * attributes with ``init=False`` can't be set with ``evolve``.
+  * the usual ``__init__`` validators will validate the new values.
 
 .. autofunction:: validate
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -262,6 +262,21 @@ And sometimes you even want mutable objects as default values (ever used acciden
 
 More information on why class methods for constructing objects are awesome can be found in this insightful `blog post <http://as.ynchrono.us/2014/12/asynchronous-object-initialization.html>`_.
 
+Default factories can also be set using a decorator.
+The method receives the partially initialiazed instance which enables you to base a default value on other attributes:
+
+.. doctest::
+
+   >>> @attr.s
+   ... class C(object):
+   ...     x = attr.ib(default=1)
+   ...     y = attr.ib()
+   ...     @y.default
+   ...     def name_does_not_matter(self):
+   ...         return self.x + 1
+   >>> C()
+   C(x=1, y=2)
+
 
 .. _examples_validators:
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -7,7 +7,11 @@ from operator import itemgetter
 
 from . import _config
 from ._compat import PY2, iteritems, isclass, iterkeys, metadata_proxy
-from .exceptions import FrozenInstanceError, NotAnAttrsClassError
+from .exceptions import (
+    DefaultAlreadySetError,
+    FrozenInstanceError,
+    NotAnAttrsClassError,
+)
 
 
 # This is used at least twice, so cache it here.
@@ -701,20 +705,25 @@ def _attrs_to_script(attrs, frozen, post_init):
             attrs_to_validate.append(a)
         attr_name = a.name
         arg_name = a.name.lstrip("_")
+        has_factory = isinstance(a.default, Factory)
+        if has_factory and a.default.takes_self:
+            maybe_self = "self"
+        else:
+            maybe_self = ""
         if a.init is False:
-            if isinstance(a.default, Factory):
+            if has_factory:
                 if a.convert is not None:
                     lines.append(fmt_setter_with_converter(
                         attr_name,
-                        "attr_dict['{attr_name}'].default.factory()"
-                        .format(attr_name=attr_name)))
+                        "attr_dict['{attr_name}'].default.factory({self})"
+                        .format(attr_name=attr_name, self=maybe_self)))
                     conv_name = _init_convert_pat.format(a.name)
                     names_for_globals[conv_name] = a.convert
                 else:
                     lines.append(fmt_setter(
                         attr_name,
-                        "attr_dict['{attr_name}'].default.factory()"
-                        .format(attr_name=attr_name)
+                        "attr_dict['{attr_name}'].default.factory({self})"
+                        .format(attr_name=attr_name, self=maybe_self)
                     ))
             else:
                 if a.convert is not None:
@@ -731,7 +740,7 @@ def _attrs_to_script(attrs, frozen, post_init):
                         "attr_dict['{attr_name}'].default"
                         .format(attr_name=attr_name)
                     ))
-        elif a.default is not NOTHING and not isinstance(a.default, Factory):
+        elif a.default is not NOTHING and not has_factory:
             args.append(
                 "{arg_name}=attr_dict['{attr_name}'].default".format(
                     arg_name=arg_name,
@@ -743,7 +752,7 @@ def _attrs_to_script(attrs, frozen, post_init):
                 names_for_globals[_init_convert_pat.format(a.name)] = a.convert
             else:
                 lines.append(fmt_setter(attr_name, arg_name))
-        elif a.default is not NOTHING and isinstance(a.default, Factory):
+        elif has_factory:
             args.append("{arg_name}=NOTHING".format(arg_name=arg_name))
             lines.append("if {arg_name} is not NOTHING:"
                          .format(arg_name=arg_name))
@@ -753,8 +762,8 @@ def _attrs_to_script(attrs, frozen, post_init):
                 lines.append("else:")
                 lines.append("    " + fmt_setter_with_converter(
                     attr_name,
-                    "attr_dict['{attr_name}'].default.factory()"
-                    .format(attr_name=attr_name)
+                    "attr_dict['{attr_name}'].default.factory({self})"
+                    .format(attr_name=attr_name, self=maybe_self)
                 ))
                 names_for_globals[_init_convert_pat.format(a.name)] = a.convert
             else:
@@ -762,8 +771,8 @@ def _attrs_to_script(attrs, frozen, post_init):
                 lines.append("else:")
                 lines.append("    " + fmt_setter(
                     attr_name,
-                    "attr_dict['{attr_name}'].default.factory()"
-                    .format(attr_name=attr_name)
+                    "attr_dict['{attr_name}'].default.factory({self})"
+                    .format(attr_name=attr_name, self=maybe_self)
                 ))
         else:
             args.append(arg_name)
@@ -808,21 +817,21 @@ class Attribute(object):
         "convert", "metadata",
     )
 
-    def __init__(self, name, default, _validator, repr, cmp, hash, init,
+    def __init__(self, name, _default, _validator, repr, cmp, hash, init,
                  convert=None, metadata=None):
         # Cache this descriptor here to speed things up later.
-        __bound_setattr = _obj_setattr.__get__(self, Attribute)
+        bound_setattr = _obj_setattr.__get__(self, Attribute)
 
-        __bound_setattr("name", name)
-        __bound_setattr("default", default)
-        __bound_setattr("validator", _validator)
-        __bound_setattr("repr", repr)
-        __bound_setattr("cmp", cmp)
-        __bound_setattr("hash", hash)
-        __bound_setattr("init", init)
-        __bound_setattr("convert", convert)
-        __bound_setattr("metadata", (metadata_proxy(metadata) if metadata
-                                     else _empty_metadata_singleton))
+        bound_setattr("name", name)
+        bound_setattr("default", _default)
+        bound_setattr("validator", _validator)
+        bound_setattr("repr", repr)
+        bound_setattr("cmp", cmp)
+        bound_setattr("hash", hash)
+        bound_setattr("init", init)
+        bound_setattr("convert", convert)
+        bound_setattr("metadata", (metadata_proxy(metadata) if metadata
+                                   else _empty_metadata_singleton))
 
     def __setattr__(self, name, value):
         raise FrozenInstanceError()
@@ -832,8 +841,10 @@ class Attribute(object):
         inst_dict = {
             k: getattr(ca, k)
             for k
-            in Attribute.__slots__ + ("_validator",)
-            if k != "name" and k != "validator"  # `validator` is a method
+            in Attribute.__slots__ + ("_validator", "_default")
+            if k != "name" and k not in (
+                "validator", "default",
+            )  # exclude methods
         }
         return cls(name=name, **inst_dict)
 
@@ -850,16 +861,16 @@ class Attribute(object):
         """
         Play nice with pickle.
         """
-        __bound_setattr = _obj_setattr.__get__(self, Attribute)
+        bound_setattr = _obj_setattr.__get__(self, Attribute)
         for name, value in zip(self.__slots__, state):
             if name != "metadata":
-                __bound_setattr(name, value)
+                bound_setattr(name, value)
             else:
-                __bound_setattr(name, metadata_proxy(value) if value else
-                                _empty_metadata_singleton)
+                bound_setattr(name, metadata_proxy(value) if value else
+                              _empty_metadata_singleton)
 
 
-_a = [Attribute(name=name, default=NOTHING, _validator=None,
+_a = [Attribute(name=name, _default=NOTHING, _validator=None,
                 repr=True, cmp=True, hash=(name != "metadata"), init=True)
       for name in Attribute.__slots__]
 
@@ -877,15 +888,15 @@ class _CountingAttr(object):
     *Internal* data structure of the attrs library.  Running into is most
     likely the result of a bug like a forgotten `@attr.s` decorator.
     """
-    __slots__ = ("counter", "default", "repr", "cmp", "hash", "init",
+    __slots__ = ("counter", "_default", "repr", "cmp", "hash", "init",
                  "metadata", "_validator", "convert")
     __attrs_attrs__ = tuple(
-        Attribute(name=name, default=NOTHING, _validator=None,
+        Attribute(name=name, _default=NOTHING, _validator=None,
                   repr=True, cmp=True, hash=True, init=True)
         for name
-        in ("counter", "default", "repr", "cmp", "hash", "init",)
+        in ("counter", "_default", "repr", "cmp", "hash", "init",)
     ) + (
-        Attribute(name="metadata", default=None, _validator=None,
+        Attribute(name="metadata", _default=None, _validator=None,
                   repr=True, cmp=True, hash=False, init=True),
     )
     cls_counter = 0
@@ -894,7 +905,7 @@ class _CountingAttr(object):
                  metadata):
         _CountingAttr.cls_counter += 1
         self.counter = _CountingAttr.cls_counter
-        self.default = default
+        self._default = default
         # If validator is a list/tuple, wrap it using helper validator.
         if validator and isinstance(validator, (list, tuple)):
             self._validator = and_(*validator)
@@ -912,6 +923,8 @@ class _CountingAttr(object):
         Decorator that adds *meth* to the list of validators.
 
         Returns *meth* unchanged.
+
+        .. versionadded:: 17.1.0
         """
         if self._validator is None:
             self._validator = meth
@@ -919,19 +932,52 @@ class _CountingAttr(object):
             self._validator = and_(self._validator, meth)
         return meth
 
+    def default(self, meth):
+        """
+        Decorator that allows to set the default for an attribute.
+
+        Returns *meth* unchanged.
+
+        :raises DefaultAlreadySetError: If default has been set before.
+
+        .. versionadded:: 17.1.0
+        """
+        if self._default is not NOTHING:
+            raise DefaultAlreadySetError()
+
+        self._default = Factory(meth, takes_self=True)
+
+        return meth
+
 
 _CountingAttr = _add_cmp(_add_repr(_CountingAttr))
 
 
-@attributes(slots=True)
+@attributes(slots=True, init=False)
 class Factory(object):
     """
     Stores a factory callable.
 
     If passed as the default value to :func:`attr.ib`, the factory is used to
     generate a new value.
+
+    :param callable factory: A callable that takes either none or exactly one
+        mandatory positional argument depending on *takes_self*.
+    :param bool takes_self: Pass the partially initialized instance that is
+        being initialized as a positional argument.
+
+    .. versionadded:: 17.1.0  *takes_self*
     """
     factory = attr()
+    takes_self = attr()
+
+    def __init__(self, factory, takes_self=False):
+        """
+        `Factory` is part of the default machinery so if we want a default
+        value here, we have to implement it ourselves.
+        """
+        self.factory = factory
+        self.takes_self = takes_self
 
 
 def make_class(name, attrs, bases=(object,), **attributes_arguments):

--- a/src/attr/exceptions.py
+++ b/src/attr/exceptions.py
@@ -28,3 +28,12 @@ class NotAnAttrsClassError(ValueError):
 
     .. versionadded:: 16.2.0
     """
+
+
+class DefaultAlreadySetError(RuntimeError):
+    """
+    A default has been set using ``attr.ib()`` and is attempted to be reset
+    using the decorator.
+
+    .. versionadded:: 17.1.0
+    """

--- a/tests/test_dark_magic.py
+++ b/tests/test_dark_magic.py
@@ -109,9 +109,9 @@ class TestDarkMagic(object):
         `attr.fields` works.
         """
         assert (
-            Attribute(name="x", default=foo, _validator=None,
+            Attribute(name="x", _default=foo, _validator=None,
                       repr=True, cmp=True, hash=None, init=True),
-            Attribute(name="y", default=attr.Factory(list), _validator=None,
+            Attribute(name="y", _default=attr.Factory(list), _validator=None,
                       repr=True, cmp=True, hash=None, init=True),
         ) == attr.fields(cls)
 
@@ -158,9 +158,9 @@ class TestDarkMagic(object):
         """
         PC = attr.make_class("PC", ["a", "b"], slots=slots, frozen=frozen)
         assert (
-            Attribute(name="a", default=NOTHING, _validator=None,
+            Attribute(name="a", _default=NOTHING, _validator=None,
                       repr=True, cmp=True, hash=None, init=True),
-            Attribute(name="b", default=NOTHING, _validator=None,
+            Attribute(name="b", _default=NOTHING, _validator=None,
                       repr=True, cmp=True, hash=None, init=True),
         ) == attr.fields(PC)
 
@@ -251,4 +251,23 @@ class TestDarkMagic(object):
 
     @pytest.mark.parametrize("cls", [WithMeta, WithMetaSlots])
     def test_metaclass_preserved(self, cls):
+        """
+        Metaclass data is preserved.
+        """
         assert Meta == type(cls)
+
+    def test_default_decorator(self):
+        """
+        Default decorator sets the default and the respective method gets
+        called.
+        """
+        @attr.s
+        class C(object):
+            x = attr.ib(default=1)
+            y = attr.ib()
+
+            @y.default
+            def compute(self):
+                return self.x + 1
+
+        assert C(1, 2) == C()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -35,7 +35,7 @@ def simple_attr(name, default=NOTHING, validator=None, repr=True,
     Return an attribute with a name and no other bells and whistles.
     """
     return Attribute(
-        name=name, default=default, _validator=validator, repr=repr,
+        name=name, _default=default, _validator=validator, repr=repr,
         cmp=cmp, hash=hash, init=init
     )
 


### PR DESCRIPTION
Now this is a biggie but I believe it’s worth it for 17.1.  There should be no performance penalty but it’s a feature that people have been yearning for since day one. :)

Let me know what you think, contains some boy scouting.  Most notably the completely hosted markup in api.rst around evolve.   Also WTF was with local dunder variables in methods?  I suppose copy pasta?

This enables the following:

```python
@attr.s
class C:
    x = attr.ib(default=1)
    y = attr.ib(default=attr.Factory(lambda self: self.x + 1, takes_self=True))
    z = attr.ib()

    @z.default
    def whatever(self):
        return self.y + 1
```

Now calling `C()` gives you `C(x=1, y=2, z=3)`.

Fixes #165 