### PR TITLE
Added support for keyword-only arguments on Python 3+

### DIFF
--- a/changelog.d/281.change.rst
+++ b/changelog.d/281.change.rst
@@ -1,2 +1,2 @@
-Added ``kwonly`` argument to ``attr.ib`` and corresponding ``kwonly`` attribute to ``attr.Attribute``.
+Added ``kw_only`` argument to ``attr.ib`` and corresponding ``kw_only`` attribute to ``attr.Attribute``.
 This change makes it possible to have a generated ``__init__`` with keyword-only arguments on Python 3.

--- a/changelog.d/281.change.rst
+++ b/changelog.d/281.change.rst
@@ -1,0 +1,2 @@
+Added ``kwonly`` argument to ``attr.ib`` and corresponding ``kwonly`` attribute to ``attr.Attribute``.
+This change makes it possible to have a generated ``__init__`` with keyword-only arguments on Python 3.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -90,7 +90,7 @@ Core
       ... class C(object):
       ...     x = attr.ib()
       >>> attr.fields(C).x
-      Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), type=None)
+      Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), type=None, kw_only=False)
 
 
 .. autofunction:: attr.make_class
@@ -202,9 +202,9 @@ Helpers
       ...     x = attr.ib()
       ...     y = attr.ib()
       >>> attr.fields(C)
-      (Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), type=None), Attribute(name='y', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), type=None))
+      (Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), type=None, kw_only=False), Attribute(name='y', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), type=None, kw_only=False))
       >>> attr.fields(C)[1]
-      Attribute(name='y', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), type=None)
+      Attribute(name='y', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), type=None, kw_only=False)
       >>> attr.fields(C).y is attr.fields(C)[1]
       True
 
@@ -299,7 +299,7 @@ See :ref:`asdict` for examples.
       >>> attr.validate(i)
       Traceback (most recent call last):
          ...
-      TypeError: ("'x' must be <type 'int'> (got '1' that is a <type 'str'>).", Attribute(name='x', default=NOTHING, validator=<instance_of validator for type <type 'int'>>, repr=True, cmp=True, hash=None, init=True, type=None), <type 'int'>, '1')
+      TypeError: ("'x' must be <type 'int'> (got '1' that is a <type 'str'>).", Attribute(name='x', default=NOTHING, validator=<instance_of validator for type <type 'int'>>, repr=True, cmp=True, hash=None, init=True, type=None, kw_only=False), <type 'int'>, '1')
 
 
 Validators can be globally disabled if you want to run them only in development and tests but not in production because you fear their performance impact:
@@ -332,11 +332,11 @@ Validators
       >>> C("42")
       Traceback (most recent call last):
          ...
-      TypeError: ("'x' must be <type 'int'> (got '42' that is a <type 'str'>).", Attribute(name='x', default=NOTHING, validator=<instance_of validator for type <type 'int'>>, type=None), <type 'int'>, '42')
+      TypeError: ("'x' must be <type 'int'> (got '42' that is a <type 'str'>).", Attribute(name='x', default=NOTHING, validator=<instance_of validator for type <type 'int'>>, type=None, kw_only=False), <type 'int'>, '42')
       >>> C(None)
       Traceback (most recent call last):
          ...
-      TypeError: ("'x' must be <type 'int'> (got None that is a <type 'NoneType'>).", Attribute(name='x', default=NOTHING, validator=<instance_of validator for type <type 'int'>>, repr=True, cmp=True, hash=None, init=True, type=None), <type 'int'>, None)
+      TypeError: ("'x' must be <type 'int'> (got None that is a <type 'NoneType'>).", Attribute(name='x', default=NOTHING, validator=<instance_of validator for type <type 'int'>>, repr=True, cmp=True, hash=None, init=True, type=None, kw_only=False), <type 'int'>, None)
 
 .. autofunction:: attr.validators.in_
 
@@ -388,7 +388,7 @@ Validators
       >>> C("42")
       Traceback (most recent call last):
          ...
