### PR TITLE
Fix pickling for instances of classes created using make_class()

### DIFF
--- a/changelog.d/282.change.rst
+++ b/changelog.d/282.change.rst
@@ -1,0 +1,1 @@
+Instances of classes created using ``attr.make_class()`` can now be pickled.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -601,7 +601,7 @@ You can still have power over the attributes if you pass a dictionary of name: `
    ...                     repr=False)
    >>> i = C()
    >>> i  # no repr added!
-   <attr._make.C object at ...>
+   <__main__.C object at ...>
    >>> i.x
    42
    >>> i.y

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1248,7 +1248,8 @@ def make_class(name, attrs, bases=(object,), **attributes_arguments):
     # sys._getframe is not defined (Jython for example) or sys._getframe is not
     # defined for arguments greater than 0 (IronPython)
     try:
-        type_.__module__ = sys._getframe(1).f_globals.get('__name__', '__main__')
+        type_.__module__ = sys._getframe(1).f_globals.get('__name__',
+                                                          '__main__')
     except (AttributeError, ValueError):
         pass
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import hashlib
 import linecache
+import sys
 
 from operator import itemgetter
 
@@ -1237,13 +1238,21 @@ def make_class(name, attrs, bases=(object,), **attributes_arguments):
         raise TypeError("attrs argument must be a dict or a list.")
 
     post_init = cls_dict.pop("__attrs_post_init__", None)
-    return _attrs(
-        these=cls_dict, **attributes_arguments
-    )(type(
+    type_ = type(
         name,
         bases,
         {} if post_init is None else {"__attrs_post_init__": post_init}
-    ))
+    )
+    # For pickling to work, the __module__ variable needs to be set to the
+    # frame where the class is created. Bypass this step in environments where
+    # sys._getframe is not defined (Jython for example) or sys._getframe is not
+    # defined for arguments greater than 0 (IronPython)
+    try:
+        type_.__module__ = sys._getframe(1).f_globals.get('__name__', '__main__')
+    except (AttributeError, ValueError):
+        pass
+
+    return _attrs(these=cls_dict, **attributes_arguments)(type_)
 
 
 # These are required by within this module so we define them here and merely

--- a/tests/test_dark_magic.py
+++ b/tests/test_dark_magic.py
@@ -103,6 +103,9 @@ class WithMetaSlots(object):
     pass
 
 
+FromMakeClass = attr.make_class('FromMakeClass', ['x'])
+
+
 class TestDarkMagic(object):
     """
     Integration tests.
@@ -218,7 +221,8 @@ class TestDarkMagic(object):
 
     @pytest.mark.parametrize("cls",
                              [C1, C1Slots, C2, C2Slots, Super, SuperSlots,
-                              Sub, SubSlots, Frozen, FrozenNoSlots])
+                              Sub, SubSlots, Frozen, FrozenNoSlots,
+                              FromMakeClass])
     @pytest.mark.parametrize("protocol",
                              range(2, pickle.HIGHEST_PROTOCOL + 1))
     def test_pickle_attributes(self, cls, protocol):
@@ -230,7 +234,8 @@ class TestDarkMagic(object):
 
     @pytest.mark.parametrize("cls",
                              [C1, C1Slots, C2, C2Slots, Super, SuperSlots,
-                              Sub, SubSlots, Frozen, FrozenNoSlots])
+                              Sub, SubSlots, Frozen, FrozenNoSlots,
+                              FromMakeClass])
     @pytest.mark.parametrize("protocol",
                              range(2, pickle.HIGHEST_PROTOCOL + 1))
     def test_pickle_object(self, cls, protocol):

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -503,6 +503,7 @@ class TestMakeClass(object):
         C = make_class("C", ["x"])
         assert C.__attrs_attrs__
 
+
 class TestFields(object):
     """
     Tests for `fields`.

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -456,7 +456,7 @@ class TestMakeClass(object):
         attributes_arguments are passed to attributes
         """
         C = make_class("C", ["x"], repr=False)
-        assert repr(C(1)).startswith("<attr._make.C object at 0x")
+        assert repr(C(1)).startswith("<tests.test_make.C object at 0x")
 
     def test_catches_wrong_attrs_type(self):
         """

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -5,6 +5,7 @@ Tests for `attr._make`.
 from __future__ import absolute_import, division, print_function
 
 import inspect
+import sys
 
 from operator import attrgetter
 
@@ -494,6 +495,13 @@ class TestMakeClass(object):
 
         assert not isinstance(x, _CountingAttr)
 
+    def test_missing_sys_getframe(self, monkeypatch):
+        """
+        `make_class()` does not fail when `sys._getframe()` is not available.
+        """
+        monkeypatch.delattr(sys, '_getframe')
+        C = make_class("C", ["x"])
+        assert C.__attrs_attrs__
 
 class TestFields(object):
     """


### PR DESCRIPTION
Currently, trying to pickle an instance of a class created using `attrs.make_class` fails (tested on Python 2.7 and 3.5):

    >>> import attr
    >>> import pickle
    >>> C = attr.make_class('C', ['x'])
    >>> obj = C(1)
    >>> pickle.dumps(obj)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    _pickle.PicklingError: Can't pickle <class 'attr._make.C'>: attribute lookup C on attr._make failed

It has something to do with pickle looking for the class/type in the wrong module. I was curious how `collections.namedtuple` solves this and found this (also present in Python 2.7):

https://github.com/python/cpython/blob/v3.5.4/Lib/collections/__init__.py#L436-L445

This PR adds the same code (with comment) verbatim to attrs, to make pickling work. As a side effect, the `repr` of classes created this way now also contain name of the module where `make_class()` was called instead of "attr._make". I'm not sure if this needs a Changelog/Documentation update?

I also noticed that Python 3.6 added an explicit `module` parameter to `collections.namedtuple`, to allow manually overriding the module name to fix issues with pickling on other Python implementations such as IronPython (https://bugs.python.org/issue17941). Maybe this would also be useful to add to `attrs` in the future.