### PR TITLE
Improve error for in_(a_string) with a non-string value

### DIFF
--- a/changelog.d/383.change.rst
+++ b/changelog.d/383.change.rst
@@ -1,2 +1,2 @@
 ``attr.validators.in_()`` now raises a ``ValueError`` with a useful message even if the options are a string and the value is not a string.
-Previously, this raised a ``TypeError`` (matching e.g. ``1 in "abc"``).
+This previously raised a ``TypeError``, like ``1 in "abc"``.

--- a/changelog.d/383.change.rst
+++ b/changelog.d/383.change.rst
@@ -1,3 +1,2 @@
-``in_()`` validators now raise a ValueError with a useful message
-even if the options are a string and the value is not a string.
-By contrast, e.g. ``1 in "abc"`` raises an unhelpful TypeError.
+``attr.validators.in_()`` now raises a ``ValueError`` with a useful message even if the options are a string and the value is not a string.
+Previously, this raised a ``TypeError`` (matching e.g. ``1 in "abc"``).

--- a/changelog.d/383.change.rst
+++ b/changelog.d/383.change.rst
@@ -1,0 +1,3 @@
+``in_()`` validators now raise a ValueError with a useful message
+even if the options are a string and the value is not a string.
+By contrast, e.g. ``1 in "abc"`` raises an unhelpful TypeError.

--- a/src/attr/validators.py
+++ b/src/attr/validators.py
@@ -137,7 +137,7 @@ class _InValidator(object):
     def __call__(self, inst, attr, value):
         try:
             in_options = value in self.options
-        except Exception as e:  # e.g. `1 in "abc"`
+        except TypeError as e:  # e.g. `1 in "abc"`
             in_options = False
 
         if not in_options:

--- a/src/attr/validators.py
+++ b/src/attr/validators.py
@@ -135,7 +135,12 @@ class _InValidator(object):
     options = attrib()
 
     def __call__(self, inst, attr, value):
-        if value not in self.options:
+        try:
+            in_options = value in self.options
+        except Exception as e:  # e.g. `1 in "abc"`
+            in_options = False
+
+        if not in_options:
             raise ValueError(
                 "'{name}' must be in {options!r} (got {value!r})"
                 .format(name=attr.name, options=self.options, value=value)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -243,6 +243,18 @@ class TestIn_(object):
             "'test' must be in [1, 2, 3] (got None)",
         ) == e.value.args
 
+    def test_fail_with_string(self):
+        """
+        Same error for string options as for list options, not TypeError.
+        """
+        v = in_("abc")
+        a = simple_attr("test")
+        with pytest.raises(ValueError) as e:
+            v(None, a, None)
+        assert (
+            "'test' must be in 'abc' (got None)",
+        ) == e.value.args
+
     def test_repr(self):
         """
         Returned validator has a useful `__repr__`.

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -245,7 +245,8 @@ class TestIn_(object):
 
     def test_fail_with_string(self):
         """
-        Same error for string options as for list options, not TypeError.
+        Raise ValueError if the value is outside our options when the
+        options are specified as a string and the value is not a string.
         """
         v = in_("abc")
         a = simple_attr("test")


### PR DESCRIPTION
- [x] Added **tests** for changed code.
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).
- [x] Is my first attrs PR :heart_eyes:

Closes #382.