### PR TITLE
No recursion error for cycles in `repr`

### DIFF
--- a/changelog.d/95.change.rst
+++ b/changelog.d/95.change.rst
@@ -1,0 +1,1 @@
+``x=X(); x.cycle = x; repr(x)`` will no longer raise a ``RecursionError``, and will instead show as ``X(x=...)``.

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -995,19 +995,15 @@ def _make_repr(attrs, ns):
         # like weakref- or hash-ability.
         working_set.add(id(self))
         try:
-            result = class_name
-            result += "("
+            result = [class_name, "("]
             first = True
             for name in attr_names:
                 if first:
                     first = False
                 else:
-                    result += ", "
-                result += name
-                result += "="
-                result += repr(getattr(self, name, NOTHING))
-            result += ")"
-            return result
+                    result.append(", ")
+                result.extend((name, "=", repr(getattr(self, name, NOTHING))))
+            return "".join(result) + ")"
         finally:
             working_set.remove(id(self))
     return __repr__

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -995,13 +995,19 @@ def _make_repr(attrs, ns):
         # like weakref- or hash-ability.
         working_set.add(id(self))
         try:
-            return "{0}({1})".format(
-                class_name,
-                ", ".join(
-                    name + "=" + repr(getattr(self, name, NOTHING))
-                    for name in attr_names
-                )
-            )
+            result = class_name
+            result += "("
+            first = True
+            for name in attr_names:
+                if first:
+                    first = False
+                else:
+                    result += ", "
+                result += name
+                result += "="
+                result += repr(getattr(self, name, NOTHING))
+            result += ")"
+            return result
         finally:
             working_set.remove(id(self))
     return __repr__

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import, division, print_function
 import hashlib
 import linecache
 import sys
-import warnings
 import threading
+import warnings
 
 from operator import itemgetter
 
@@ -953,7 +953,9 @@ def _add_cmp(cls, attrs=None):
 
     return cls
 
+
 _already_repring = threading.local()
+
 
 def _make_repr(attrs, ns):
     """

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -187,6 +187,20 @@ class TestAddRepr(object):
         """
         assert "C(a=1, b=2)" == repr(cls(1, 2))
 
+    def test_infinite_recursion(self):
+        """
+        In the presence of a cyclic graph, repr will emit an ellipsis and not
+        raise an exception.
+        """
+        @attr.s
+        class Cycle(object):
+            value = attr.ib(default=7)
+            cycle = attr.ib(default=None)
+
+        cycle = Cycle()
+        cycle.cycle = cycle
+        assert "Cycle(value=7, cycle=...)" == repr(cycle)
+
     def test_underscores(self):
         """
         repr does not strip underscores.


### PR DESCRIPTION
Fixes #95.

> - [x] Added **tests** for changed code.

Done.

There are no tests for the multithreaded case because it's literally impossible to test that, you just have to think really hard.  I could try harder if the reviewer thinks that this implementation strategy is risky but it seems pretty boring; just using threading.local to avoid sharing state between threads.

> - [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/utils.py).

I don't *think* I need to do this here because I don't see anything relevant, but, I am not a Hypothesis expert so I might be missing something.

> - [ ] Updated **documentation** for changed code.

It's a bugfix, so I don't think it calls for updated docs.

- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

Done.