### PR TITLE
Use new serious biz names in internal code

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -9,12 +9,12 @@ def C():
     """
     Return a simple but fully featured attrs class with an x and a y attribute.
     """
-    from attr import attrs, attrib
+    import attr
 
-    @attrs
+    @attr.s
     class C(object):
-        x = attrib()
-        y = attrib()
+        x = attr.ib()
+        y = attr.ib()
 
     return C
 

--- a/conftest.py
+++ b/conftest.py
@@ -9,12 +9,12 @@ def C():
     """
     Return a simple but fully featured attrs class with an x and a y attribute.
     """
-    from attr import attributes, attr
+    from attr import attrs, attrib
 
-    @attributes
+    @attrs
     class C(object):
-        x = attr()
-        y = attr()
+        x = attrib()
+        y = attrib()
 
     return C
 

--- a/src/attr/__init__.py
+++ b/src/attr/__init__.py
@@ -11,8 +11,8 @@ from ._make import (
     Attribute,
     Factory,
     NOTHING,
-    attr,
-    attributes,
+    attrib,
+    attrs,
     fields,
     make_class,
     validate,
@@ -41,8 +41,8 @@ __license__ = "MIT"
 __copyright__ = "Copyright (c) 2015 Hynek Schlawack"
 
 
-s = attrs = attributes
-ib = attrib = attr
+s = attributes = attrs
+ib = attr = attrib
 
 __all__ = [
     "Attribute",

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -59,9 +59,9 @@ Sentinel to indicate the lack of a value when ``None`` is ambiguous.
 """
 
 
-def attr(default=NOTHING, validator=None,
-         repr=True, cmp=True, hash=None, init=True,
-         convert=None, metadata={}, type=None):
+def attrib(default=NOTHING, validator=None,
+           repr=True, cmp=True, hash=None, init=True,
+           convert=None, metadata={}, type=None):
     """
     Create a new attribute on a class.
 
@@ -263,9 +263,9 @@ def _frozen_delattrs(self, name):
     raise FrozenInstanceError()
 
 
-def attributes(maybe_cls=None, these=None, repr_ns=None,
-               repr=True, cmp=True, hash=None, init=True,
-               slots=False, frozen=False, str=False):
+def attrs(maybe_cls=None, these=None, repr_ns=None,
+          repr=True, cmp=True, hash=None, init=True,
+          slots=False, frozen=False, str=False):
     r"""
     A class decorator that adds `dunder
     <https://wiki.python.org/moin/DunderAlias>`_\ -methods according to the
@@ -417,12 +417,19 @@ def attributes(maybe_cls=None, these=None, repr_ns=None,
 
         return cls
 
-    # attrs_or class type depends on the usage of the decorator.  It's a class
-    # if it's used as `@attributes` but ``None`` if used # as `@attributes()`.
+    # maybe_cls's type depends on the usage of the decorator.  It's a class
+    # if it's used as `@attrs` but ``None`` if used as `@attrs()`.
     if maybe_cls is None:
         return wrap
     else:
         return wrap(maybe_cls)
+
+
+_attrs = attrs
+"""
+Internal alias so we can use it in functions that take an argument called
+*attrs*.
+"""
 
 
 if PY2:
@@ -1010,7 +1017,7 @@ class _CountingAttr(object):
 _CountingAttr = _add_cmp(_add_repr(_CountingAttr))
 
 
-@attributes(slots=True, init=False, hash=True)
+@attrs(slots=True, init=False, hash=True)
 class Factory(object):
     """
     Stores a factory callable.
@@ -1025,8 +1032,8 @@ class Factory(object):
 
     .. versionadded:: 17.1.0  *takes_self*
     """
-    factory = attr()
-    takes_self = attr()
+    factory = attrib()
+    takes_self = attrib()
 
     def __init__(self, factory, takes_self=False):
         """
@@ -1060,12 +1067,12 @@ def make_class(name, attrs, bases=(object,), **attributes_arguments):
     if isinstance(attrs, dict):
         cls_dict = attrs
     elif isinstance(attrs, (list, tuple)):
-        cls_dict = dict((a, attr()) for a in attrs)
+        cls_dict = dict((a, attrib()) for a in attrs)
     else:
         raise TypeError("attrs argument must be a dict or a list.")
 
     post_init = cls_dict.pop("__attrs_post_init__", None)
-    return attributes(
+    return _attrs(
         these=cls_dict, **attributes_arguments
     )(type(
         name,
@@ -1078,12 +1085,12 @@ def make_class(name, attrs, bases=(object,), **attributes_arguments):
 # import into .validators.
 
 
-@attributes(slots=True, hash=True)
+@attrs(slots=True, hash=True)
 class _AndValidator(object):
     """
     Compose many validators to a single one.
     """
-    _validators = attr()
+    _validators = attrib()
 
     def __call__(self, inst, attr, value):
         for v in self._validators:

--- a/src/attr/validators.py
+++ b/src/attr/validators.py
@@ -4,7 +4,7 @@ Commonly useful validators.
 
 from __future__ import absolute_import, division, print_function
 
-from ._make import attr, attributes, and_, _AndValidator
+from ._make import attrib, attrs, and_, _AndValidator
 
 
 __all__ = [
@@ -16,9 +16,9 @@ __all__ = [
 ]
 
 
-@attributes(repr=False, slots=True, hash=True)
+@attrs(repr=False, slots=True, hash=True)
 class _InstanceOfValidator(object):
-    type = attr()
+    type = attrib()
 
     def __call__(self, inst, attr, value):
         """
@@ -56,9 +56,9 @@ def instance_of(type):
     return _InstanceOfValidator(type)
 
 
-@attributes(repr=False, slots=True, hash=True)
+@attrs(repr=False, slots=True, hash=True)
 class _ProvidesValidator(object):
-    interface = attr()
+    interface = attrib()
 
     def __call__(self, inst, attr, value):
         """
@@ -95,9 +95,9 @@ def provides(interface):
     return _ProvidesValidator(interface)
 
 
-@attributes(repr=False, slots=True, hash=True)
+@attrs(repr=False, slots=True, hash=True)
 class _OptionalValidator(object):
-    validator = attr()
+    validator = attrib()
 
     def __call__(self, inst, attr, value):
         if value is None:
@@ -130,9 +130,9 @@ def optional(validator):
     return _OptionalValidator(validator)
 
 
-@attributes(repr=False, slots=True, hash=True)
+@attrs(repr=False, slots=True, hash=True)
 class _InValidator(object):
-    options = attr()
+    options = attrib()
 
     def __call__(self, inst, attr, value):
         if value not in self.options:

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -6,11 +6,7 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from attr._make import (
-    attrib,
-    attrs,
-    fields
-)
+import attr
 
 import typing
 
@@ -24,24 +20,24 @@ class TestAnnotations(object):
         """
         Sets the `Attribute.type` attr from basic type annotations.
         """
-        @attrs
+        @attr.s
         class C(object):
-            x: int = attrib()
-            y = attrib(type=str)
-            z = attrib()
+            x: int = attr.ib()
+            y = attr.ib(type=str)
+            z = attr.ib()
 
-        assert int is fields(C).x.type
-        assert str is fields(C).y.type
-        assert None is fields(C).z.type
+        assert int is attr.fields(C).x.type
+        assert str is attr.fields(C).y.type
+        assert None is attr.fields(C).z.type
 
     def test_catches_basic_type_conflict(self):
         """
         Raises ValueError type is specified both ways.
         """
         with pytest.raises(ValueError) as e:
-            @attrs
+            @attr.s
             class C:
-                x: int = attrib(type=int)
+                x: int = attr.ib(type=int)
 
         assert ("Type annotation and type argument cannot "
                 "both be present",) == e.value.args
@@ -50,10 +46,10 @@ class TestAnnotations(object):
         """
         Sets the `Attribute.type` attr from typing annotations.
         """
-        @attrs
+        @attr.s
         class C(object):
-            x: typing.List[int] = attrib()
-            y = attrib(type=typing.Optional[str])
+            x: typing.List[int] = attr.ib()
+            y = attr.ib(type=typing.Optional[str])
 
-        assert typing.List[int] is fields(C).x.type
-        assert typing.Optional[str] is fields(C).y.type
+        assert typing.List[int] is attr.fields(C).x.type
+        assert typing.Optional[str] is attr.fields(C).y.type

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -7,8 +7,8 @@ from __future__ import absolute_import, division, print_function
 import pytest
 
 from attr._make import (
-    attr,
-    attributes,
+    attrib,
+    attrs,
     fields
 )
 
@@ -24,11 +24,12 @@ class TestAnnotations(object):
         """
         Sets the `Attribute.type` attr from basic type annotations.
         """
-        @attributes
+        @attrs
         class C(object):
-            x: int = attr()
-            y = attr(type=str)
-            z = attr()
+            x: int = attrib()
+            y = attrib(type=str)
+            z = attrib()
+
         assert int is fields(C).x.type
         assert str is fields(C).y.type
         assert None is fields(C).z.type
@@ -38,9 +39,10 @@ class TestAnnotations(object):
         Raises ValueError type is specified both ways.
         """
         with pytest.raises(ValueError) as e:
-            @attributes
+            @attrs
             class C:
-                x: int = attr(type=int)
+                x: int = attrib(type=int)
+
         assert ("Type annotation and type argument cannot "
                 "both be present",) == e.value.args
 
@@ -48,10 +50,10 @@ class TestAnnotations(object):
         """
         Sets the `Attribute.type` attr from typing annotations.
         """
-        @attributes
+        @attrs
         class C(object):
-            x: typing.List[int] = attr()
-            y = attr(type=typing.Optional[str])
+            x: typing.List[int] = attrib()
+            y = attrib(type=typing.Optional[str])
 
         assert typing.List[int] is fields(C).x.type
         assert typing.Optional[str] is fields(C).y.type

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -7,22 +7,24 @@ from __future__ import absolute_import, division, print_function
 import copy
 
 import pytest
+
 from hypothesis import given
 from hypothesis.strategies import booleans
 
-from .utils import simple_attr, simple_class
+import attr
+
 from attr._make import (
     Factory,
     NOTHING,
     _Nothing,
     _add_init,
     _add_repr,
-    attrib,
-    attrs,
     fields,
     make_class,
 )
 from attr.validators import instance_of
+
+from .utils import simple_attr, simple_class
 
 
 CmpC = simple_class(cmp=True)
@@ -53,8 +55,8 @@ class TestAddCmp(object):
         If `cmp` is False, ignore that attribute.
         """
         C = make_class("C", {
-            "a": attrib(cmp=False),
-            "b": attrib()
+            "a": attr.ib(cmp=False),
+            "b": attr.ib()
         }, slots=slots)
 
         assert C(1, 2) == C(2, 2)
@@ -178,8 +180,8 @@ class TestAddRepr(object):
         If `repr` is False, ignore that attribute.
         """
         C = make_class("C", {
-            "a": attrib(repr=False),
-            "b": attrib()
+            "a": attr.ib(repr=False),
+            "b": attr.ib()
         }, slots=slots)
 
         assert "C(b=2)" == repr(C(1, 2))
@@ -212,9 +214,9 @@ class TestAddRepr(object):
         This only makes sense when subclassing a class with an poor __str__
         (like Exceptions).
         """
-        @attrs(str=add_str, slots=slots)
+        @attr.s(str=add_str, slots=slots)
         class Error(Exception):
-            x = attrib()
+            x = attr.ib()
 
         e = Error(42)
 
@@ -249,7 +251,7 @@ class TestAddHash(object):
         assert exc_args == e.value.args
 
         with pytest.raises(TypeError) as e:
-            make_class("C", {"a": attrib(hash=1)}),
+            make_class("C", {"a": attr.ib(hash=1)}),
 
         assert exc_args == e.value.args
 
@@ -258,7 +260,7 @@ class TestAddHash(object):
         """
         If `hash` is False on an attribute, ignore that attribute.
         """
-        C = make_class("C", {"a": attrib(hash=False), "b": attrib()},
+        C = make_class("C", {"a": attr.ib(hash=False), "b": attr.ib()},
                        slots=slots, hash=True)
 
         assert hash(C(1, 2)) == hash(C(2, 2))
@@ -268,7 +270,7 @@ class TestAddHash(object):
         """
         If `hash` is None, the hash generation mirrors `cmp`.
         """
-        C = make_class("C", {"a": attrib(cmp=cmp)}, cmp=True, frozen=True)
+        C = make_class("C", {"a": attr.ib(cmp=cmp)}, cmp=True, frozen=True)
 
         if cmp:
             assert C(1) != C(2)
@@ -283,7 +285,7 @@ class TestAddHash(object):
         """
         If `hash` is None, the hash generation mirrors `cmp`.
         """
-        C = make_class("C", {"a": attrib()}, cmp=cmp, frozen=True)
+        C = make_class("C", {"a": attr.ib()}, cmp=cmp, frozen=True)
 
         i = C(1)
 
@@ -328,7 +330,7 @@ class TestAddInit(object):
         """
         If `init` is False, ignore that attribute.
         """
-        C = make_class("C", {"a": attrib(init=False), "b": attrib()},
+        C = make_class("C", {"a": attr.ib(init=False), "b": attr.ib()},
                        slots=slots, frozen=frozen)
         with pytest.raises(TypeError) as e:
             C(a=1, b=2)
@@ -345,9 +347,9 @@ class TestAddInit(object):
         argument but initialize it anyway.
         """
         C = make_class("C", {
-            "_a": attrib(init=False, default=42),
-            "_b": attrib(init=False, default=Factory(list)),
-            "c": attrib()
+            "_a": attr.ib(init=False, default=42),
+            "_b": attr.ib(init=False, default=Factory(list)),
+            "c": attr.ib()
         }, slots=slots, frozen=frozen)
         with pytest.raises(TypeError):
             C(a=1, c=2)
@@ -364,8 +366,8 @@ class TestAddInit(object):
         attribute.
         """
         make_class("C", {
-            "a": attrib(default=Factory(list)),
-            "b": attrib(init=False),
+            "a": attr.ib(default=Factory(list)),
+            "b": attr.ib(init=False),
         }, slots=slots, frozen=frozen)
 
     def test_sets_attributes(self):
@@ -422,7 +424,7 @@ class TestAddInit(object):
         def raiser(*args):
             raise VException(*args)
 
-        C = make_class("C", {"a": attrib("a", validator=raiser)})
+        C = make_class("C", {"a": attr.ib("a", validator=raiser)})
         with pytest.raises(VException) as e:
             C(42)
 
@@ -440,7 +442,7 @@ class TestAddInit(object):
         def raiser(*args):
             raise VException(*args)
 
-        C = make_class("C", {"a": attrib("a", validator=raiser)}, slots=True)
+        C = make_class("C", {"a": attr.ib("a", validator=raiser)}, slots=True)
         with pytest.raises(VException) as e:
             C(42)
 
@@ -453,7 +455,7 @@ class TestAddInit(object):
         Does not interfere when setting non-attrs attributes.
         """
         C = make_class("C", {
-            "a": attrib("a", validator=instance_of(int))
+            "a": attr.ib("a", validator=instance_of(int))
         }, slots=slots)
         i = C(1)
 

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -17,8 +17,8 @@ from attr._make import (
     _Nothing,
     _add_init,
     _add_repr,
-    attr,
-    attributes,
+    attrib,
+    attrs,
     fields,
     make_class,
 )
@@ -52,7 +52,10 @@ class TestAddCmp(object):
         """
         If `cmp` is False, ignore that attribute.
         """
-        C = make_class("C", {"a": attr(cmp=False), "b": attr()}, slots=slots)
+        C = make_class("C", {
+            "a": attrib(cmp=False),
+            "b": attrib()
+        }, slots=slots)
 
         assert C(1, 2) == C(2, 2)
 
@@ -174,7 +177,10 @@ class TestAddRepr(object):
         """
         If `repr` is False, ignore that attribute.
         """
-        C = make_class("C", {"a": attr(repr=False), "b": attr()}, slots=slots)
+        C = make_class("C", {
+            "a": attrib(repr=False),
+            "b": attrib()
+        }, slots=slots)
 
         assert "C(b=2)" == repr(C(1, 2))
 
@@ -206,9 +212,9 @@ class TestAddRepr(object):
         This only makes sense when subclassing a class with an poor __str__
         (like Exceptions).
         """
-        @attributes(str=add_str, slots=slots)
+        @attrs(str=add_str, slots=slots)
         class Error(Exception):
-            x = attr()
+            x = attrib()
 
         e = Error(42)
 
@@ -243,7 +249,7 @@ class TestAddHash(object):
         assert exc_args == e.value.args
 
         with pytest.raises(TypeError) as e:
-            make_class("C", {"a": attr(hash=1)}),
+            make_class("C", {"a": attrib(hash=1)}),
 
         assert exc_args == e.value.args
 
@@ -252,7 +258,7 @@ class TestAddHash(object):
         """
         If `hash` is False on an attribute, ignore that attribute.
         """
-        C = make_class("C", {"a": attr(hash=False), "b": attr()},
+        C = make_class("C", {"a": attrib(hash=False), "b": attrib()},
                        slots=slots, hash=True)
 
         assert hash(C(1, 2)) == hash(C(2, 2))
@@ -262,7 +268,7 @@ class TestAddHash(object):
         """
         If `hash` is None, the hash generation mirrors `cmp`.
         """
-        C = make_class("C", {"a": attr(cmp=cmp)}, cmp=True, frozen=True)
+        C = make_class("C", {"a": attrib(cmp=cmp)}, cmp=True, frozen=True)
 
         if cmp:
             assert C(1) != C(2)
@@ -277,7 +283,7 @@ class TestAddHash(object):
         """
         If `hash` is None, the hash generation mirrors `cmp`.
         """
-        C = make_class("C", {"a": attr()}, cmp=cmp, frozen=True)
+        C = make_class("C", {"a": attrib()}, cmp=cmp, frozen=True)
 
         i = C(1)
 
@@ -322,7 +328,7 @@ class TestAddInit(object):
         """
         If `init` is False, ignore that attribute.
         """
-        C = make_class("C", {"a": attr(init=False), "b": attr()},
+        C = make_class("C", {"a": attrib(init=False), "b": attrib()},
                        slots=slots, frozen=frozen)
         with pytest.raises(TypeError) as e:
             C(a=1, b=2)
@@ -339,9 +345,9 @@ class TestAddInit(object):
         argument but initialize it anyway.
         """
         C = make_class("C", {
-            "_a": attr(init=False, default=42),
-            "_b": attr(init=False, default=Factory(list)),
-            "c": attr()
+            "_a": attrib(init=False, default=42),
+            "_b": attrib(init=False, default=Factory(list)),
+            "c": attrib()
         }, slots=slots, frozen=frozen)
         with pytest.raises(TypeError):
             C(a=1, c=2)
@@ -358,8 +364,8 @@ class TestAddInit(object):
         attribute.
         """
         make_class("C", {
-            "a": attr(default=Factory(list)),
-            "b": attr(init=False),
+            "a": attrib(default=Factory(list)),
+            "b": attrib(init=False),
         }, slots=slots, frozen=frozen)
 
     def test_sets_attributes(self):
@@ -401,6 +407,7 @@ class TestAddInit(object):
             ]
         C = _add_init(C, False)
         i = C()
+
         assert [] == i.a
         assert isinstance(i.b, D)
 
@@ -415,9 +422,10 @@ class TestAddInit(object):
         def raiser(*args):
             raise VException(*args)
 
-        C = make_class("C", {"a": attr("a", validator=raiser)})
+        C = make_class("C", {"a": attrib("a", validator=raiser)})
         with pytest.raises(VException) as e:
             C(42)
+
         assert (fields(C).a, 42,) == e.value.args[1:]
         assert isinstance(e.value.args[0], C)
 
@@ -432,9 +440,10 @@ class TestAddInit(object):
         def raiser(*args):
             raise VException(*args)
 
-        C = make_class("C", {"a": attr("a", validator=raiser)}, slots=True)
+        C = make_class("C", {"a": attrib("a", validator=raiser)}, slots=True)
         with pytest.raises(VException) as e:
             C(42)
+
         assert (fields(C)[0], 42,) == e.value.args[1:]
         assert isinstance(e.value.args[0], C)
 
@@ -443,10 +452,13 @@ class TestAddInit(object):
         """
         Does not interfere when setting non-attrs attributes.
         """
-        C = make_class("C", {"a": attr("a", validator=instance_of(int))},
-                       slots=slots)
+        C = make_class("C", {
+            "a": attrib("a", validator=instance_of(int))
+        }, slots=slots)
         i = C(1)
+
         assert 1 == i.a
+
         if not slots:
             i.b = "foo"
             assert "foo" == i.b

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -6,14 +6,16 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from attr._make import attrs, attrib, fields
+import attr
+
+from attr import fields
 from attr.filters import _split_what, include, exclude
 
 
-@attrs
+@attr.s
 class C(object):
-    a = attrib()
-    b = attrib()
+    a = attr.ib()
+    b = attr.ib()
 
 
 class TestSplitWhat(object):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -6,14 +6,14 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-from attr._make import attributes, attr, fields
+from attr._make import attrs, attrib, fields
 from attr.filters import _split_what, include, exclude
 
 
-@attributes
+@attrs
 class C(object):
-    a = attr()
-    b = attr()
+    a = attrib()
+    b = attrib()
 
 
 class TestSplitWhat(object):

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -13,8 +13,8 @@ from hypothesis import assume, given, strategies as st, settings, HealthCheck
 from .utils import simple_classes, nested_classes
 
 from attr import (
-    attr,
-    attributes,
+    attrib,
+    attrs,
     asdict,
     assoc,
     astuple,
@@ -327,7 +327,7 @@ class TestHas(object):
         """
         Returns `True` on decorated classes even if there are no attributes.
         """
-        @attributes
+        @attrs
         class D(object):
             pass
 
@@ -349,7 +349,7 @@ class TestAssoc(object):
         """
         Empty classes without changes get copied.
         """
-        @attributes(slots=slots, frozen=frozen)
+        @attrs(slots=slots, frozen=frozen)
         class C(object):
             pass
 
@@ -410,10 +410,10 @@ class TestAssoc(object):
         """
         Works on frozen classes.
         """
-        @attributes(frozen=True)
+        @attrs(frozen=True)
         class C(object):
-            x = attr()
-            y = attr()
+            x = attrib()
+            y = attrib()
 
         with pytest.deprecated_call():
             assert C(3, 2) == assoc(C(1, 2), x=3)
@@ -422,9 +422,9 @@ class TestAssoc(object):
         """
         DeprecationWarning points to the correct file.
         """
-        @attributes
+        @attrs
         class C(object):
-            x = attr()
+            x = attrib()
 
         with pytest.warns(DeprecationWarning) as wi:
             assert C(2) == assoc(C(1), x=2)
@@ -441,7 +441,7 @@ class TestEvolve(object):
         """
         Empty classes without changes get copied.
         """
-        @attributes(slots=slots, frozen=frozen)
+        @attrs(slots=slots, frozen=frozen)
         class C(object):
             pass
 
@@ -496,22 +496,23 @@ class TestEvolve(object):
         """
         TypeError isn't swallowed when validation fails within evolve.
         """
-        @attributes
+        @attrs
         class C(object):
-            a = attr(validator=instance_of(int))
+            a = attrib(validator=instance_of(int))
 
         with pytest.raises(TypeError) as e:
             evolve(C(a=1), a="some string")
         m = e.value.args[0]
+
         assert m.startswith("'a' must be <{type} 'int'>".format(type=TYPE))
 
     def test_private(self):
         """
         evolve() acts as `__init__` with regards to private attributes.
         """
-        @attributes
+        @attrs
         class C(object):
-            _a = attr()
+            _a = attrib()
 
         assert evolve(C(1), a=2)._a == 2
 
@@ -525,9 +526,9 @@ class TestEvolve(object):
         """
         evolve() handles `init=False` attributes.
         """
-        @attributes
+        @attrs
         class C(object):
-            a = attr()
-            b = attr(init=False, default=0)
+            a = attrib()
+            b = attrib(init=False, default=0)
 
         assert evolve(C(1), a=2).a == 2

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -12,9 +12,9 @@ from hypothesis import assume, given, strategies as st, settings, HealthCheck
 
 from .utils import simple_classes, nested_classes
 
+import attr
+
 from attr import (
-    attrib,
-    attrs,
     asdict,
     assoc,
     astuple,
@@ -327,7 +327,7 @@ class TestHas(object):
         """
         Returns `True` on decorated classes even if there are no attributes.
         """
-        @attrs
+        @attr.s
         class D(object):
             pass
 
@@ -349,7 +349,7 @@ class TestAssoc(object):
         """
         Empty classes without changes get copied.
         """
-        @attrs(slots=slots, frozen=frozen)
+        @attr.s(slots=slots, frozen=frozen)
         class C(object):
             pass
 
@@ -410,10 +410,10 @@ class TestAssoc(object):
         """
         Works on frozen classes.
         """
-        @attrs(frozen=True)
+        @attr.s(frozen=True)
         class C(object):
-            x = attrib()
-            y = attrib()
+            x = attr.ib()
+            y = attr.ib()
 
         with pytest.deprecated_call():
             assert C(3, 2) == assoc(C(1, 2), x=3)
@@ -422,9 +422,9 @@ class TestAssoc(object):
         """
         DeprecationWarning points to the correct file.
         """
-        @attrs
+        @attr.s
         class C(object):
-            x = attrib()
+            x = attr.ib()
 
         with pytest.warns(DeprecationWarning) as wi:
             assert C(2) == assoc(C(1), x=2)
@@ -441,7 +441,7 @@ class TestEvolve(object):
         """
         Empty classes without changes get copied.
         """
-        @attrs(slots=slots, frozen=frozen)
+        @attr.s(slots=slots, frozen=frozen)
         class C(object):
             pass
 
@@ -496,9 +496,9 @@ class TestEvolve(object):
         """
         TypeError isn't swallowed when validation fails within evolve.
         """
-        @attrs
+        @attr.s
         class C(object):
-            a = attrib(validator=instance_of(int))
+            a = attr.ib(validator=instance_of(int))
 
         with pytest.raises(TypeError) as e:
             evolve(C(a=1), a="some string")
@@ -510,9 +510,9 @@ class TestEvolve(object):
         """
         evolve() acts as `__init__` with regards to private attributes.
         """
-        @attrs
+        @attr.s
         class C(object):
-            _a = attrib()
+            _a = attr.ib()
 
         assert evolve(C(1), a=2)._a == 2
 
@@ -526,9 +526,9 @@ class TestEvolve(object):
         """
         evolve() handles `init=False` attributes.
         """
-        @attrs
+        @attr.s
         class C(object):
-            a = attrib()
-            b = attrib(init=False, default=0)
+            a = attr.ib()
+            b = attr.ib(init=False, default=0)
 
         assert evolve(C(1), a=2).a == 2

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -13,6 +13,8 @@ import pytest
 from hypothesis import given
 from hypothesis.strategies import booleans, integers, lists, sampled_from, text
 
+import attr
+
 from attr import _config
 from attr._compat import PY2
 from attr._make import (
@@ -22,8 +24,6 @@ from attr._make import (
     _CountingAttr,
     _transform_attrs,
     and_,
-    attrib,
-    attrs,
     fields,
     make_class,
     validate,
@@ -44,7 +44,7 @@ class TestCountingAttr(object):
         """
         Returns an instance of _CountingAttr.
         """
-        a = attrib()
+        a = attr.ib()
 
         assert isinstance(a, _CountingAttr)
 
@@ -58,7 +58,7 @@ class TestCountingAttr(object):
         def v2(_, __):
             pass
 
-        a = attrib(validator=[v1, v2])
+        a = attr.ib(validator=[v1, v2])
 
         assert _AndValidator((v1, v2,)) == a._validator
 
@@ -67,7 +67,7 @@ class TestCountingAttr(object):
         If _CountingAttr.validator is used as a decorator and there is no
         decorator set, the decorated method is used as the validator.
         """
-        a = attrib()
+        a = attr.ib()
 
         @a.validator
         def v():
@@ -89,7 +89,7 @@ class TestCountingAttr(object):
         def v(_, __):
             pass
 
-        a = attrib(validator=wrap(v))
+        a = attr.ib(validator=wrap(v))
 
         @a.validator
         def v2(self, _, __):
@@ -102,7 +102,7 @@ class TestCountingAttr(object):
         Raise DefaultAlreadySetError if the decorator is used after a default
         has been set.
         """
-        a = attrib(default=42)
+        a = attr.ib(default=42)
 
         with pytest.raises(DefaultAlreadySetError):
             @a.default
@@ -114,7 +114,7 @@ class TestCountingAttr(object):
         Decorator wraps the method in a Factory with pass_self=True and sets
         the default.
         """
-        a = attrib()
+        a = attr.ib()
 
         @a.default
         def f(self):
@@ -125,9 +125,9 @@ class TestCountingAttr(object):
 
 def make_tc():
     class TransformC(object):
-        z = attrib()
-        y = attrib()
-        x = attrib()
+        z = attr.ib()
+        y = attr.ib()
+        x = attr.ib()
         a = 42
     return TransformC
 
@@ -148,7 +148,7 @@ class TestTransformAttrs(object):
         """
         No attributes works as expected.
         """
-        @attrs
+        @attr.s
         class C(object):
             pass
 
@@ -176,8 +176,8 @@ class TestTransformAttrs(object):
         mandatory attributes.
         """
         class C(object):
-            x = attrib(default=None)
-            y = attrib()
+            x = attr.ib(default=None)
+            y = attr.ib()
 
         with pytest.raises(ValueError) as e:
             _transform_attrs(C, None)
@@ -194,9 +194,9 @@ class TestTransformAttrs(object):
         If these is passed, use it and ignore body.
         """
         class C(object):
-            y = attrib()
+            y = attr.ib()
 
-        _transform_attrs(C, {"x": attrib()})
+        _transform_attrs(C, {"x": attr.ib()})
         assert (
             simple_attr("x"),
         ) == C.__attrs_attrs__
@@ -210,22 +210,22 @@ class TestTransformAttrs(object):
             a = None
 
         class B(A):
-            b = attrib()
+            b = attr.ib()
 
         _transform_attrs(B, None)
 
         class C(B):
-            c = attrib()
+            c = attr.ib()
 
         _transform_attrs(C, None)
 
         class D(C):
-            d = attrib()
+            d = attr.ib()
 
         _transform_attrs(D, None)
 
         class E(D):
-            e = attrib()
+            e = attr.ib()
 
         _transform_attrs(E, None)
 
@@ -247,7 +247,7 @@ class TestAttributes(object):
         Raises TypeError on old-style classes.
         """
         with pytest.raises(TypeError) as e:
-            @attrs
+            @attr.s
             class C:
                 pass
         assert ("attrs only works with new-style classes.",) == e.value.args
@@ -256,9 +256,9 @@ class TestAttributes(object):
         """
         Sets the `__attrs_attrs__` class attribute with a list of `Attribute`s.
         """
-        @attrs
+        @attr.s
         class C(object):
-            x = attrib()
+            x = attr.ib()
         assert "x" == C.__attrs_attrs__[0].name
         assert all(isinstance(a, Attribute) for a in C.__attrs_attrs__)
 
@@ -266,7 +266,7 @@ class TestAttributes(object):
         """
         No attributes, no problems.
         """
-        @attrs
+        @attr.s
         class C3(object):
             pass
         assert "C3()" == repr(C3())
@@ -296,11 +296,11 @@ class TestAttributes(object):
         sentinel = object()
 
         class C(object):
-            x = attrib()
+            x = attr.ib()
 
         setattr(C, method_name, sentinel)
 
-        C = attrs(C)
+        C = attr.s(C)
         meth = getattr(C, method_name)
 
         assert sentinel != meth
@@ -330,11 +330,11 @@ class TestAttributes(object):
         am_args[arg_name] = False
 
         class C(object):
-            x = attrib()
+            x = attr.ib()
 
         setattr(C, method_name, sentinel)
 
-        C = attrs(**am_args)(C)
+        C = attr.s(**am_args)(C)
 
         assert sentinel == getattr(C, method_name)
 
@@ -344,9 +344,9 @@ class TestAttributes(object):
         """
         On Python 3, the name in repr is the __qualname__.
         """
-        @attrs(slots=slots_outer)
+        @attr.s(slots=slots_outer)
         class C(object):
-            @attrs(slots=slots_inner)
+            @attr.s(slots=slots_inner)
             class D(object):
                 pass
 
@@ -358,9 +358,9 @@ class TestAttributes(object):
         """
         Setting repr_ns overrides a potentially guessed namespace.
         """
-        @attrs(slots=slots_outer)
+        @attr.s(slots=slots_outer)
         class C(object):
-            @attrs(repr_ns="C", slots=slots_inner)
+            @attr.s(repr_ns="C", slots=slots_inner)
             class D(object):
                 pass
         assert "C.D()" == repr(C.D())
@@ -371,9 +371,9 @@ class TestAttributes(object):
         """
         On Python 3, __name__ is different from __qualname__.
         """
-        @attrs(slots=slots_outer)
+        @attr.s(slots=slots_outer)
         class C(object):
-            @attrs(slots=slots_inner)
+            @attr.s(slots=slots_inner)
             class D(object):
                 pass
 
@@ -387,10 +387,10 @@ class TestAttributes(object):
         """
         monkeypatch.setattr(_config, "_run_validators", with_validation)
 
-        @attrs
+        @attr.s
         class C(object):
-            x = attrib()
-            y = attrib()
+            x = attr.ib()
+            y = attr.ib()
 
             def __attrs_post_init__(self2):
                 self2.z = self2.x + self2.y
@@ -403,11 +403,11 @@ class TestAttributes(object):
         """
         Sets the `Attribute.type` attr from type argument.
         """
-        @attrs
+        @attr.s
         class C(object):
-            x = attrib(type=int)
-            y = attrib(type=str)
-            z = attrib()
+            x = attr.ib(type=int)
+            y = attr.ib(type=str)
+            z = attr.ib()
 
         assert int is fields(C).x.type
         assert str is fields(C).y.type
@@ -418,18 +418,18 @@ class TestAttributes(object):
         """
         Attribute definitions do not appear on the class body after @attr.s.
         """
-        @attrs(slots=slots)
+        @attr.s(slots=slots)
         class C(object):
-            x = attrib()
+            x = attr.ib()
 
         x = getattr(C, "x", None)
 
         assert not isinstance(x, _CountingAttr)
 
 
-@attrs
+@attr.s
 class GC(object):
-    @attrs
+    @attr.s
     class D(object):
         pass
 
@@ -448,10 +448,10 @@ class TestMakeClass(object):
         """
         C1 = make_class("C1", ls(["a", "b"]))
 
-        @attrs
+        @attr.s
         class C2(object):
-            a = attrib()
-            b = attrib()
+            a = attr.ib()
+            b = attr.ib()
 
         assert C1.__attrs_attrs__ == C2.__attrs_attrs__
 
@@ -460,14 +460,14 @@ class TestMakeClass(object):
         Passing a dict of name: _CountingAttr creates an equivalent class.
         """
         C1 = make_class("C1", {
-            "a": attrib(default=42),
-            "b": attrib(default=None),
+            "a": attr.ib(default=42),
+            "b": attr.ib(default=None),
         })
 
-        @attrs
+        @attr.s
         class C2(object):
-            a = attrib(default=42)
-            b = attrib(default=None)
+            a = attr.ib(default=42)
+            b = attr.ib(default=None)
 
         assert C1.__attrs_attrs__ == C2.__attrs_attrs__
 
@@ -562,8 +562,8 @@ class TestConvert(object):
         Return value of convert is used as the attribute's value.
         """
         C = make_class("C", {
-            "x": attrib(convert=lambda v: v + 1),
-            "y": attrib(),
+            "x": attr.ib(convert=lambda v: v + 1),
+            "y": attr.ib(),
         })
         c = C(1, 2)
 
@@ -576,8 +576,8 @@ class TestConvert(object):
         Property tests for attributes with convert.
         """
         C = make_class("C", {
-            "y": attrib(),
-            "x": attrib(init=init, default=val, convert=lambda v: v + 1),
+            "y": attr.ib(),
+            "x": attr.ib(init=init, default=val, convert=lambda v: v + 1),
         })
         c = C(2)
 
@@ -590,8 +590,8 @@ class TestConvert(object):
         Property tests for attributes with convert, and a factory default.
         """
         C = make_class("C", {
-            "y": attrib(),
-            "x": attrib(
+            "y": attr.ib(),
+            "x": attr.ib(
                 init=init,
                 default=Factory(lambda: val),
                 convert=lambda v: v + 1),
@@ -606,7 +606,7 @@ class TestConvert(object):
         If takes_self on factories is True, self is passed.
         """
         C = make_class("C", {
-            "x": attrib(default=Factory((lambda self: self), takes_self=True)),
+            "x": attr.ib(default=Factory((lambda self: self), takes_self=True)),
         })
 
         i = C()
@@ -627,8 +627,8 @@ class TestConvert(object):
             raise RuntimeError("foo")
         C = make_class(
             "C", {
-                "x": attrib(validator=validator, convert=lambda v: 1 / 0),
-                "y": attrib(),
+                "x": attr.ib(validator=validator, convert=lambda v: 1 / 0),
+                "y": attr.ib(),
             })
         with pytest.raises(ZeroDivisionError):
             C(1, 2)
@@ -638,7 +638,7 @@ class TestConvert(object):
         Converters circumvent immutability.
         """
         C = make_class("C", {
-            "x": attrib(convert=lambda v: int(v)),
+            "x": attr.ib(convert=lambda v: int(v)),
         }, frozen=True)
         C("1")
 
@@ -652,8 +652,8 @@ class TestValidate(object):
         If the validator succeeds, nothing gets raised.
         """
         C = make_class("C", {
-            "x": attrib(validator=lambda *a: None),
-            "y": attrib()
+            "x": attr.ib(validator=lambda *a: None),
+            "y": attr.ib()
         })
         validate(C(1, 2))
 
@@ -665,7 +665,7 @@ class TestValidate(object):
             if value == 42:
                 raise FloatingPointError
 
-        C = make_class("C", {"x": attrib(validator=raiser)})
+        C = make_class("C", {"x": attr.ib(validator=raiser)})
         i = C(1)
         i.x = 42
 
@@ -682,7 +682,7 @@ class TestValidate(object):
         def raiser(_, __, ___):
             raise Exception(obj)
 
-        C = make_class("C", {"x": attrib(validator=raiser)})
+        C = make_class("C", {"x": attr.ib(validator=raiser)})
         c = C(1)
         validate(c)
         assert 1 == c.x
@@ -708,7 +708,7 @@ class TestValidate(object):
             if value == 42:
                 raise ValueError("omg")
 
-        C = make_class("C", {"x": attrib(validator=[v1, v2])})
+        C = make_class("C", {"x": attr.ib(validator=[v1, v2])})
 
         validate(C(1))
 
@@ -726,8 +726,8 @@ class TestValidate(object):
         """
         Empty list/tuple for validator is the same as None.
         """
-        C1 = make_class("C", {"x": attrib(validator=[])})
-        C2 = make_class("C", {"x": attrib(validator=None)})
+        C1 = make_class("C", {"x": attr.ib(validator=[])})
+        C2 = make_class("C", {"x": attr.ib(validator=None)})
 
         assert inspect.getsource(C1.__init__) == inspect.getsource(C2.__init__)
 

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -22,8 +22,8 @@ from attr._make import (
     _CountingAttr,
     _transform_attrs,
     and_,
-    attr,
-    attributes,
+    attrib,
+    attrs,
     fields,
     make_class,
     validate,
@@ -33,7 +33,7 @@ from attr.exceptions import NotAnAttrsClassError, DefaultAlreadySetError
 from .utils import (gen_attr_names, list_of_attrs, simple_attr, simple_attrs,
                     simple_attrs_without_metadata, simple_classes)
 
-attrs = simple_attrs.map(lambda c: Attribute.from_counting_attr("name", c))
+attrs_st = simple_attrs.map(lambda c: Attribute.from_counting_attr("name", c))
 
 
 class TestCountingAttr(object):
@@ -44,7 +44,7 @@ class TestCountingAttr(object):
         """
         Returns an instance of _CountingAttr.
         """
-        a = attr()
+        a = attrib()
 
         assert isinstance(a, _CountingAttr)
 
@@ -58,7 +58,7 @@ class TestCountingAttr(object):
         def v2(_, __):
             pass
 
-        a = attr(validator=[v1, v2])
+        a = attrib(validator=[v1, v2])
 
         assert _AndValidator((v1, v2,)) == a._validator
 
@@ -67,7 +67,7 @@ class TestCountingAttr(object):
         If _CountingAttr.validator is used as a decorator and there is no
         decorator set, the decorated method is used as the validator.
         """
-        a = attr()
+        a = attrib()
 
         @a.validator
         def v():
@@ -89,7 +89,7 @@ class TestCountingAttr(object):
         def v(_, __):
             pass
 
-        a = attr(validator=wrap(v))
+        a = attrib(validator=wrap(v))
 
         @a.validator
         def v2(self, _, __):
@@ -102,7 +102,7 @@ class TestCountingAttr(object):
         Raise DefaultAlreadySetError if the decorator is used after a default
         has been set.
         """
-        a = attr(default=42)
+        a = attrib(default=42)
 
         with pytest.raises(DefaultAlreadySetError):
             @a.default
@@ -114,7 +114,7 @@ class TestCountingAttr(object):
         Decorator wraps the method in a Factory with pass_self=True and sets
         the default.
         """
-        a = attr()
+        a = attrib()
 
         @a.default
         def f(self):
@@ -125,9 +125,9 @@ class TestCountingAttr(object):
 
 def make_tc():
     class TransformC(object):
-        z = attr()
-        y = attr()
-        x = attr()
+        z = attrib()
+        y = attrib()
+        x = attrib()
         a = 42
     return TransformC
 
@@ -148,7 +148,7 @@ class TestTransformAttrs(object):
         """
         No attributes works as expected.
         """
-        @attributes
+        @attrs
         class C(object):
             pass
 
@@ -176,8 +176,8 @@ class TestTransformAttrs(object):
         mandatory attributes.
         """
         class C(object):
-            x = attr(default=None)
-            y = attr()
+            x = attrib(default=None)
+            y = attrib()
 
         with pytest.raises(ValueError) as e:
             _transform_attrs(C, None)
@@ -194,9 +194,9 @@ class TestTransformAttrs(object):
         If these is passed, use it and ignore body.
         """
         class C(object):
-            y = attr()
+            y = attrib()
 
-        _transform_attrs(C, {"x": attr()})
+        _transform_attrs(C, {"x": attrib()})
         assert (
             simple_attr("x"),
         ) == C.__attrs_attrs__
@@ -210,22 +210,22 @@ class TestTransformAttrs(object):
             a = None
 
         class B(A):
-            b = attr()
+            b = attrib()
 
         _transform_attrs(B, None)
 
         class C(B):
-            c = attr()
+            c = attrib()
 
         _transform_attrs(C, None)
 
         class D(C):
-            d = attr()
+            d = attrib()
 
         _transform_attrs(D, None)
 
         class E(D):
-            e = attr()
+            e = attrib()
 
         _transform_attrs(E, None)
 
@@ -247,7 +247,7 @@ class TestAttributes(object):
         Raises TypeError on old-style classes.
         """
         with pytest.raises(TypeError) as e:
-            @attributes
+            @attrs
             class C:
                 pass
         assert ("attrs only works with new-style classes.",) == e.value.args
@@ -256,9 +256,9 @@ class TestAttributes(object):
         """
         Sets the `__attrs_attrs__` class attribute with a list of `Attribute`s.
         """
-        @attributes
+        @attrs
         class C(object):
-            x = attr()
+            x = attrib()
         assert "x" == C.__attrs_attrs__[0].name
         assert all(isinstance(a, Attribute) for a in C.__attrs_attrs__)
 
@@ -266,13 +266,13 @@ class TestAttributes(object):
         """
         No attributes, no problems.
         """
-        @attributes
+        @attrs
         class C3(object):
             pass
         assert "C3()" == repr(C3())
         assert C3() == C3()
 
-    @given(attr=attrs, attr_name=sampled_from(Attribute.__slots__))
+    @given(attr=attrs_st, attr_name=sampled_from(Attribute.__slots__))
     def test_immutable(self, attr, attr_name):
         """
         Attribute instances are immutable.
@@ -296,11 +296,11 @@ class TestAttributes(object):
         sentinel = object()
 
         class C(object):
-            x = attr()
+            x = attrib()
 
         setattr(C, method_name, sentinel)
 
-        C = attributes(C)
+        C = attrs(C)
         meth = getattr(C, method_name)
 
         assert sentinel != meth
@@ -330,11 +330,11 @@ class TestAttributes(object):
         am_args[arg_name] = False
 
         class C(object):
-            x = attr()
+            x = attrib()
 
         setattr(C, method_name, sentinel)
 
-        C = attributes(**am_args)(C)
+        C = attrs(**am_args)(C)
 
         assert sentinel == getattr(C, method_name)
 
@@ -344,9 +344,9 @@ class TestAttributes(object):
         """
         On Python 3, the name in repr is the __qualname__.
         """
-        @attributes(slots=slots_outer)
+        @attrs(slots=slots_outer)
         class C(object):
-            @attributes(slots=slots_inner)
+            @attrs(slots=slots_inner)
             class D(object):
                 pass
 
@@ -358,9 +358,9 @@ class TestAttributes(object):
         """
         Setting repr_ns overrides a potentially guessed namespace.
         """
-        @attributes(slots=slots_outer)
+        @attrs(slots=slots_outer)
         class C(object):
-            @attributes(repr_ns="C", slots=slots_inner)
+            @attrs(repr_ns="C", slots=slots_inner)
             class D(object):
                 pass
         assert "C.D()" == repr(C.D())
@@ -371,9 +371,9 @@ class TestAttributes(object):
         """
         On Python 3, __name__ is different from __qualname__.
         """
-        @attributes(slots=slots_outer)
+        @attrs(slots=slots_outer)
         class C(object):
-            @attributes(slots=slots_inner)
+            @attrs(slots=slots_inner)
             class D(object):
                 pass
 
@@ -387,10 +387,10 @@ class TestAttributes(object):
         """
         monkeypatch.setattr(_config, "_run_validators", with_validation)
 
-        @attributes
+        @attrs
         class C(object):
-            x = attr()
-            y = attr()
+            x = attrib()
+            y = attrib()
 
             def __attrs_post_init__(self2):
                 self2.z = self2.x + self2.y
@@ -403,11 +403,11 @@ class TestAttributes(object):
         """
         Sets the `Attribute.type` attr from type argument.
         """
-        @attributes
+        @attrs
         class C(object):
-            x = attr(type=int)
-            y = attr(type=str)
-            z = attr()
+            x = attrib(type=int)
+            y = attrib(type=str)
+            z = attrib()
 
         assert int is fields(C).x.type
         assert str is fields(C).y.type
@@ -418,18 +418,18 @@ class TestAttributes(object):
         """
         Attribute definitions do not appear on the class body after @attr.s.
         """
-        @attributes(slots=slots)
+        @attrs(slots=slots)
         class C(object):
-            x = attr()
+            x = attrib()
 
         x = getattr(C, "x", None)
 
         assert not isinstance(x, _CountingAttr)
 
 
-@attributes
+@attrs
 class GC(object):
-    @attributes
+    @attrs
     class D(object):
         pass
 
@@ -448,10 +448,10 @@ class TestMakeClass(object):
         """
         C1 = make_class("C1", ls(["a", "b"]))
 
-        @attributes
+        @attrs
         class C2(object):
-            a = attr()
-            b = attr()
+            a = attrib()
+            b = attrib()
 
         assert C1.__attrs_attrs__ == C2.__attrs_attrs__
 
@@ -459,12 +459,15 @@ class TestMakeClass(object):
         """
         Passing a dict of name: _CountingAttr creates an equivalent class.
         """
-        C1 = make_class("C1", {"a": attr(default=42), "b": attr(default=None)})
+        C1 = make_class("C1", {
+            "a": attrib(default=42),
+            "b": attrib(default=None),
+        })
 
-        @attributes
+        @attrs
         class C2(object):
-            a = attr(default=42)
-            b = attr(default=None)
+            a = attrib(default=42)
+            b = attrib(default=None)
 
         assert C1.__attrs_attrs__ == C2.__attrs_attrs__
 
@@ -558,9 +561,12 @@ class TestConvert(object):
         """
         Return value of convert is used as the attribute's value.
         """
-        C = make_class("C", {"x": attr(convert=lambda v: v + 1),
-                             "y": attr()})
+        C = make_class("C", {
+            "x": attrib(convert=lambda v: v + 1),
+            "y": attrib(),
+        })
         c = C(1, 2)
+
         assert c.x == 2
         assert c.y == 2
 
@@ -569,11 +575,12 @@ class TestConvert(object):
         """
         Property tests for attributes with convert.
         """
-        C = make_class("C", {"y": attr(),
-                             "x": attr(init=init, default=val,
-                                       convert=lambda v: v + 1),
-                             })
+        C = make_class("C", {
+            "y": attrib(),
+            "x": attrib(init=init, default=val, convert=lambda v: v + 1),
+        })
         c = C(2)
+
         assert c.x == val + 1
         assert c.y == 2
 
@@ -582,12 +589,15 @@ class TestConvert(object):
         """
         Property tests for attributes with convert, and a factory default.
         """
-        C = make_class("C", {"y": attr(),
-                             "x": attr(init=init,
-                                       default=Factory(lambda: val),
-                                       convert=lambda v: v + 1),
-                             })
+        C = make_class("C", {
+            "y": attrib(),
+            "x": attrib(
+                init=init,
+                default=Factory(lambda: val),
+                convert=lambda v: v + 1),
+        })
         c = C(2)
+
         assert c.x == val + 1
         assert c.y == 2
 
@@ -595,9 +605,9 @@ class TestConvert(object):
         """
         If takes_self on factories is True, self is passed.
         """
-        C = make_class("C", {"x": attr(default=Factory(
-            (lambda self: self), takes_self=True
-        ))})
+        C = make_class("C", {
+            "x": attrib(default=Factory((lambda self: self), takes_self=True)),
+        })
 
         i = C()
 
@@ -616,9 +626,10 @@ class TestConvert(object):
         def validator(inst, attr, val):
             raise RuntimeError("foo")
         C = make_class(
-            "C",
-            {"x": attr(validator=validator, convert=lambda v: 1 / 0),
-             "y": attr()})
+            "C", {
+                "x": attrib(validator=validator, convert=lambda v: 1 / 0),
+                "y": attrib(),
+            })
         with pytest.raises(ZeroDivisionError):
             C(1, 2)
 
@@ -626,7 +637,9 @@ class TestConvert(object):
         """
         Converters circumvent immutability.
         """
-        C = make_class("C", {"x": attr(convert=lambda v: int(v))}, frozen=True)
+        C = make_class("C", {
+            "x": attrib(convert=lambda v: int(v)),
+        }, frozen=True)
         C("1")
 
 
@@ -638,8 +651,10 @@ class TestValidate(object):
         """
         If the validator succeeds, nothing gets raised.
         """
-        C = make_class("C", {"x": attr(validator=lambda *a: None),
-                             "y": attr()})
+        C = make_class("C", {
+            "x": attrib(validator=lambda *a: None),
+            "y": attrib()
+        })
         validate(C(1, 2))
 
     def test_propagates(self):
@@ -650,7 +665,7 @@ class TestValidate(object):
             if value == 42:
                 raise FloatingPointError
 
-        C = make_class("C", {"x": attr(validator=raiser)})
+        C = make_class("C", {"x": attrib(validator=raiser)})
         i = C(1)
         i.x = 42
 
@@ -667,7 +682,7 @@ class TestValidate(object):
         def raiser(_, __, ___):
             raise Exception(obj)
 
-        C = make_class("C", {"x": attr(validator=raiser)})
+        C = make_class("C", {"x": attrib(validator=raiser)})
         c = C(1)
         validate(c)
         assert 1 == c.x
@@ -693,7 +708,7 @@ class TestValidate(object):
             if value == 42:
                 raise ValueError("omg")
 
-        C = make_class("C", {"x": attr(validator=[v1, v2])})
+        C = make_class("C", {"x": attrib(validator=[v1, v2])})
 
         validate(C(1))
 
@@ -711,8 +726,8 @@ class TestValidate(object):
         """
         Empty list/tuple for validator is the same as None.
         """
-        C1 = make_class("C", {"x": attr(validator=[])})
-        C2 = make_class("C", {"x": attr(validator=None)})
+        C1 = make_class("C", {"x": attrib(validator=[])})
+        C2 = make_class("C", {"x": attrib(validator=None)})
 
         assert inspect.getsource(C1.__init__) == inspect.getsource(C2.__init__)
 

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -606,7 +606,9 @@ class TestConvert(object):
         If takes_self on factories is True, self is passed.
         """
         C = make_class("C", {
-            "x": attr.ib(default=Factory((lambda self: self), takes_self=True)),
+            "x": attr.ib(
+                default=Factory((lambda self: self), takes_self=True)
+            ),
         })
 
         i = C()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -7,10 +7,11 @@ from __future__ import absolute_import, division, print_function
 import pytest
 import zope.interface
 
+import attr
+
 from attr import validators as validator_module, has
 from attr.validators import and_, instance_of, provides, optional, in_
 from attr._compat import TYPE
-from attr._make import attrs, attrib
 
 from .utils import simple_attr
 
@@ -95,12 +96,12 @@ class TestAnd(object):
         """
         `and_(v1, v2, v3)` and `[v1, v2, v3]` are equivalent.
         """
-        @attrs
+        @attr.s
         class C(object):
-            a1 = attrib("a1", validator=and_(
+            a1 = attr.ib("a1", validator=and_(
                 instance_of(int),
             ))
-            a2 = attrib("a2", validator=[
+            a2 = attr.ib("a2", validator=[
                 instance_of(int),
             ])
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -10,7 +10,7 @@ import zope.interface
 from attr import validators as validator_module, has
 from attr.validators import and_, instance_of, provides, optional, in_
 from attr._compat import TYPE
-from attr._make import attributes, attr
+from attr._make import attrs, attrib
 
 from .utils import simple_attr
 
@@ -95,12 +95,12 @@ class TestAnd(object):
         """
         `and_(v1, v2, v3)` and `[v1, v2, v3]` are equivalent.
         """
-        @attributes
+        @attrs
         class C(object):
-            a1 = attr("a1", validator=and_(
+            a1 = attrib("a1", validator=and_(
                 instance_of(int),
             ))
-            a2 = attr("a2", validator=[
+            a2 = attrib("a2", validator=[
                 instance_of(int),
             ])
 


### PR DESCRIPTION
This is a purely internal change.

The old internal names (that were also the old serious biz names) were kind of non-sensical so I’m moving the APIs to our newer ones that mirror the official names.

This PR doesn’t change any public APIs but makes sure that we have more consistent naming throughout the project.

This is something that has been annoying me for quite a while. *shiver*