-      TypeError: ("'x' must be <type 'int'> (got '42' that is a <type 'str'>).", Attribute(name='x', default=NOTHING, validator=<instance_of validator for type <type 'int'>>, type=None), <type 'int'>, '42')
+      TypeError: ("'x' must be <type 'int'> (got '42' that is a <type 'str'>).", Attribute(name='x', default=NOTHING, validator=<instance_of validator for type <type 'int'>>, type=None, kw_only=False), <type 'int'>, '42')
       >>> C(None)
       C(x=None)
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -141,6 +141,55 @@ Therefore ``@attr.s`` comes with the ``repr_ns`` option to set it manually:
 ``repr_ns`` works on both Python 2 and 3.
 On Python 3 it overrides the implicit detection.
 
+Keyword-only Attributes
+~~~~~~~~~~~~~~~~~~~~~~~
+
+When using ``attrs`` on Python 3, you can also add `keyword-only <https://docs.python.org/3/glossary.html#keyword-only-parameter>`_ attributes:
+
+.. doctest::
+
+    >>> @attr.s
+    ... class A:
+    ...     a = attr.ib(kwonly=True)
+    >>> A()
+    Traceback (most recent call last):
+      ...
+    TypeError: A() missing 1 required keyword-only argument: 'a'
+    >>> A(a=1)
+    A(a=1)
+
+If you create an attribute with ``init=False``, ``kwonly`` argument is simply ignored.
+
+Keyword-only attributes allow subclasses to add attributes without default values, even if the base class defines attributes with default values:
+
+.. doctest::
+
+    >>> @attr.s
+    ... class A:
+    ...     a = attr.ib(default=0)
+    >>> @attr.s
+    ... class B(A):
+    ...     b = attr.ib(kwonly=True)
+    >>> B(b=1)
+    B(a=0, b=1)
+    >>> B()
+    Traceback (most recent call last):
+      ...
+    TypeError: B() missing 1 required keyword-only argument: 'b'
+
+If you omit ``kwonly`` or specify ``kwonly=False``, then you'll get an error:
+
+.. doctest::
+
+    >>> @attr.s
+    ... class A:
+    ...     a = attr.ib(default=0)
+    >>> @attr.s
+    ... class B(Base):
+    ...     b = attr.ib()
+    Traceback (most recent call last):
+      ...
+    ValueError: No mandatory attributes allowed after an attribute with a default value or factory.  Attribute in question: Attribute(name='b', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), type=None, kwonly=False)
 
 .. _asdict:
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -185,7 +185,7 @@ If you omit ``kw_only`` or specify ``kw_only=False``, then you'll get an error:
     ... class A:
     ...     a = attr.ib(default=0)
     >>> @attr.s
-    ... class B(Base):
+    ... class B(A):
     ...     b = attr.ib()
     Traceback (most recent call last):
       ...
