### PR TITLE
Ignore build/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
-.tox
-.coverage*
 *.pyc
 *.egg-info
-docs/_build/
-htmlcov
-dist
 .cache
+.coverage*
 .hypothesis
 .pytest_cache
+.tox
+build
+dist
+docs/_build/
+htmlcov


### PR DESCRIPTION
This change ignores the `build/` directory, created by `python setup.py build`, with `git status`, etc.

While here, sort .gitignore entries.
