### PR TITLE
Add attr.fields_dict()

### DIFF
--- a/changelog.d/290.change.rst
+++ b/changelog.d/290.change.rst
@@ -1,0 +1,1 @@
+Added ``attr.field_dict()`` to return an ``OrderedDict` of ``attrs`` attributes for a class, whose keys are the attribute names.

--- a/changelog.d/290.change.rst
+++ b/changelog.d/290.change.rst
@@ -1,1 +1,1 @@
-Added ``attr.field_dict()`` to return an ``OrderedDict` of ``attrs`` attributes for a class, whose keys are the attribute names.
+Added ``attr.field_dict()`` to return an ordered dictionary of ``attrs`` attributes for a class, whose keys are the attribute names.

--- a/changelog.d/349.change.rst
+++ b/changelog.d/349.change.rst
@@ -1,0 +1,1 @@
+Added ``attr.field_dict()`` to return an ``OrderedDict` of ``attrs`` attributes for a class, whose keys are the attribute names.

--- a/changelog.d/349.change.rst
+++ b/changelog.d/349.change.rst
@@ -1,1 +1,1 @@
-Added ``attr.field_dict()`` to return an ``OrderedDict` of ``attrs`` attributes for a class, whose keys are the attribute names.
+Added ``attr.field_dict()`` to return an ordered dictionary of ``attrs`` attributes for a class, whose keys are the attribute names.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -216,6 +216,23 @@ Helpers
       >>> attr.fields(C).y is attr.fields(C)[1]
       True
 
+.. autofunction:: attr.fields_dict
+
+   For example:
+
+   .. doctest::
+
+      >>> @attr.s
+      ... class C(object):
+      ...     x = attr.ib()
+      ...     y = attr.ib()
+      >>> attr.fields_dict(C)
+      {'x': Attribute(name='x', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, metadata=mappingproxy({}), type=None, converter=None), 'y': Attribute(name='y', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, metadata=mappingproxy({}), type=None, converter=None)}
+      >>> attr.fields_dict(C)['y']
+      Attribute(name='y', default=NOTHING, validator=None, repr=True, cmp=True, hash=None, init=True, metadata=mappingproxy({}), type=None, converter=None)
+      >>> attr.fields_dict(C)['y'] is attr.fields(C).y
+      True
+
 
 .. autofunction:: attr.has
 

--- a/src/attr/__init__.py
+++ b/src/attr/__init__.py
@@ -6,7 +6,8 @@ from . import converters, exceptions, filters, validators
 from ._config import get_run_validators, set_run_validators
 from ._funcs import asdict, assoc, astuple, evolve, has
 from ._make import (
-    NOTHING, Attribute, Factory, attrib, attrs, fields, make_class, validate
+    NOTHING, Attribute, Factory, attrib, attrs, fields, fields_dict,
+    make_class, validate
 )
 
 