@@ -417,7 +417,7 @@ This example also shows of some syntactic sugar for using the :func:`attr.valida
    >>> C("42")
    Traceback (most recent call last):
       ...
-   TypeError: ("'x' must be <type 'int'> (got '42' that is a <type 'str'>).", Attribute(name='x', default=NOTHING, factory=NOTHING, validator=<instance_of validator for type <type 'int'>>, type=None), <type 'int'>, '42')
+   TypeError: ("'x' must be <type 'int'> (got '42' that is a <type 'str'>).", Attribute(name='x', default=NOTHING, factory=NOTHING, validator=<instance_of validator for type <type 'int'>>, type=None, kw_only=False), <type 'int'>, '42')
 
 Of course you can mix and match the two approaches at your convenience:
 
@@ -435,7 +435,7 @@ Of course you can mix and match the two approaches at your convenience:
    >>> C("128")
    Traceback (most recent call last):
       ...
-   TypeError: ("'x' must be <class 'int'> (got '128' that is a <class 'str'>).", Attribute(name='x', default=NOTHING, validator=[<instance_of validator for type <class 'int'>>, <function fits_byte at 0x10fd7a0d0>], repr=True, cmp=True, hash=True, init=True, convert=None, metadata=mappingproxy({}), type=None), <class 'int'>, '128')
+   TypeError: ("'x' must be <class 'int'> (got '128' that is a <class 'str'>).", Attribute(name='x', default=NOTHING, validator=[<instance_of validator for type <class 'int'>>, <function fits_byte at 0x10fd7a0d0>], repr=True, cmp=True, hash=True, init=True, convert=None, metadata=mappingproxy({}), type=None, kw_only=False), <class 'int'>, '128')
    >>> C(256)
    Traceback (most recent call last):
       ...
@@ -450,7 +450,7 @@ And finally you can disable validators globally:
    >>> C("128")
    Traceback (most recent call last):
       ...
-   TypeError: ("'x' must be <class 'int'> (got '128' that is a <class 'str'>).", Attribute(name='x', default=NOTHING, validator=[<instance_of validator for type <class 'int'>>, <function fits_byte at 0x10fd7a0d0>], repr=True, cmp=True, hash=True, init=True, convert=None, metadata=mappingproxy({}), type=None), <class 'int'>, '128')
+   TypeError: ("'x' must be <class 'int'> (got '128' that is a <class 'str'>).", Attribute(name='x', default=NOTHING, validator=[<instance_of validator for type <class 'int'>>, <function fits_byte at 0x10fd7a0d0>], repr=True, cmp=True, hash=True, init=True, convert=None, metadata=mappingproxy({}), type=None, kw_only=False), <class 'int'>, '128')
 
 
 Conversion

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -150,7 +150,7 @@ When using ``attrs`` on Python 3, you can also add `keyword-only <https://docs.p
 
     >>> @attr.s
     ... class A:
-    ...     a = attr.ib(kwonly=True)
+    ...     a = attr.ib(kw_only=True)
     >>> A()
     Traceback (most recent call last):
       ...
