### PR TITLE
Fix some typos in doc strings

### DIFF
--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -17,7 +17,7 @@ def asdict(inst, recurse=True, filter=None, dict_factory=dict,
     :param inst: Instance of an ``attrs``-decorated class.
     :param bool recurse: Recurse into classes that are also
         ``attrs``-decorated.
-    :param callable filter: A callable whose return code deteremines whether an
+    :param callable filter: A callable whose return code determines whether an
         attribute or element is included (``True``) or dropped (``False``).  Is
         called with the :class:`attr.Attribute` as the first argument and the
         value as the second argument.

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -69,7 +69,7 @@ def attr(default=NOTHING, validator=None,
         excluded using ``init=False``.
 
         If the value is an instance of :class:`Factory`, its callable will be
-        used to construct a new value (useful for mutable datatypes like lists
+        used to construct a new value (useful for mutable data types like lists
         or dicts).
 
         If a default is not set (or set manually to ``attr.NOTHING``), a value
@@ -256,7 +256,7 @@ def attributes(maybe_cls=None, these=None, repr_ns=None,
         to automatically detect that.  Therefore it's possible to set the
         namespace explicitly for a more meaningful ``repr`` output.
     :param bool repr: Create a ``__repr__`` method with a human readable
-        represantation of ``attrs`` attributes..
+        representation of ``attrs`` attributes..
     :param bool str: Create a ``__str__`` method that is identical to
         ``__repr__``.  This is usually not necessary except for
         :class:`Exception`\ s.
@@ -284,7 +284,7 @@ def attributes(maybe_cls=None, these=None, repr_ns=None,
         and the `GitHub issue that led to the default behavior \
         <https://github.com/python-attrs/attrs/issues/136>`_ for more details.
     :type hash: ``bool`` or ``None``
-    :param bool init: Create a ``__init__`` method that initialiazes the
+    :param bool init: Create a ``__init__`` method that initializes the
         ``attrs`` attributes.  Leading underscores are stripped for the
         argument name.  If a ``__attrs_post_init__`` method exists on the
         class, it will be called after the class is fully initialized.
@@ -627,7 +627,7 @@ def fields(cls):
     :raise attr.exceptions.NotAnAttrsClassError: If *cls* is not an ``attrs``
         class.
 
-    :rtype: tuple (with name accesors) of :class:`attr.Attribute`
+    :rtype: tuple (with name accessors) of :class:`attr.Attribute`
 
     ..  versionchanged:: 16.2.0 Returned tuple allows accessing the fields
         by name.
@@ -1022,7 +1022,7 @@ def make_class(name, attrs, bases=(object,), **attributes_arguments):
     return attributes(**attributes_arguments)(type(name, bases, cls_dict))
 
 
-# These are required by whithin this module so we define them here and merely
+# These are required by within this module so we define them here and merely
 # import into .validators.
 
 

--- a/src/attr/validators.py
+++ b/src/attr/validators.py
@@ -43,7 +43,7 @@ class _InstanceOfValidator(object):
 def instance_of(type):
     """
     A validator that raises a :exc:`TypeError` if the initializer is called
-    with a wrong type for this particular attribute (checks are perfomed using
+    with a wrong type for this particular attribute (checks are performed using
     :func:`isinstance` therefore it's also valid to pass a tuple of types).
 
     :param type: The type to check for.


### PR DESCRIPTION
Found by scrolling through the files in PyCharm and looking at
highlighted words.

# Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](http://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

- [N/A] Added **tests** for changed code.
- [N/A] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/utils.py).
- [N/A] Updated **documentation** for changed code.
- [N/A] Documentation in `.rst` files is written using [semantic newlines](http://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [N/A] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [N/A] Changes (and possible deprecations) are documented in [`CHANGELOG.rst`](https://github.com/python-attrs/attrs/blob/master/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