@@ -43,6 +44,7 @@ __all__ = [
     "evolve",
     "exceptions",
     "fields",
+    "fields_dict",
     "filters",
     "get_run_validators",
     "has",

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1068,6 +1068,32 @@ def fields(cls):
     return attrs
 
 
+def fields_dict(cls):
+    """
+    Returns an OrderedDict of ``attrs`` attributes for a class, whose keys are
+    the attribute names.
+
+    :param type cls: Class to introspect.
+
+    :raise TypeError: If *cls* is not a class.
+    :raise attr.exceptions.NotAnAttrsClassError: If *cls* is not an ``attrs``
+        class.
+
+    :rtype: OrderedDict where keys are attribute names and values are
+        :class:`attr.Attribute`\ s.
+
+    .. versionadded:: 18.1.0
+    """
+    if not isclass(cls):
+        raise TypeError("Passed object must be a class.")
+    attrs = getattr(cls, "__attrs_attrs__", None)
+    if attrs is None:
+        raise NotAnAttrsClassError(
+            "{cls!r} is not an attrs-decorated class.".format(cls=cls)
+        )
+    return ordered_dict([(a.name, a) for a in attrs])
+
+
 def validate(inst):
     """
     Validate all attributes on *inst* that have a validator.

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1042,7 +1042,7 @@ def _add_init(cls, frozen):
 
 def fields(cls):
     """
-    Returns the tuple of ``attrs`` attributes for a class.
+    Return the tuple of ``attrs`` attributes for a class.
 
     The tuple also allows accessing the fields by their names (see below for
     examples).
@@ -1070,8 +1070,8 @@ def fields(cls):
 
 def fields_dict(cls):
     """
-    Returns an OrderedDict of ``attrs`` attributes for a class, whose keys are
-    the attribute names.
+    Return an ordered dictionary of ``attrs`` attributes for a class, whose
+    keys are the attribute names.
 
     :param type cls: Class to introspect.
 
@@ -1079,8 +1079,10 @@ def fields_dict(cls):
     :raise attr.exceptions.NotAnAttrsClassError: If *cls* is not an ``attrs``
         class.
 
-    :rtype: OrderedDict where keys are attribute names and values are
-        :class:`attr.Attribute`\ s.
+    :rtype: an ordered dict where keys are attribute names and values are
+        :class:`attr.Attribute`\ s. This will be a :class:`dict` if it's
+        naturally ordered like on Python 3.6+ or an
+        :class:`~collections.OrderedDict` otherwise.
 
     .. versionadded:: 18.1.0
     """
@@ -1091,7 +1093,7 @@ def fields_dict(cls):
         raise NotAnAttrsClassError(
             "{cls!r} is not an attrs-decorated class.".format(cls=cls)
         )
-    return ordered_dict([(a.name, a) for a in attrs])
+    return ordered_dict(((a.name, a) for a in attrs))
 
 
 def validate(inst):

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -22,7 +22,8 @@ from attr import _config
 from attr._compat import PY2, ordered_dict
 from attr._make import (
     Attribute, Factory, _AndValidator, _Attributes, _ClassBuilder,
-    _CountingAttr, _transform_attrs, and_, fields, make_class, validate
+    _CountingAttr, _transform_attrs, and_, fields, fields_dict, make_class,
+    validate
 )
 from attr.exceptions import DefaultAlreadySetError, NotAnAttrsClassError
 
@@ -674,6 +675,40 @@ class TestFields(object):
         """
         for attribute in fields(C):
             assert getattr(fields(C), attribute.name) is attribute
+
+
+class TestFieldsDict(object):
+    """
+    Tests for `fields_dict`.
+    """
+    def test_instance(self, C):
+        """
+        Raises `TypeError` on non-classes.
+        """
+        with pytest.raises(TypeError) as e:
+            fields_dict(C(1, 2))
+
+        assert "Passed object must be a class." == e.value.args[0]
+
+    def test_handler_non_attrs_class(self, C):
+        """
+        Raises `ValueError` if passed a non-``attrs`` instance.
+        """
+        with pytest.raises(NotAnAttrsClassError) as e:
+            fields_dict(object)
+        assert (
+            "{o!r} is not an attrs-decorated class.".format(o=object)
+        ) == e.value.args[0]
+
+    @given(simple_classes())
+    def test_fields_dict(self, C):
+        """
+        Returns an ordered dict of ``{attribute_name: Attribute}``.
+        """
+        d = fields_dict(C)
+        assert isinstance(d, ordered_dict)
+        assert list(fields(C)) == list(d.values())
+        assert [a.name for a in fields(C)] == [field_name for field_name in d]
 
 
 class TestConverter(object):

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -657,6 +657,7 @@ class TestFields(object):
         """
         with pytest.raises(NotAnAttrsClassError) as e:
             fields(object)
+
         assert (
             "{o!r} is not an attrs-decorated class.".format(o=object)
         ) == e.value.args[0]
@@ -696,6 +697,7 @@ class TestFieldsDict(object):
         """
         with pytest.raises(NotAnAttrsClassError) as e:
             fields_dict(object)
+
         assert (
             "{o!r} is not an attrs-decorated class.".format(o=object)
         ) == e.value.args[0]
@@ -706,6 +708,7 @@ class TestFieldsDict(object):
         Returns an ordered dict of ``{attribute_name: Attribute}``.
         """
         d = fields_dict(C)
+
         assert isinstance(d, ordered_dict)
         assert list(fields(C)) == list(d.values())
         assert [a.name for a in fields(C)] == [field_name for field_name in d]


### PR DESCRIPTION
This patch adds `attr.fields_dict()`, which returns an `OrderedDict` of `{attribute_name: Attribute}` for all attrs attributes of a class.

Closes #290.

I'm bad at describing dictionaries in prose, so feel free to improve. :)

 # Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](http://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/utils.py).
- [x] Updated **documentation** for changed code.
- [x] Documentation in `.rst` files is written using [semantic newlines](http://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!