@@ -158,7 +158,7 @@ When using ``attrs`` on Python 3, you can also add `keyword-only <https://docs.p
     >>> A(a=1)
     A(a=1)
 
-If you create an attribute with ``init=False``, ``kwonly`` argument is simply ignored.
+If you create an attribute with ``init=False``, ``kw_only`` argument is simply ignored.
 
 Keyword-only attributes allow subclasses to add attributes without default values, even if the base class defines attributes with default values:
 
@@ -169,7 +169,7 @@ Keyword-only attributes allow subclasses to add attributes without default value
     ...     a = attr.ib(default=0)
     >>> @attr.s
     ... class B(A):
-    ...     b = attr.ib(kwonly=True)
+    ...     b = attr.ib(kw_only=True)
     >>> B(b=1)
     B(a=0, b=1)
     >>> B()
@@ -177,7 +177,7 @@ Keyword-only attributes allow subclasses to add attributes without default value
       ...
     TypeError: B() missing 1 required keyword-only argument: 'b'
 
-If you omit ``kwonly`` or specify ``kwonly=False``, then you'll get an error:
+If you omit ``kw_only`` or specify ``kw_only=False``, then you'll get an error:
 
 .. doctest::
 
@@ -189,7 +189,7 @@ If you omit ``kwonly`` or specify ``kwonly=False``, then you'll get an error:
     ...     b = attr.ib()
     Traceback (most recent call last):
       ...
-    ValueError: No mandatory attributes allowed after an attribute with a default value or factory.  Attribute in question: Attribute(name='b', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), type=None, kwonly=False)
+    ValueError: No mandatory attributes allowed after an attribute with a default value or factory.  Attribute in question: Attribute(name='b', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), type=None, kw_only=False)
 
 .. _asdict:
 

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -17,7 +17,7 @@ So it is fairly simple to build your own decorators on top of ``attrs``:
    ... @attr.s
    ... class C(object):
    ...     a = attr.ib()
-   (Attribute(name='a', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), type=None),)
+   (Attribute(name='a', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, convert=None, metadata=mappingproxy({}), type=None, kw_only=False),)
 
 
 .. warning::

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -61,7 +61,7 @@ Sentinel to indicate the lack of a value when ``None`` is ambiguous.
 
 def attrib(default=NOTHING, validator=None,
            repr=True, cmp=True, hash=None, init=True,
-           convert=None, metadata={}, type=None, kwonly=False):
+           convert=None, metadata={}, type=None, kw_only=False):
     """
     Create a new attribute on a class.
 
@@ -130,7 +130,7 @@ def attrib(default=NOTHING, validator=None,
         This argument is provided for backward compatibility.
         Regardless of the approach used, the type will be stored on
         ``Attribute.type``.
-    :param kwonly: Make this attribute keyword-only (Python 3+)
+    :param kw_only: Make this attribute keyword-only (Python 3+)
         in the generated ``__init__`` (if ``init`` is ``False``, this
         parameter is simply ignored).
 
@@ -138,7 +138,7 @@ def attrib(default=NOTHING, validator=None,
     ..  versionchanged:: 17.1.0
         *hash* is ``None`` and therefore mirrors *cmp* by default .
     ..  versionadded:: 17.3.0 *type*
-    ..  versionadded:: 17.3.0 *kwonly*
+    ..  versionadded:: 17.3.0 *kw_only*
     """
     if hash is not None and hash is not True and hash is not False:
         raise TypeError(
@@ -154,7 +154,7 @@ def attrib(default=NOTHING, validator=None,
         convert=convert,
         metadata=metadata,
         type=type,
-        kwonly=kwonly,
+        kw_only=kw_only,
     )
 
 
@@ -262,11 +262,11 @@ def _transform_attrs(cls, these):
     )
 
     had_default = False
-    was_kwonly = False
+    was_kw_only = False
     for a in attrs:
-        if (was_kwonly is False and had_default is True and
+        if (was_kw_only is False and had_default is True and
                 a.default is NOTHING and a.init is True and
-                a.kwonly is False):
+                a.kw_only is False):
             raise ValueError(
                 "No mandatory attributes allowed after an attribute with a "
                 "default value or factory.  Attribute in question: {a!r}"
@@ -277,16 +277,16 @@ def _transform_attrs(cls, these):
                 a.init is not False and
                 # Keyword-only attributes without defaults can be specified
                 # after keyword-only attributes with defaults.
-                a.kwonly is False):
+                a.kw_only is False):
             had_default = True
-        if was_kwonly is True and a.kwonly is False:
+        if was_kw_only is True and a.kw_only is False:
             raise ValueError(
                 "Non keyword-only attributes are not allowed after a "
                 "keyword-only attribute.  Attribute in question: {a!r}"
                 .format(a=a)
             )
-        if was_kwonly is False and a.init is True and a.kwonly is True:
-            was_kwonly = True
+        if was_kw_only is False and a.init is True and a.kw_only is True:
+            was_kw_only = True
 
     return _Attributes((attrs, super_attrs))
 
@@ -932,7 +932,7 @@ def _attrs_to_script(attrs, frozen, post_init):
             }
 
     args = []
-    kwonly_args = []
+    kw_only_args = []
     attrs_to_validate = []
 
     # This is a dictionary of names to validator and converter callables.
@@ -984,8 +984,8 @@ def _attrs_to_script(attrs, frozen, post_init):
                 arg_name=arg_name,
                 attr_name=attr_name,
             )
-            if a.kwonly:
-                kwonly_args.append(arg)
+            if a.kw_only:
+                kw_only_args.append(arg)
             else:
                 args.append(arg)
             if a.convert is not None:
@@ -995,8 +995,8 @@ def _attrs_to_script(attrs, frozen, post_init):
                 lines.append(fmt_setter(attr_name, arg_name))
         elif has_factory:
             arg = "{arg_name}=NOTHING".format(arg_name=arg_name)
-            if a.kwonly:
-                kwonly_args.append(arg)
+            if a.kw_only:
+                kw_only_args.append(arg)
             else:
                 args.append(arg)
             lines.append("if {arg_name} is not NOTHING:"
@@ -1020,8 +1020,8 @@ def _attrs_to_script(attrs, frozen, post_init):
                 ))
             names_for_globals[init_factory_name] = a.default.factory
         else:
-            if a.kwonly:
-                kwonly_args.append(arg_name)
+            if a.kw_only:
+                kw_only_args.append(arg_name)
             else:
                 args.append(arg_name)
             if a.convert is not None:
@@ -1044,10 +1044,10 @@ def _attrs_to_script(attrs, frozen, post_init):
         lines.append("self.__attrs_post_init__()")
 
     args = ", ".join(args)
-    if kwonly_args:
-        args += "{leading_comma}*, {kwonly_args}".format(
+    if kw_only_args:
+        args += "{leading_comma}*, {kw_only_args}".format(
             leading_comma=", " if args else "",
-            kwonly_args=", ".join(kwonly_args)
+            kw_only_args=", ".join(kw_only_args)
         )
     return """\
 def __init__(self, {args}):
@@ -1068,11 +1068,11 @@ class Attribute(object):
     """
     __slots__ = (
         "name", "default", "validator", "repr", "cmp", "hash", "init",
-        "convert", "metadata", "type", "kwonly"
+        "convert", "metadata", "type", "kw_only"
     )
 
     def __init__(self, name, default, validator, repr, cmp, hash, init,
-                 convert=None, metadata=None, type=None, kwonly=False):
+                 convert=None, metadata=None, type=None, kw_only=False):
         # Cache this descriptor here to speed things up later.
         bound_setattr = _obj_setattr.__get__(self, Attribute)
 
@@ -1087,7 +1087,7 @@ class Attribute(object):
         bound_setattr("metadata", (metadata_proxy(metadata) if metadata
                                    else _empty_metadata_singleton))
         bound_setattr("type", type)
-        bound_setattr("kwonly", kwonly)
+        bound_setattr("kw_only", kw_only)
 
     def __setattr__(self, name, value):
         raise FrozenInstanceError()
@@ -1153,20 +1153,20 @@ class _CountingAttr(object):
     likely the result of a bug like a forgotten `@attr.s` decorator.
     """
     __slots__ = ("counter", "_default", "repr", "cmp", "hash", "init",
-                 "metadata", "_validator", "convert", "type", "kwonly")
+                 "metadata", "_validator", "convert", "type", "kw_only")
     __attrs_attrs__ = tuple(
         Attribute(name=name, default=NOTHING, validator=None,
-                  repr=True, cmp=True, hash=True, init=True, kwonly=False)
+                  repr=True, cmp=True, hash=True, init=True, kw_only=False)
         for name
         in ("counter", "_default", "repr", "cmp", "hash", "init",)
     ) + (
         Attribute(name="metadata", default=None, validator=None,
-                  repr=True, cmp=True, hash=False, init=True, kwonly=False),
+                  repr=True, cmp=True, hash=False, init=True, kw_only=False),
     )
     cls_counter = 0
 
     def __init__(self, default, validator, repr, cmp, hash, init, convert,
-                 metadata, type, kwonly):
+                 metadata, type, kw_only):
         _CountingAttr.cls_counter += 1
         self.counter = _CountingAttr.cls_counter
         self._default = default
@@ -1182,7 +1182,7 @@ class _CountingAttr(object):
         self.convert = convert
         self.metadata = metadata
         self.type = type
-        self.kwonly = kwonly
+        self.kw_only = kw_only
 
     def validator(self, meth):
         """

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -61,7 +61,7 @@ Sentinel to indicate the lack of a value when ``None`` is ambiguous.
 
 def attrib(default=NOTHING, validator=None,
            repr=True, cmp=True, hash=None, init=True,
-           convert=None, metadata={}, type=None):
+           convert=None, metadata={}, type=None, kwonly=False):
     """
     Create a new attribute on a class.
 
@@ -130,11 +130,15 @@ def attrib(default=NOTHING, validator=None,
         This argument is provided for backward compatibility.
         Regardless of the approach used, the type will be stored on
         ``Attribute.type``.
+    :param kwonly: Make this attribute keyword-only (Python 3+)
+        in the generated ``__init__`` (if ``init`` is ``False``, this
+        parameter is simply ignored).
 
     ..  versionchanged:: 17.1.0 *validator* can be a ``list`` now.
     ..  versionchanged:: 17.1.0
         *hash* is ``None`` and therefore mirrors *cmp* by default .
     ..  versionadded:: 17.3.0 *type*
+    ..  versionadded:: 17.3.0 *kwonly*
     """
     if hash is not None and hash is not True and hash is not False:
         raise TypeError(
@@ -150,6 +154,7 @@ def attrib(default=NOTHING, validator=None,
         convert=convert,
         metadata=metadata,
         type=type,
+        kwonly=kwonly,
     )
 
 
@@ -257,17 +262,31 @@ def _transform_attrs(cls, these):
     )
 
     had_default = False
+    was_kwonly = False
     for a in attrs:
-        if had_default is True and a.default is NOTHING and a.init is True:
+        if (was_kwonly is False and had_default is True and
+                a.default is NOTHING and a.init is True and
+                a.kwonly is False):
             raise ValueError(
                 "No mandatory attributes allowed after an attribute with a "
                 "default value or factory.  Attribute in question: {a!r}"
                 .format(a=a)
             )
-        elif had_default is False and \
-                a.default is not NOTHING and \
-                a.init is not False:
+        elif (had_default is False and
+                a.default is not NOTHING and
+                a.init is not False and
+                # Keyword-only attributes without defaults can be specified
+                # after keyword-only attributes with defaults.
+                a.kwonly is False):
             had_default = True
+        if was_kwonly is True and a.kwonly is False:
+            raise ValueError(
+                "Non keyword-only attributes are not allowed after a "
+                "keyword-only attribute.  Attribute in question: {a!r}"
+                .format(a=a)
+            )
+        if was_kwonly is False and a.init is True and a.kwonly is True:
+            was_kwonly = True
 
     return _Attributes((attrs, super_attrs))
 
@@ -913,6 +932,7 @@ def _attrs_to_script(attrs, frozen, post_init):
             }
 
     args = []
+    kwonly_args = []
     attrs_to_validate = []
 
     # This is a dictionary of names to validator and converter callables.
@@ -960,19 +980,25 @@ def _attrs_to_script(attrs, frozen, post_init):
                         .format(attr_name=attr_name)
                     ))
         elif a.default is not NOTHING and not has_factory:
-            args.append(
-                "{arg_name}=attr_dict['{attr_name}'].default".format(
-                    arg_name=arg_name,
-                    attr_name=attr_name,
-                )
+            arg = "{arg_name}=attr_dict['{attr_name}'].default".format(
+                arg_name=arg_name,
+                attr_name=attr_name,
             )
+            if a.kwonly:
+                kwonly_args.append(arg)
+            else:
+                args.append(arg)
             if a.convert is not None:
                 lines.append(fmt_setter_with_converter(attr_name, arg_name))
                 names_for_globals[_init_convert_pat.format(a.name)] = a.convert
             else:
                 lines.append(fmt_setter(attr_name, arg_name))
         elif has_factory:
-            args.append("{arg_name}=NOTHING".format(arg_name=arg_name))
+            arg = "{arg_name}=NOTHING".format(arg_name=arg_name)
+            if a.kwonly:
+                kwonly_args.append(arg)
+            else:
+                args.append(arg)
             lines.append("if {arg_name} is not NOTHING:"
                          .format(arg_name=arg_name))
             init_factory_name = _init_factory_pat.format(a.name)
@@ -994,7 +1020,10 @@ def _attrs_to_script(attrs, frozen, post_init):
                 ))
             names_for_globals[init_factory_name] = a.default.factory
         else:
-            args.append(arg_name)
+            if a.kwonly:
+                kwonly_args.append(arg_name)
+            else:
+                args.append(arg_name)
             if a.convert is not None:
                 lines.append(fmt_setter_with_converter(attr_name, arg_name))
                 names_for_globals[_init_convert_pat.format(a.name)] = a.convert
@@ -1014,11 +1043,17 @@ def _attrs_to_script(attrs, frozen, post_init):
     if post_init:
         lines.append("self.__attrs_post_init__()")
 
+    args = ", ".join(args)
+    if kwonly_args:
+        args += "{leading_comma}*, {kwonly_args}".format(
+            leading_comma=", " if args else "",
+            kwonly_args=", ".join(kwonly_args)
+        )
     return """\
 def __init__(self, {args}):
     {lines}
 """.format(
-        args=", ".join(args),
+        args=args,
         lines="\n    ".join(lines) if lines else "pass",
     ), names_for_globals
 
@@ -1033,11 +1068,11 @@ class Attribute(object):
     """
     __slots__ = (
         "name", "default", "validator", "repr", "cmp", "hash", "init",
-        "convert", "metadata", "type"
+        "convert", "metadata", "type", "kwonly"
     )
 
     def __init__(self, name, default, validator, repr, cmp, hash, init,
-                 convert=None, metadata=None, type=None):
+                 convert=None, metadata=None, type=None, kwonly=False):
         # Cache this descriptor here to speed things up later.
         bound_setattr = _obj_setattr.__get__(self, Attribute)
 
@@ -1052,6 +1087,7 @@ class Attribute(object):
         bound_setattr("metadata", (metadata_proxy(metadata) if metadata
                                    else _empty_metadata_singleton))
         bound_setattr("type", type)
+        bound_setattr("kwonly", kwonly)
 
     def __setattr__(self, name, value):
         raise FrozenInstanceError()
@@ -1117,20 +1153,20 @@ class _CountingAttr(object):
     likely the result of a bug like a forgotten `@attr.s` decorator.
     """
     __slots__ = ("counter", "_default", "repr", "cmp", "hash", "init",
-                 "metadata", "_validator", "convert", "type")
+                 "metadata", "_validator", "convert", "type", "kwonly")
     __attrs_attrs__ = tuple(
         Attribute(name=name, default=NOTHING, validator=None,
-                  repr=True, cmp=True, hash=True, init=True)
+                  repr=True, cmp=True, hash=True, init=True, kwonly=False)
         for name
         in ("counter", "_default", "repr", "cmp", "hash", "init",)
     ) + (
         Attribute(name="metadata", default=None, validator=None,
-                  repr=True, cmp=True, hash=False, init=True),
+                  repr=True, cmp=True, hash=False, init=True, kwonly=False),
     )
     cls_counter = 0
 
     def __init__(self, default, validator, repr, cmp, hash, init, convert,
-                 metadata, type):
+                 metadata, type, kwonly):
         _CountingAttr.cls_counter += 1
         self.counter = _CountingAttr.cls_counter
         self._default = default
@@ -1146,6 +1182,7 @@ class _CountingAttr(object):
         self.convert = convert
         self.metadata = metadata
         self.type = type
+        self.kwonly = kwonly
 
     def validator(self, meth):
         """

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -193,7 +193,7 @@ class TestTransformAttrs(object):
             "default value or factory.  Attribute in question: Attribute"
             "(name='y', default=NOTHING, validator=None, repr=True, "
             "cmp=True, hash=None, init=True, convert=None, "
-            "metadata=mappingproxy({}), type=None, kwonly=False)",
+            "metadata=mappingproxy({}), type=None, kw_only=False)",
         ) == e.value.args
 
     def test_these(self):
@@ -420,9 +420,9 @@ class TestKeywordOnlyAttributes(object):
         @attr.s
         class C(object):
             a = attr.ib()
-            b = attr.ib(default=2, kwonly=True)
-            c = attr.ib(kwonly=True)
-            d = attr.ib(default=attr.Factory(lambda: 4), kwonly=True)
+            b = attr.ib(default=2, kw_only=True)
+            c = attr.ib(kw_only=True)
+            d = attr.ib(default=attr.Factory(lambda: 4), kw_only=True)
 
         c = C(1, c=3)
 
@@ -431,13 +431,13 @@ class TestKeywordOnlyAttributes(object):
         assert c.c == 3
         assert c.d == 4
 
-    def test_ignores_kwonly_when_init_is_false(self):
+    def test_ignores_kw_only_when_init_is_false(self):
         """
-        Specifying ``kwonly=True`` when ``init=False`` is essentially a no-op.
+        Specifying ``kw_only=True`` when ``init=False`` is essentially a no-op.
         """
         @attr.s
         class C(object):
-            x = attr.ib(init=False, default=0, kwonly=True)
+            x = attr.ib(init=False, default=0, kw_only=True)
             y = attr.ib()
 
         c = C(1)
@@ -451,7 +451,7 @@ class TestKeywordOnlyAttributes(object):
         """
         @attr.s
         class C(object):
-            x = attr.ib(kwonly=True)
+            x = attr.ib(kw_only=True)
 
         with pytest.raises(TypeError) as e:
             C()
@@ -466,7 +466,7 @@ class TestKeywordOnlyAttributes(object):
         regular (non keyword-only) attributes.
         """
         class C(object):
-            x = attr.ib(kwonly=True)
+            x = attr.ib(kw_only=True)
             y = attr.ib()
 
         with pytest.raises(ValueError) as e:
@@ -476,7 +476,7 @@ class TestKeywordOnlyAttributes(object):
             "keyword-only attribute.  Attribute in question: Attribute"
             "(name='y', default=NOTHING, validator=None, repr=True, "
             "cmp=True, hash=None, init=True, convert=None, "
-            "metadata=mappingproxy({}), type=None, kwonly=False)",
+            "metadata=mappingproxy({}), type=None, kw_only=False)",
         ) == e.value.args
 
     def test_keyword_only_attributes_allow_subclassing(self):
@@ -490,7 +490,7 @@ class TestKeywordOnlyAttributes(object):
 
         @attr.s
         class C(Base):
-            y = attr.ib(kwonly=True)
+            y = attr.ib(kw_only=True)
 
         c = C(y=1)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -30,13 +30,13 @@ def simple_class(cmp=False, repr=False, hash=False, str=False, slots=False,
 
 
 def simple_attr(name, default=NOTHING, validator=None, repr=True,
-                cmp=True, hash=None, init=True, kwonly=False):
+                cmp=True, hash=None, init=True, kw_only=False):
     """
     Return an attribute with a name and no other bells and whistles.
     """
     return Attribute(
         name=name, default=default, validator=validator, repr=repr,
-        cmp=cmp, hash=hash, init=init, kwonly=kwonly,
+        cmp=cmp, hash=hash, init=init, kw_only=kw_only,
     )
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -30,13 +30,13 @@ def simple_class(cmp=False, repr=False, hash=False, str=False, slots=False,
 
 
 def simple_attr(name, default=NOTHING, validator=None, repr=True,
-                cmp=True, hash=None, init=True):
+                cmp=True, hash=None, init=True, kwonly=False):
     """
     Return an attribute with a name and no other bells and whistles.
     """
     return Attribute(
         name=name, default=default, validator=validator, repr=repr,
-        cmp=cmp, hash=hash, init=init
+        cmp=cmp, hash=hash, init=init, kwonly=kwonly,
     )
 
 


### PR DESCRIPTION
# Pull Request Check List

- [x] Added **tests** for changed code.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/utils.py).
- [x] Updated **documentation** for changed code.
- [x] Documentation in `.rst` files is written using [semantic newlines](http://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

Please, correct me if I checked something wrong.