### PR TITLE
Disable hypothesis.HealthCheck.too_slow globally

### DIFF
--- a/changelog.d/364.change.rst
+++ b/changelog.d/364.change.rst
@@ -1,0 +1,1 @@
+The test suite now runs with ``hypothesis.HealthCheck.too_slow`` disabled to prevent CI breakage on slower computers.

--- a/changelog.d/396.change.rst
+++ b/changelog.d/396.change.rst
@@ -1,0 +1,1 @@
+The test suite now runs with ``hypothesis.HealthCheck.too_slow`` disabled to prevent CI breakage on slower computers.

--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,16 @@ import sys
 
 import pytest
 
+from hypothesis import HealthCheck, settings
+
+
+def pytest_configure(config):
+    # HealthCheck.too_slow causes more trouble than good -- especially in CIs.
+    settings.register_profile(
+        "patience", settings(suppress_health_check=[HealthCheck.too_slow])
+    )
+    settings.load_profile("patience")
+
 
 @pytest.fixture(scope="session")
 def C():

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -8,7 +8,7 @@ from collections import Mapping, OrderedDict, Sequence
 
 import pytest
 
-from hypothesis import HealthCheck, assume, given, settings
+from hypothesis import assume, given
 from hypothesis import strategies as st
 
 import attr
@@ -67,7 +67,6 @@ class TestAsDict(object):
         assert {"x": {1: {2: {"x": 1, "y": 2}}}, "y": None} == asdict(outer)
 
     @given(nested_classes, st.sampled_from(MAPPING_TYPES))
-    @settings(suppress_health_check=[HealthCheck.too_slow])
     def test_recurse_property(self, cls, dict_class):
         """
         Property tests for recursive asdict.
@@ -196,7 +195,6 @@ class TestAsTuple(object):
         ) == astuple(C(C(1, 2), C(3, 4)), tuple_factory=tuple_factory)
 
     @given(nested_classes, st.sampled_from(SEQUENCE_TYPES))
-    @settings(suppress_health_check=[HealthCheck.too_slow])
     def test_recurse_property(self, cls, tuple_class):
         """
         Property tests for recursive astuple.
@@ -215,7 +213,6 @@ class TestAsTuple(object):
         assert_proper_tuple_class(obj, obj_tuple)
 
     @given(nested_classes, st.sampled_from(SEQUENCE_TYPES))
-    @settings(suppress_health_check=[HealthCheck.too_slow])
     def test_recurse_retain(self, cls, tuple_class):
         """
         Property tests for asserting collection types are retained.


### PR DESCRIPTION
We can always enable it when something seems off. As it stands now, it only makes our tests brittle.

Fixes #364 