### PR TITLE
Some more typos

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -263,7 +263,7 @@ And sometimes you even want mutable objects as default values (ever used acciden
 More information on why class methods for constructing objects are awesome can be found in this insightful `blog post <http://as.ynchrono.us/2014/12/asynchronous-object-initialization.html>`_.
 
 Default factories can also be set using a decorator.
-The method receives the partially initialiazed instance which enables you to base a default value on other attributes:
+The method receives the partially initialized instance which enables you to base a default value on other attributes:
 
 .. doctest::
 

--- a/docs/how-does-it-work.rst
+++ b/docs/how-does-it-work.rst
@@ -51,7 +51,7 @@ Immutability
 
 In order to give you immutability, ``attrs`` will attach a ``__setattr__`` method to your class that raises a :exc:`attr.exceptions.FrozenInstanceError` whenever anyone tries to set an attribute.
 
-In order to circumvent that ourselves in ``__init__``, ``attrs`` uses (an agressively cached) :meth:`object.__setattr__` to set your attributes.  This is (still) slower than a plain assignment:
+In order to circumvent that ourselves in ``__init__``, ``attrs`` uses (an aggressively cached) :meth:`object.__setattr__` to set your attributes.  This is (still) slower than a plain assignment:
 
 .. code-block:: none
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -2,7 +2,7 @@
 Overview
 ========
 
-In order to fullfil its ambitious goal of bringing back the joy to writing classes, it gives you a class decorator and a way to declaratively define the attributes on that class:
+In order to fulfill its ambitious goal of bringing back the joy to writing classes, it gives you a class decorator and a way to declaratively define the attributes on that class:
 
 .. include:: ../README.rst
    :start-after: -code-begin-

--- a/tests/test_dark_magic.py
+++ b/tests/test_dark_magic.py
@@ -183,7 +183,7 @@ class TestDarkMagic(object):
     def test_subclass_without_extra_attrs(self, base):
         """
         Sub-classing (where the subclass does not have extra attrs) still
-        behaves the same as a subclss with extra attrs.
+        behaves the same as a subclass with extra attrs.
         """
         class Sub2(base):
             pass


### PR DESCRIPTION
I went with the American spelling of "fulfill" instead of the British "fulfil".

# Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](http://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

- [N/A] Added **tests** for changed code.
- [N/A] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/utils.py).
- [N/A] Updated **documentation** for changed code.
- [N/A] Documentation in `.rst` files is written using [semantic newlines](http://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [N/A] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [N/A] Changes (and possible deprecations) are documented in [`CHANGELOG.rst`](https://github.com/python-attrs/attrs/blob/master/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
