### PR TITLE
Fix warning from py3 regarding "improper regex escapes"

### DIFF
--- a/src/attr/filters.py
+++ b/src/attr/filters.py
@@ -23,7 +23,7 @@ def include(*what):
     Whitelist *what*.
 
     :param what: What to whitelist.
-    :type what: :class:`list` of :class:`type` or :class:`attr.Attribute`\ s
+    :type what: :class:`list` of :class:`type` or :class:`attr.Attribute`s.
 
     :rtype: :class:`callable`
     """
@@ -40,7 +40,7 @@ def exclude(*what):
     Blacklist *what*.
 
     :param what: What to blacklist.
-    :type what: :class:`list` of classes or :class:`attr.Attribute`\ s.
+    :type what: :class:`list` of classes or :class:`attr.Attribute`s.
 
     :rtype: :class:`callable`
     """


### PR DESCRIPTION
py3 emits warnings about strings which contain improper character escapes. This silences one of those warnings, while keeping the desired documentation output.
