### PR TITLE
Document weakref to slot class

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -531,6 +531,20 @@ Slot classes are a little different than ordinary, dictionary-backed classes:
   Those methods are created for frozen slot classes because they won't pickle otherwise.
   `Think twice <https://www.youtube.com/watch?v=7KnfGDajDQw>`_ before using :mod:`pickle` though.
 
+- As always with slot classes, you must specify a ``__weakref__`` slot if you wish for the class to be weak-referenceable.
+  Here's how it looks using attrs:
+
+  .. doctest::
+
+    >>> import weakref
+    >>> @attr.s(slots=True)
+    ... class C(object):
+    ...     __weakref__ = attr.ib(init=False, hash=False, repr=False, cmp=False)
+    ...     x = attr.ib()
+    >>> c = C(1)
+    >>> weakref.ref(c)
+    <weakref at 0x...; to 'C' at 0x...>
+
 All in all, setting ``slots=True`` is usually a very good idea.
 
 


### PR DESCRIPTION
This adds a paragraph to the documentation that includes the method
described by @Tinche in #174 for making a slot class weak-referenceable.

# Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](http://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/utils.py).
- [ ] Updated **documentation** for changed code.
- [x] Documentation in `.rst` files is written using [semantic newlines](http://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [ ] Changes (and possible deprecations) are documented in [`CHANGELOG.rst`](https://github.com/python-attrs/attrs/blob/master/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
