### PR TITLE
Annotate __init__ with type hints

### DIFF
--- a/changelog.d/363.change.rst
+++ b/changelog.d/363.change.rst
@@ -1,1 +1,1 @@
-Generated `__init__` methods now have an `__annotations__` attribute derived from the types of the fields.
+Generated ``__init__`` methods now have an ``__annotations__`` attribute derived from the types of the fields.

--- a/changelog.d/363.change.rst
+++ b/changelog.d/363.change.rst
@@ -1,0 +1,1 @@
+Generated `__init__` methods now have an `__annotations__` attribute derived from the types of the fields.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -519,6 +519,7 @@ If you don't mind annotating *all* attributes, you can even drop the :func:`attr
    >>> AutoC.cls_var
    5
 
+The generated ``__init__`` method will have an attribute called ``__annotations__`` that contains this type information.
 
 .. warning::
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1261,7 +1261,7 @@ def _attrs_to_init_script(attrs, frozen, slots, post_init, super_attr_map):
     # This is a dictionary of names to validator and converter callables.
     # Injecting this into __init__ globals lets us avoid lookups.
     names_for_globals = {}
-    annotations = {}
+    annotations = {'return': None}
 
     for a in attrs:
         if a.validator:

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1034,7 +1034,7 @@ def _make_init(attrs, post_init, frozen, slots, super_attr_map):
         sha1.hexdigest()
     )
 
-    script, globs = _attrs_to_init_script(
+    script, globs, annotations = _attrs_to_init_script(
         attrs,
         frozen,
         slots,
@@ -1063,7 +1063,9 @@ def _make_init(attrs, post_init, frozen, slots, super_attr_map):
         unique_filename,
     )
 
-    return locs["__init__"]
+    __init__ = locs["__init__"]
+    __init__.__annotations__ = annotations
+    return __init__
 
 
 def _add_init(cls, frozen):
@@ -1259,6 +1261,7 @@ def _attrs_to_init_script(attrs, frozen, slots, post_init, super_attr_map):
     # This is a dictionary of names to validator and converter callables.
     # Injecting this into __init__ globals lets us avoid lookups.
     names_for_globals = {}
+    annotations = {}
 
     for a in attrs:
         if a.validator:
@@ -1349,6 +1352,9 @@ def _attrs_to_init_script(attrs, frozen, slots, post_init, super_attr_map):
             else:
                 lines.append(fmt_setter(attr_name, arg_name))
 
+        if a.init is True and a.converter is None and a.type is not None:
+            annotations[arg_name] = a.type
+
     if attrs_to_validate:  # we can skip this if there are no validators.
         names_for_globals["_config"] = _config
         lines.append("if _config._run_validators is True:")
@@ -1368,7 +1374,7 @@ def __init__(self, {args}):
 """.format(
         args=", ".join(args),
         lines="\n    ".join(lines) if lines else "pass",
-    ), names_for_globals
+    ), names_for_globals, annotations
 
 
 class Attribute(object):

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -32,7 +32,11 @@ class TestAnnotations:
         assert int is attr.fields(C).x.type
         assert str is attr.fields(C).y.type
         assert None is attr.fields(C).z.type
-        assert C.__init__.__annotations__ == {'x': int, 'y': str}
+        assert C.__init__.__annotations__ == {
+            'x': int,
+            'y': str,
+            'return': None,
+        }
 
     def test_catches_basic_type_conflict(self):
         """
@@ -60,7 +64,8 @@ class TestAnnotations:
         assert typing.Optional[str] is attr.fields(C).y.type
         assert C.__init__.__annotations__ == {
             'x': typing.List[int],
-            'y': typing.Union[str, type(None)]
+            'y': typing.Optional[str],
+            'return': None,
         }
 
     def test_only_attrs_annotations_collected(self):
@@ -73,7 +78,10 @@ class TestAnnotations:
             y: int
 
         assert 1 == len(attr.fields(C))
-        assert C.__init__.__annotations__ == {'x': typing.List[int]}
+        assert C.__init__.__annotations__ == {
+            'x': typing.List[int],
+            'return': None,
+        }
 
     @pytest.mark.parametrize("slots", [True, False])
     def test_auto_attribs(self, slots):
@@ -126,7 +134,8 @@ class TestAnnotations:
             'x': typing.List[int],
             'y': int,
             'z': int,
-            'foo': typing.Any
+            'foo': typing.Any,
+            'return': None,
         }
 
     @pytest.mark.parametrize("slots", [True, False])
