### PR TITLE
BF: reverse MRO as well if we are reversing the attrs at the end

### DIFF
--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -279,13 +279,12 @@ def _transform_attrs(cls, these, auto_attribs):
     # redefinitions deeper in the hierarchy.
     super_attrs = []
     taken_attr_names = {a.name: a for a in non_super_attrs}
-    for super_cls in reversed(cls.__mro__[1:-1]):
+    for super_cls in cls.__mro__[1:]:
         sub_attrs = getattr(super_cls, "__attrs_attrs__", None)
         if sub_attrs is not None:
-            # We iterate over sub_attrs backwards so we can reverse the whole
-            # list in the end and get all attributes in the order they have
-            # been defined.
-            for a in reversed(sub_attrs):
+            # We iterate over sub_attrs forward and populate them as soon
+            # as we see it
+            for a in sub_attrs:
                 prev_a = taken_attr_names.get(a.name)
                 if prev_a is None:
                     super_attrs.append(a)
@@ -293,13 +292,12 @@ def _transform_attrs(cls, these, auto_attribs):
                 elif prev_a == a:
                     # This happens through multiple inheritance.  We don't want
                     # to favor attributes that are further down in the tree
-                    # so we move them to the back.
-                    super_attrs.remove(a)
-                    super_attrs.append(a)
+                    # so we ... skip them altogether
+                    continue
 
     # Now reverse the list, such that the attributes are sorted by *descending*
     # age.  IOW: the oldest attribute definition is at the head of the list.
-    super_attrs.reverse()
+    # super_attrs.reverse()
 
     attr_names = [a.name for a in super_attrs + non_super_attrs]
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -279,7 +279,7 @@ def _transform_attrs(cls, these, auto_attribs):
     # redefinitions deeper in the hierarchy.
     super_attrs = []
     taken_attr_names = {a.name: a for a in non_super_attrs}
-    for super_cls in cls.__mro__[1:-1]:
+    for super_cls in reversed(cls.__mro__[1:-1]):
         sub_attrs = getattr(super_cls, "__attrs_attrs__", None)
         if sub_attrs is not None:
             # We iterate over sub_attrs backwards so we can reverse the whole
@@ -291,7 +291,7 @@ def _transform_attrs(cls, these, auto_attribs):
                     super_attrs.append(a)
                     taken_attr_names[a.name] = a
                 elif prev_a == a:
-                    # This happens thru multiple inheritance.  We don't want
+                    # This happens through multiple inheritance.  We don't want
                     # to favor attributes that are further down in the tree
                     # so we move them to the back.
                     super_attrs.remove(a)

--- a/tests/test_dark_magic.py
+++ b/tests/test_dark_magic.py
@@ -380,3 +380,32 @@ class TestDarkMagic(object):
             z = attr.ib(default=4)
 
         assert "E(c=100, b=23, a=42, x=2, d=3.14, y=3, z=4)" == repr(E())
+        assert "E(c=100, b=23, a=42, x=2, d=3.14, y=3, z=4)" == repr(E(100, 23, 42, 2, 3.14, 3, 4))
+
+    def test_multiple_inheritance2(self):
+
+        @attr.s
+        class A(object):
+            a = attr.ib()
+
+        @attr.s
+        class B(A):
+            b = attr.ib()
+
+        @attr.s
+        class C(object):
+            c = attr.ib()
+
+        @attr.s
+        class D(B, C):
+            d = attr.ib()
+
+        assert "D(a=1, b=2, c=3, d=4)" == repr(D(1, 2, 3, 4))
+
+        # overload c
+        @attr.s
+        class D2(B, C):
+            d = attr.ib()
+            c = attr.ib()
+
+        assert "D2(a=1, b=2, d=3, c=4)" == repr(D2(1, 2, 3, 4))

--- a/tests/test_dark_magic.py
+++ b/tests/test_dark_magic.py
@@ -380,7 +380,8 @@ class TestDarkMagic(object):
             z = attr.ib(default=4)
 
         assert "E(c=100, b=23, a=42, x=2, d=3.14, y=3, z=4)" == repr(E())
-        assert "E(c=100, b=23, a=42, x=2, d=3.14, y=3, z=4)" == repr(E(100, 23, 42, 2, 3.14, 3, 4))
+        assert "E(c=100, b=23, a=42, x=2, d=3.14, y=3, z=4)" == \
+               repr(E(100, 23, 42, 2, 3.14, 3, 4))
 
     def test_multiple_inheritance2(self):
 

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -240,8 +240,8 @@ class TestTransformAttrs(object):
             e2 = attr.ib(default="e2")
 
         assert (
-            "E(a1='a1', a2='a2', b1='b1', b2='b2', c1='c1', c2='c2', d1='d1', "
-            "d2='d2', e1='e1', e2='e2')"
+            "E(a1='a1', a2='a2', d1='d1', d2='d2', b1='b1', b2='b2', "
+            "c1='c1', c2='c2', e1='e1', e2='e2')"
         ) == repr(E())
 
 


### PR DESCRIPTION
Changes traversal of MRO to be done without any reverse-twice dance -- not really sure why it is needed since attributes simply "sink down" into derived classes quite naturally, or tests do not capture the intricacies enough.  

- [x] It does resolve incorrect (IMHO) ordering of attributes in case of multiple inheritance (Closes #298) 
       This changed behavior from what was discussed/fixed in #285 .  To me, the order enforced by the test `test_multiple_inheritance` did not make much sense, so I might be utterly wrong!
- [x] Added **tests** for changed code and adjusted (as stated above) one previous test
- [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

