### PR TITLE
Document how to get help

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -11,7 +11,7 @@ But don't be afraid to open half-finished PRs and ask questions if something is 
 Support
 -------
 
-In case you'd like to help out but don't want deal with GitHub, there's a great opportunity:
+In case you'd like to help out but don't want to deal with GitHub, there's a great opportunity:
 help your fellow developers on `StackOverflow <https://stackoverflow.com/questions/tagged/python-attrs>`_!
 
 The offical tag is ``python-attrs`` and helping out in support frees us up for improving ``attrs`` instead!

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -8,6 +8,15 @@ This document is mainly to help you to get started by codifying tribal knowledge
 But don't be afraid to open half-finished PRs and ask questions if something is unclear!
 
 
+Support
+-------
+
+In case you'd like to help out but don't want deal with GitHub, there's a great opportunity:
+help your fellow developers on `StackOverflow <https://stackoverflow.com/questions/tagged/python-attrs>`_!
+
+The offical tag is ``python-attrs`` and helping out in support frees us up for improving ``attrs`` instead!
+
+
 Workflow
 --------
 

--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,13 @@ Testimonials
   -- **Kenneth Reitz**, author of `requests <http://www.python-requests.org/>`_, Python Overlord at Heroku, `on paper no less <https://twitter.com/hynek/status/866817877650751488>`_
 
 
+Getting Help
+============
+
+Please use the ``python-attrs`` tag on `StackOverflow <https://stackoverflow.com/questions/tagged/python-attrs>`_ to get help.
+
+Answering questions of your fellow developers is also great way to help the project!
+
 .. -end-
 
 .. -project-information-


### PR DESCRIPTION
As discussed in #247, this PR introduces the official `python-attrs` tag on StackOverflow and encourages people to help out with questions.

It’s very much overdue to have an official way.

***

As for live support: I really cannot bootstrap a new IRC channel and provide live support there.  There's a bunch of attrs users on #pylib so if they’d be so gracious to host us, I wouldn’t mind adding it the docs as a secondary help channel but so far, *this* is all *I* can commit to right now

fixes #247