@@ -171,11 +180,48 @@ class TestAnnotations:
 
         assert A.__init__.__annotations__ == {
             'a': int,
+            'return': None,
         }
         assert B.__init__.__annotations__ == {
             'a': int,
             'b': int,
+            'return': None,
         }
         assert C.__init__.__annotations__ == {
             'a': int,
+            'return': None,
+        }
+
+    def test_converter_annotations(self):
+        """
+        Attributes with converters don't have annotations.
+        """
+
+        @attr.s(auto_attribs=True)
+        class A:
+            a: int = attr.ib(converter=int)
+
+        assert A.__init__.__annotations__ == {'return': None}
+
+    @pytest.mark.parametrize("slots", [True, False])
+    def test_annotations_strings(self, slots):
+        """
+        String annotations are passed into __init__ as is.
+        """
+        @attr.s(auto_attribs=True, slots=slots)
+        class C:
+            cls_var: 'typing.ClassVar[int]' = 23
+            a: 'int'
+            x: 'typing.List[int]' = attr.Factory(list)
+            y: 'int' = 2
+            z: 'int' = attr.ib(default=3)
+            foo: 'typing.Any' = None
+
+        assert C.__init__.__annotations__ == {
+            'a': 'int',
+            'x': 'typing.List[int]',
+            'y': 'int',
+            'z': 'int',
+            'foo': 'typing.Any',
+            'return': None,
         }

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -32,6 +32,7 @@ class TestAnnotations:
         assert int is attr.fields(C).x.type
         assert str is attr.fields(C).y.type
         assert None is attr.fields(C).z.type
+        assert C.__init__.__annotations__ == {'x': int, 'y': str}
 
     def test_catches_basic_type_conflict(self):
         """
@@ -57,6 +58,10 @@ class TestAnnotations:
 
         assert typing.List[int] is attr.fields(C).x.type
         assert typing.Optional[str] is attr.fields(C).y.type
+        assert C.__init__.__annotations__ == {
+            'x': typing.List[int],
+            'y': typing.Union[str, type(None)]
+        }
 
     def test_only_attrs_annotations_collected(self):
         """
@@ -68,6 +73,7 @@ class TestAnnotations:
             y: int
 
         assert 1 == len(attr.fields(C))
+        assert C.__init__.__annotations__ == {'x': typing.List[int]}
 
     @pytest.mark.parametrize("slots", [True, False])
     def test_auto_attribs(self, slots):
@@ -115,6 +121,14 @@ class TestAnnotations:
             i.y = 23
             assert 23 == i.y
 
+        assert C.__init__.__annotations__ == {
+            'a': int,
+            'x': typing.List[int],
+            'y': int,
+            'z': int,
+            'foo': typing.Any
+        }
+
     @pytest.mark.parametrize("slots", [True, False])
     def test_auto_attribs_unannotated(self, slots):
         """
@@ -154,3 +168,14 @@ class TestAnnotations:
 
         assert "B(a=1, b=2)" == repr(B())
         assert "C(a=1)" == repr(C())
+
+        assert A.__init__.__annotations__ == {
+            'a': int,
+        }
+        assert B.__init__.__annotations__ == {
+            'a': int,
+            'b': int,
+        }
+        assert C.__init__.__annotations__ == {
+            'a': int,
+        }


### PR DESCRIPTION
This just adds the annotations found at run-time to the
`__annotations__` attribute of the created `__init__` function

Fixes #249

# Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](http://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/utils.py).
- [x] Updated **documentation** for changed code.
- [x] Documentation in `.rst` files is written using [semantic newlines](http://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
