### PR TITLE
Use `\\` instead of a single `\` in docstrings

### DIFF
--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -106,7 +106,7 @@ def attrib(default=NOTHING, validator=None,
 
         The validator can also be set using decorator notation as shown below.
 
-    :type validator: ``callable`` or a ``list`` of ``callable``\ s.
+    :type validator: ``callable`` or a ``list`` of ``callable``\\ s.
 
     :param bool repr: Include this attribute in the generated ``__repr__``
         method.
@@ -1125,7 +1125,7 @@ def fields_dict(cls):
         class.
 
     :rtype: an ordered dict where keys are attribute names and values are
-        :class:`attr.Attribute`\ s. This will be a :class:`dict` if it's
+        :class:`attr.Attribute`\\ s. This will be a :class:`dict` if it's
         naturally ordered like on Python 3.6+ or an
         :class:`~collections.OrderedDict` otherwise.
 

--- a/src/attr/filters.py
+++ b/src/attr/filters.py
@@ -23,7 +23,7 @@ def include(*what):
     Whitelist *what*.
 
     :param what: What to whitelist.
-    :type what: :class:`list` of :class:`type` or :class:`attr.Attribute`\ s
+    :type what: :class:`list` of :class:`type` or :class:`attr.Attribute`\\ s
 
     :rtype: :class:`callable`
     """
@@ -40,7 +40,7 @@ def exclude(*what):
     Blacklist *what*.
 
     :param what: What to blacklist.
-    :type what: :class:`list` of classes or :class:`attr.Attribute`\ s.
+    :type what: :class:`list` of classes or :class:`attr.Attribute`\\ s.
 
     :rtype: :class:`callable`
     """

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,9 @@ commands = coverage run --parallel -m pytest {posargs}
 
 
 [testenv:py36]
+install_command = pip install --no-compile {opts} {packages}
+setenv =
+    PYTHONWARNINGS=d
 extras = tests
 commands = coverage run --parallel -m pytest {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,8 @@ commands = coverage run --parallel -m pytest {posargs}
 
 
 [testenv:py36]
+# Python 3.6+ has a number of compile-time warnings on invalid string escapes.
+# PYTHONWARNINGS=d and --no-compile below make them visible during the Tox run.
 install_command = pip install --no-compile {opts} {packages}
 setenv =
     PYTHONWARNINGS=d


### PR DESCRIPTION
The latter is not an invalid escape and Python 3.6+ complains about it.  I also
updated tox.ini so that those warnings are visible in the future.

Fixes #351