### PR TITLE
Stop setting attributes on class bodies

### DIFF
--- a/changelog.d/253.breaking.rst
+++ b/changelog.d/253.breaking.rst
@@ -1,0 +1,5 @@
+Attributes are not defined on the class body anymore.
+This means that if you define a class ``C`` with an attribute ``x``, the class will *not* have an attribute ``x`` for introspection anymore.
+Instead of ``C.x``, use ``attr.fields(C).x`` or look at ``C.__attrs_attrs__``.
+
+The old behavior has been deprecated since version 16.1.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -89,7 +89,7 @@ Core
       >>> @attr.s
       ... class C(object):
       ...     x = attr.ib()
-      >>> C.x
+      >>> attr.fields(C).x
       Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), type=None)
 
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -505,22 +505,6 @@ Slot classes are a little different than ordinary, dictionary-backed classes:
          ...
      AttributeError: 'Coordinates' object has no attribute 'z'
 
-- Slot classes cannot share attribute names with their instances, while non-slot classes can.
-  The following behaves differently if slot classes are used:
-
-  .. doctest::
-
-    >>> @attr.s
-    ... class C(object):
-    ...     x = attr.ib()
-    >>> C.x
-    Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), type=None)
-    >>> @attr.s(slots=True)
-    ... class C(object):
-    ...     x = attr.ib()
-    >>> C.x
-    <member 'x' of 'C' objects>
-
 - Since non-slot classes cannot be turned into slot classes after they have been created, ``attr.s(.., slots=True)`` will *replace* the class it is applied to with a copy.
   In almost all cases this isn't a problem, but we mention it for the sake of completeness.
 

--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -23,9 +23,6 @@ if PY2:
     def iteritems(d):
         return d.iteritems()
 
-    def iterkeys(d):
-        return d.iterkeys()
-
     # Python 2 is bereft of a read-only dict proxy, so we make one!
     class ReadOnlyDict(IterableUserDict):
         """
@@ -84,9 +81,6 @@ else:
 
     def iteritems(d):
         return d.items()
-
-    def iterkeys(d):
-        return d.keys()
 
     def metadata_proxy(d):
         return types.MappingProxyType(dict(d))

--- a/tests/test_dark_magic.py
+++ b/tests/test_dark_magic.py
@@ -137,7 +137,7 @@ class TestDarkMagic(object):
         assert (
             "'x' must be <{type} 'int'> (got '1' that is a <{type} "
             "'str'>).".format(type=TYPE),
-            C1.x, int, "1",
+            attr.fields(C1).x, int, "1",
         ) == e.value.args
 
     @given(booleans())

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -418,7 +418,7 @@ class TestAddInit(object):
         C = make_class("C", {"a": attr("a", validator=raiser)})
         with pytest.raises(VException) as e:
             C(42)
-        assert (C.a, 42,) == e.value.args[1:]
+        assert (fields(C).a, 42,) == e.value.args[1:]
         assert isinstance(e.value.args[0], C)
 
     def test_validator_slots(self):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -26,8 +26,8 @@ class TestSplitWhat(object):
         """
         assert (
             frozenset((int, str)),
-            frozenset((C.a,)),
-        ) == _split_what((str, C.a, int,))
+            frozenset((fields(C).a,)),
+        ) == _split_what((str, fields(C).a, int,))
 
 
 class TestInclude(object):

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -70,6 +70,7 @@ class TestAsDict(object):
 
         def assert_proper_dict_class(obj, obj_dict):
             assert isinstance(obj_dict, dict_class)
+
             for field in fields(obj.__class__):
                 field_val = getattr(obj, field.name)
                 if has(field_val.__class__):
@@ -83,6 +84,7 @@ class TestAsDict(object):
                 elif isinstance(field_val, Mapping):
                     # This field holds a dictionary.
                     assert isinstance(obj_dict[field.name], dict_class)
+
                     for key, val in field_val.items():
                         if has(val.__class__):
                             assert_proper_dict_class(val,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -225,5 +225,8 @@ def simple_classes(draw, slots=None, frozen=None, private_attrs=None):
 # st.recursive works by taking a base strategy (in this case, simple_classes)
 # and a special function.  This function receives a strategy, and returns
 # another strategy (building on top of the base strategy).
-nested_classes = st.recursive(simple_classes(), _create_hyp_nested_strategy,
-                              max_leaves=10)
+nested_classes = st.recursive(
+    simple_classes(),
+    _create_hyp_nested_strategy,
+    max_leaves=10
+)


### PR DESCRIPTION
This behavior has been deprecated since 16.1 and can now be removed in
accordance with our backward-compatibility policy.

Interestingly, this simplified a lot of our code and might even improve performance of class creation.