### PR TITLE
Fix typo in example error message

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -308,7 +308,7 @@ If the value does not pass the validator's standards, it just raises an appropri
    ...     @x.validator
    ...     def check(self, attribute, value):
    ...         if value > 42:
-   ...             raise ValueError("y must be smaller or equal to 42")
+   ...             raise ValueError("x must be smaller or equal to 42")
    >>> C(42)
    C(x=42)
    >>> C(43)


### PR DESCRIPTION
The error message on line 311 said "y must be... when it was supposed to be "x must be...

# Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](http://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/utils.py).
- [x] Updated **documentation** for changed code.
- [x] Documentation in `.rst` files is written using [semantic newlines](http://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [ ] Changes (and possible deprecations) are documented in [`CHANGELOG.rst`](https://github.com/python-attrs/attrs/blob/master/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
