### PR TITLE
warn when combining types as converter and None as default -  #385

### DIFF
--- a/changelog.d/385.change.rst
+++ b/changelog.d/385.change.rst
@@ -1,0 +1,1 @@
+Emmit a warning when a plain type as converter is combined with None as default as one typically wants a None-aware converter or a factory in that case

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -146,6 +146,8 @@ def attrib(default=NOTHING, validator=None,
        *convert* to achieve consistency with other noun-based arguments.
     .. versionadded:: 18.1.0
        ``factory=f`` is syntactic sugar for ``default=attr.Factory(f)``.
+    .. versionchanged:: 18.2.0
+        warn when **converter** is a plain type and default is None
     """
     if hash is not None and hash is not True and hash is not False:
         raise TypeError(
@@ -164,6 +166,13 @@ def attrib(default=NOTHING, validator=None,
             DeprecationWarning, stacklevel=2
         )
         converter = convert
+
+    if default is None and isclass(converter):
+        warnings.warn(
+            "The `converter` is a plain type "
+            "which is usually not compatible with a `default` of none. "
+            "Please consider using a factory or attr.converters.optional",
+            UserWarning, stacklevel=2)
 
     if factory is not None:
         if default is not NOTHING:

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 
 import pytest
 
+from attr import attrib
 from attr.converters import optional
 
 
@@ -34,3 +35,12 @@ class TestOptional(object):
         c = optional(int)
         with pytest.raises(ValueError):
             c("not_an_int")
+
+
+class TestOptionalWarningWarning(object):
+
+    def test_warn_type_optional(self):
+        with pytest.warns(Warning) as record:
+            attrib(default=None, converter=int)
+        msg = list(record)[0]
+        assert "consider using " in str(msg)


### PR DESCRIPTION
# Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](http://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

- [x] Added **tests** for changed code.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/strategies.py).
- [x] Updated **documentation** for changed code.
- [x] Documentation in `.rst` files is written using [semantic newlines](http://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
