### PR TITLE
"fits_byte" validator should allow 0

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -383,7 +383,7 @@ Of course you can mix and match the two approaches at your convenience:
    ...     x = attr.ib(validator=attr.validators.instance_of(int))
    ...     @x.validator
    ...     def fits_byte(self, attribute, value):
-   ...         if not 0 < value < 256:
+   ...         if not 0 <= value < 256:
    ...             raise ValueError("value out of bounds")
    >>> C(128)
    C(x=128)


### PR DESCRIPTION
bytes are in the range 0..255, not 1...255.

# Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](http://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/utils.py).
- [ ] Updated **documentation** for changed code.
- [x] Documentation in `.rst` files is written using [semantic newlines](http://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
