### PR TITLE
Eliminate __init__ overhead for frozen dict classes.

### DIFF
--- a/changelog.d/336.change.rst
+++ b/changelog.d/336.change.rst
@@ -1,0 +1,1 @@
+The overhead of instantiating frozen dict classes is virtually eliminated.

--- a/tests/test_dark_magic.py
+++ b/tests/test_dark_magic.py
@@ -380,3 +380,36 @@ class TestDarkMagic(object):
             z = attr.ib(default=4)
 
         assert "E(c=100, b=23, a=42, x=2, d=3.14, y=3, z=4)" == repr(E())
+
+    @pytest.mark.parametrize("base_slots", [True, False])
+    @pytest.mark.parametrize("sub_slots", [True, False])
+    @pytest.mark.parametrize("base_frozen", [True, False])
+    @pytest.mark.parametrize("sub_frozen", [True, False])
+    @pytest.mark.parametrize("base_converter", [True, False])
+    @pytest.mark.parametrize("sub_converter", [True, False])
+    def test_frozen_slots_combo(self, base_slots, sub_slots, base_frozen,
+                                sub_frozen, base_converter, sub_converter):
+        """
+        A class with a single attribute, inheriting from another class
+        with a single attribute.
+        """
+
+        @attr.s(frozen=base_frozen, slots=base_slots)
+        class Base(object):
+            a = attr.ib(converter=int if base_converter else None)
+
+        @attr.s(frozen=sub_frozen, slots=sub_slots)
+        class Sub(Base):
+            b = attr.ib(converter=int if sub_converter else None)
+
+        i = Sub("1", "2")
+
+        assert i.a == (1 if base_converter else "1")
+        assert i.b == (2 if sub_converter else "2")
+
+        if base_frozen or sub_frozen:
+            with pytest.raises(FrozenInstanceError):
+                i.a = "2"
+
+            with pytest.raises(FrozenInstanceError):
+                i.b = "3"

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -209,7 +209,7 @@ class TestTransformAttrs(object):
         Transforms every `_CountingAttr` and leaves others (a) be.
         """
         C = make_tc()
-        attrs, _, = _transform_attrs(C, None, False)
+        attrs, _, _ = _transform_attrs(C, None, False)
 
         assert ["z", "y", "x"] == [a.name for a in attrs]
 
@@ -221,14 +221,14 @@ class TestTransformAttrs(object):
         class C(object):
             pass
 
-        assert _Attributes(((), [])) == _transform_attrs(C, None, False)
+        assert _Attributes(((), [], {})) == _transform_attrs(C, None, False)
 
     def test_transforms_to_attribute(self):
         """
         All `_CountingAttr`s are transformed into `Attribute`s.
         """
         C = make_tc()
-        attrs, super_attrs = _transform_attrs(C, None, False)
+        attrs, super_attrs, _ = _transform_attrs(C, None, False)
 
         assert [] == super_attrs
         assert 3 == len(attrs)
@@ -263,7 +263,7 @@ class TestTransformAttrs(object):
         class C(Base):
             y = attr.ib()
 
-        attrs, super_attrs = _transform_attrs(C, {"x": attr.ib()}, False)
+        attrs, super_attrs, _ = _transform_attrs(C, {"x": attr.ib()}, False)
 
         assert [] == super_attrs
         assert (


### PR DESCRIPTION
Non-frozen:
```
> pyperf timeit -g --rigorous --duplicate 5 -s "import attr; C = attr.make_class('C', ['a', 'b', 'c'])" "C(1,2,3)"

Mean +- std dev: 721 ns +- 29 ns
```

Before:
```
> pyperf timeit -g --rigorous --duplicate 5 -s "import attr; C = attr.make_class('C', ['a', 'b', 'c'], frozen=True)" "C(1,2,3)"

Mean +- std dev: 1.29 us +- 0.05 us
```

After:
```
> pyperf timeit -g --rigorous --duplicate 5 -s "import attr; C = attr.make_class('C', ['a', 'b', 'c'], frozen=True)" "C(1,2,3)"

Mean +- std dev: 738 ns +- 27 ns
```

That's an overhead of 17 ns per ~720, or 2.2%. It used to be 80%. I'd call that a win.

What's happening is that instead of using the cached setattr, we're now assigning directly to `self.__dict__`. Unfortunately, this trick works only for dict classes.