### PR TITLE
attr.asdict(recurse=True) now can handle nested lists

### DIFF
--- a/changelog.d/345.change.rst
+++ b/changelog.d/345.change.rst
@@ -1,0 +1,1 @@
+``attr.asdict(recurse=True)`` now can handle nested lists

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -64,16 +64,21 @@ class TestAsDict(object):
         def assert_proper_dict_class(obj, obj_dict):
             assert isinstance(obj_dict, dict_class)
 
+            def assert_sequence_value(field_val, dict_val):
+                for item, item_dict in zip(field_val, dict_val):
+                    if has(item.__class__):
+                        assert_proper_dict_class(item, item_dict)
+                    if isinstance(item, Sequence):
+                        assert isinstance(item_dict, Sequence)
+                        assert_sequence_value(item, item_dict)
+
             for field in fields(obj.__class__):
                 field_val = getattr(obj, field.name)
                 if has(field_val.__class__):
                     # This field holds a class, recurse the assertions.
                     assert_proper_dict_class(field_val, obj_dict[field.name])
-                elif isinstance(field_val, Sequence):
-                    dict_val = obj_dict[field.name]
-                    for item, item_dict in zip(field_val, dict_val):
-                        if has(item.__class__):
-                            assert_proper_dict_class(item, item_dict)
+                elif isinstance(field_val, SEQUENCE_TYPES):
+                    assert_sequence_value(field_val, obj_dict[field.name])
                 elif isinstance(field_val, Mapping):
                     # This field holds a dictionary.
                     assert isinstance(obj_dict[field.name], dict_class)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -116,6 +116,12 @@ def _create_hyp_nested_strategy(simple_class_strategy):
         combined_attrs.append(attr.ib(default=default))
         return _create_hyp_class(combined_attrs)
 
+    def list_of_list_of_class(tup):
+        default = attr.Factory(lambda: [[tup[1]()]])
+        combined_attrs = list(tup[0])
+        combined_attrs.append(attr.ib(default=default))
+        return _create_hyp_class(combined_attrs)
+
     def tuple_of_class(tup):
         default = attr.Factory(lambda: (tup[1](),))
         combined_attrs = list(tup[0])
@@ -140,6 +146,7 @@ def _create_hyp_nested_strategy(simple_class_strategy):
 
     return st.one_of(attrs_and_classes.map(just_class),
                      attrs_and_classes.map(list_of_class),
+                     attrs_and_classes.map(list_of_list_of_class),
                      attrs_and_classes.map(tuple_of_class),
                      attrs_and_classes.map(dict_of_class),
                      attrs_and_classes.map(ordereddict_of_class))


### PR DESCRIPTION
Right now if field contains nested lists it will not properly encoded to dict:
```python
>>> @attr.s
... class Foo():
...     a = attr.ib()
...
>>> a = Foo(a=[[Foo(a=1)]])
>>> attr.asdict(a)
{'a': [[Foo(a=1)]]}
```

I added support for this case (only for lists and only for `asdict` function) and also updated testing strategy