### PR TITLE
Add init_validation flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,7 @@ Changes:
   `#198 <https://github.com/python-attrs/attrs/issues/198>`_
 - ``attr.Factory`` is hashable again.
   `#204 <https://github.com/python-attrs/attrs/issues/204>`_
+- Add ``init_validation`` option to ``attr.s`` that controls whether validators are run at the end of the ``__init__()`` method.
 
 
 ----

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -18,7 +18,7 @@ What follows is the API explanation, if you'd like a more hands-on introduction,
 Core
 ----
 
-.. autofunction:: attr.s(these=None, repr_ns=None, repr=True, cmp=True, hash=None, init=True, slots=False, frozen=False, str=False)
+.. autofunction:: attr.s(these=None, repr_ns=None, repr=True, cmp=True, hash=None, init=True, init_validation=True, slots=False, frozen=False, str=False)
 
    .. note::
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -371,8 +371,7 @@ def attributes(maybe_cls=None, these=None, repr_ns=None,
             cls.__hash__ = None
 
         if init is True:
-            cls = _add_init(cls, effectively_frozen,
-                            init_validation=init_validation)
+            cls = _add_init(cls, effectively_frozen, init_validation)
         if effectively_frozen is True:
             cls.__setattr__ = _frozen_setattrs
             cls.__delattr__ = _frozen_delattrs
@@ -574,7 +573,7 @@ def _add_repr(cls, ns=None, attrs=None, str=False):
     return cls
 
 
-def _add_init(cls, frozen, *, init_validation=True):
+def _add_init(cls, frozen, init_validation):
     """
     Add a __init__ method to *cls*.  If *frozen* is True, make it immutable.
     """

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -40,7 +40,7 @@ class InitC(object):
     __attrs_attrs__ = [simple_attr("a"), simple_attr("b")]
 
 
-InitC = _add_init(InitC, False)
+InitC = _add_init(InitC, False, True)
 
 
 class TestAddCmp(object):
@@ -381,7 +381,7 @@ class TestAddInit(object):
                 simple_attr(name="c", default=None),
             ]
 
-        C = _add_init(C, False)
+        C = _add_init(C, False, True)
         i = C()
         assert 2 == i.a
         assert "hallo" == i.b
@@ -399,7 +399,7 @@ class TestAddInit(object):
                 simple_attr(name="a", default=Factory(list)),
                 simple_attr(name="b", default=Factory(D)),
             ]
-        C = _add_init(C, False)
+        C = _add_init(C, False, True)
         i = C()
         assert [] == i.a
         assert isinstance(i.b, D)
@@ -462,7 +462,7 @@ class TestAddInit(object):
         class C(object):
             __attrs_attrs__ = [simple_attr("_private")]
 
-        C = _add_init(C, False)
+        C = _add_init(C, False, True)
         i = C(private=42)
         assert 42 == i._private
 

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -626,6 +626,22 @@ class TestValidate(object):
         with pytest.raises(FloatingPointError):
             validate(i)
 
+    def test_init_validation(self):
+        """
+        Setting init_validation to False prevent validation from
+        running during init.
+        """
+        def raiser(_, __, value):
+            if value == 42:
+                raise FloatingPointError
+
+        C = make_class("C", {"x": attr(validator=raiser)},
+                       init_validation=False)
+        i = C(42)
+
+        with pytest.raises(FloatingPointError):
+            validate(i)
+
     def test_run_validators(self):
         """
         Setting `_run_validators` to False prevents validators from running.


### PR DESCRIPTION
This adds an `init_validation` flag to ``attr.s`` that controls whether validators are run at the end of the ``__init__()`` method.  This allows one to choose when validation should be run, which can be useful in some situations.

# Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](http://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/utils.py).
- [x] Updated **documentation** for changed code.
- [x] Documentation in `.rst` files is written using [semantic newlines](http://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [x] Changes (and possible deprecations) are documented in [`CHANGELOG.rst`](https://github.com/python-attrs/attrs/blob/master/CHANGELOG.rst).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
