### PR TITLE
Fix unbound __str__ on Python 2 when slots=True

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,7 +24,8 @@ Deprecations:
 Changes:
 ^^^^^^^^
 
-*none*
+- Fix *str* on Python 2 when ``slots=True``.
+  `#198 <https://github.com/python-attrs/attrs/issues/198>`_
 
 
 ----

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -343,9 +343,7 @@ def attributes(maybe_cls=None, these=None, repr_ns=None,
         # Can't compare function objects because Python 2 is terrible. :(
         effectively_frozen = _has_frozen_superclass(cls) or frozen
         if repr is True:
-            cls = _add_repr(cls, ns=repr_ns)
-        if str is True:
-            cls.__str__ = cls.__repr__
+            cls = _add_repr(cls, ns=repr_ns, str=str)
         if cmp is True:
             cls = _add_cmp(cls)
 
@@ -516,9 +514,9 @@ def _add_cmp(cls, attrs=None):
     return cls
 
 
-def _add_repr(cls, ns=None, attrs=None):
+def _add_repr(cls, ns=None, attrs=None, str=False):
     """
-    Add a repr method to *cls*.
+    Add a repr method to *cls*. If *str* is True, also add __str__.
     """
     if attrs is None:
         attrs = [a for a in cls.__attrs_attrs__ if a.repr]
@@ -543,6 +541,8 @@ def _add_repr(cls, ns=None, attrs=None):
                       for a in attrs)
         )
     cls.__repr__ = repr_
+    if str is True:
+        cls.__str__ = repr_
     return cls
 
 

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -198,15 +198,15 @@ class TestAddRepr(object):
 
         assert "C(_x=42)" == repr(i)
 
-    @pytest.mark.parametrize("add_str", [True, False])
-    def test_str(self, add_str):
+    @given(add_str=booleans(), slots=booleans())
+    def test_str(self, add_str, slots):
         """
         If str is True, it returns the same as repr.
 
         This only makes sense when subclassing a class with an poor __str__
         (like Exceptions).
         """
-        @attributes(str=add_str)
+        @attributes(str=add_str, slots=slots)
         class Error(Exception):
             x = attr()
 


### PR DESCRIPTION
Previously:

```pycon
>>> import attr
>>> @attr.s(str=True, slots=True)
... class A(object):
...     a = attr.ib()
...
>>> a = A(1)
>>> str(a)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unbound method repr_() must be called with A instance as first argument (got nothing instead)
```

Fixes #198.

# Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](http://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/utils.py).
- [ ] Updated **documentation** for changed code.
- [x] Documentation in `.rst` files is written using [semantic newlines](http://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [x] Changes (and possible deprecations) are documented in [`CHANGELOG.rst`](https://github.com/python-attrs/attrs/blob/master/CHANGELOG.rst).

