### PR TITLE
Pass appropriate stacklevel in assoc deprecation warning.

### DIFF
--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -170,7 +170,7 @@ def assoc(inst, **changes):
     """
     import warnings
     warnings.warn("assoc is deprecated and will be removed after 2018/01.",
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
     new = copy.copy(inst)
     attrs = fields(inst.__class__)
     for k, v in iteritems(changes):

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -416,6 +416,19 @@ class TestAssoc(object):
         with pytest.deprecated_call():
             assert C(3, 2) == assoc(C(1, 2), x=3)
 
+    def test_warning(self):
+        """
+        DeprecationWarning points to the correct file.
+        """
+        @attributes
+        class C(object):
+            x = attr()
+
+        with pytest.deprecated_call() as wi:
+            assert C(2) == assoc(C(1), x=2)
+
+        assert __file__ == wi.list[0].filename
+
 
 class TestEvolve(object):
     """

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -424,7 +424,7 @@ class TestAssoc(object):
         class C(object):
             x = attr()
 
-        with pytest.deprecated_call() as wi:
+        with pytest.warns(DeprecationWarning) as wi:
             assert C(2) == assoc(C(1), x=2)
 
         assert __file__ == wi.list[0].filename


### PR DESCRIPTION
Fixes #208.

I (deliberately) didn't document this change or write a test for it, let me know if that was a mistake.