### PR TITLE
Speed up __eq__ by generating code

### DIFF
--- a/changelog.d/306.change.rst
+++ b/changelog.d/306.change.rst
@@ -1,0 +1,1 @@
+Equality tests are *much* faster now.


### PR DESCRIPTION
So this is a 1:1 implementation of the old behaviour, ignoring #305 for now.

Improvements:

```python
import attr


@attr.s(hash=True)
class C:
    x = attr.ib()
    y = attr.ib()
    z = attr.ib()


c1 = C(1, "2", 3.0)
c2 = C(1, "2", 3.0)
```

attrs 17.3.0:
```
➤ pyperf timeit --rigorous -s "from t import c1, c2" "c1 == c2"
.........................................
Mean +- std dev: 3.24 us +- 0.13 us
```

New:
```
➤ pyperf timeit --rigorous -s "from t import c1, c2" "c1 == c2"
.........................................
Mean +- std dev: 538 ns +- 29 ns
```

For sets:

attrs 17.3.0:
```
➤ pyperf timeit --rigorous -s "from t import c1, c2" "s = {c1, c2}; c1 in s"
.........................................
Mean +- std dev: 8.56 us +- 0.32 us
```

New:
```
➤ pyperf timeit --rigorous -s "from t import c1, c2" "s = {c1, c2}; c1 in s"
.........................................
Mean +- std dev: 1.82 us +- 0.09 us
```

This looks nice. :)