### PR TITLE
Fix __repr__ crashing when a member is uninitialized or deleted

### DIFF
--- a/changelog.d/308.breaking.rst
+++ b/changelog.d/308.breaking.rst
@@ -1,0 +1,20 @@
+The ``__repr__`` set by ``attrs``
+no longer produces an ``AttributeError``
+when the instance is missing some of the specified attributes
+(either through deleting
+or after using ``init=False`` on some attributes).
+
+This can break code
+that relied on ``repr(attr_cls_instance)`` raising ``AttributeError``
+to check if any attr-specified members were unset.
+
+If you were using this,
+you can implement a custom method for checking this::
+
+    def has_unset_members(self):
+        for field in attr.fields(type(self)):
+            try:
+                getattr(self, field.name)
+            except AttributeError:
+                return True
+        return False

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -849,7 +849,7 @@ def _make_repr(attrs, ns):
         return "{0}({1})".format(
             class_name,
             ", ".join(
-                name + "=" + repr(getattr(self, name))
+                name + "=" + repr(getattr(self, name, NOTHING))
                 for name in attr_names
             )
         )

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -200,6 +200,16 @@ class TestAddRepr(object):
 
         assert "C(_x=42)" == repr(i)
 
+    def test_repr_uninitialized_member(self):
+        """
+        repr signals unset attributes
+        """
+        C = make_class("C", {
+            "a": attr.ib(init=False),
+        })
+
+        assert "C(a=NOTHING)" == repr(C())
+
     @given(add_str=booleans(), slots=booleans())
     def test_str(self, add_str, slots):
         """


### PR DESCRIPTION
# Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](http://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/utils.py).
- [ ] Updated **documentation** for changed code.
- [ ] Documentation in `.rst` files is written using [semantic newlines](http://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
