### PR TITLE
 Auto-detect user-written methods

### DIFF
--- a/changelog.d/324.change.rst
+++ b/changelog.d/324.change.rst
@@ -1,0 +1,1 @@
+``attr.s`` now auto-detects user-written methods and does not overwrite them. # is missing the __hash__ == None if it shouldn't be hashable

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -556,29 +556,27 @@ class _ClassBuilder(object):
 
     def add_repr(self, ns):
         if "__repr__" in self._cls.__dict__:
-            meth = getattr(self._cls, "__repr__")
-        else:
-            meth = self._add_method_dunders(_make_repr(self._attrs, ns=ns))
+            return self
 
-        self._cls_dict["__repr__"] = meth
+        self._cls_dict["__repr__"] = self._add_method_dunders(
+            _make_repr(self._attrs, ns=ns)
+        )
         return self
 
     def add_str(self):
         if "__str__" in self._cls.__dict__:
-            meth = getattr(self._cls, "__str__")
-        else:
-            repr = self._cls_dict.get("__repr__")
-            if repr is None:
-                raise ValueError(
-                    "__str__ can only be generated if a __repr__ exists."
-                )
+            return self
 
-            def __str__(self):
-                return self.__repr__()
+        repr = self._cls_dict.get("__repr__")
+        if repr is None:
+            raise ValueError(
+                "__str__ can only be generated if a __repr__ exists."
+            )
 
-            meth = self._add_method_dunders(__str__)
+        def __str__(self):
+            return self.__repr__()
 
-        self._cls_dict["__str__"] = meth
+        self._cls_dict["__str__"] = self._add_method_dunders(__str__)
         return self
 
     def make_unhashable(self):
@@ -587,28 +585,27 @@ class _ClassBuilder(object):
 
     def add_hash(self):
         if "__hash__" in self._cls.__dict__:
-            meth = getattr(self._cls, "__hash__")
-        else:
-            meth = self._add_method_dunders(_make_hash(self._attrs))
+            return self
 
-        self._cls_dict["__hash__"] = meth
+        self._cls_dict["__hash__"] = self._add_method_dunders(
+            _make_hash(self._attrs)
+        )
         return self
 
     def add_init(self):
         if "__init__" in self._cls.__dict__:
-            meth = getattr(self._cls, "__init__")
-        else:
-            meth = self._add_method_dunders(
-                _make_init(
-                    self._attrs,
-                    self._has_post_init,
-                    self._frozen,
-                    self._slots,
-                    self._super_attr_map,
-                )
-            )
+            return self
 
-        self._cls_dict["__init__"] = meth
+        self._cls_dict["__init__"] = self._add_method_dunders(
+            _make_init(
+                self._attrs,
+                self._has_post_init,
+                self._frozen,
+                self._slots,
+                self._super_attr_map,
+            )
+        )
+
         return self
 
     def add_cmp(self):
@@ -618,11 +615,9 @@ class _ClassBuilder(object):
             method_name = meth.__name__
 
             if method_name in self._cls.__dict__:
-                meth = getattr(self._cls, method_name)
-            else:
-                meth = self._add_method_dunders(meth)
+                continue
 
-            cd[method_name] = meth
+            cd[method_name] = self._add_method_dunders(meth)
 
         return self
 

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -1307,7 +1307,7 @@ class TestClassBuilder(object):
         # doesn't work
         sentinel = getattr(C, method_name)
 
-        C = attr.s(C, hash=True, str=True)
+        C = attr.s(C, hash=True, str=(method_name == "__str__"))
 
         assert sentinel == getattr(C, method_name)
 

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -422,21 +422,21 @@ class TestAttributes(object):
         If no further arguments are supplied, all add_XXX functions except
         add_hash are applied.  __hash__ is set to None.
         """
-        # Set the method name to a sentinel and check whether it has been
-        # overwritten afterwards.
-        sentinel = object()
 
         class C(object):
             x = attr.ib()
 
-        setattr(C, method_name, sentinel)
+        # Assert that the method does not exist yet.
+        assert method_name not in C.__dict__
 
         C = attr.s(C)
-        meth = getattr(C, method_name)
 
-        assert sentinel != meth
+        method = getattr(C, method_name)
+
         if method_name == "__hash__":
-            assert meth is None
+            assert method is None
+        else:
+            assert method is not None
 
     @pytest.mark.parametrize(
         "arg_name, method_name",
@@ -1269,6 +1269,65 @@ class TestClassBuilder(object):
         gc.collect()
 
         assert [C2] == C.__subclasses__()
+
+    @pytest.mark.parametrize(
+        "method_name",
+        [
+            "__init__",
+            "__hash__",
+            "__repr__",
+            "__str__",
+            "__eq__",
+            "__ne__",
+            "__lt__",
+            "__le__",
+            "__gt__",
+            "__ge__",
+        ],
+    )
+    def test_respect_user_defined_methods(self, method_name):
+        """
+          Does not replace methods provided by the original class.
+        """
+
+        # Set the method name to a sentinel and check that it has not been
+        # overwritten afterwards.
+        def sentinel():
+            pass
+
+        # add_cmp relies on __name__.
+        sentinel.__name__ = method_name
+
+        class C(object):
+            x = attr.ib()
+
+        setattr(C, method_name, sentinel)
+
+        # set sentinel to unbound method of C otherwise assertion for py27
+        # doesn't work
+        sentinel = getattr(C, method_name)
+
+        C = attr.s(C, hash=True, str=True)
+
+        assert sentinel == getattr(C, method_name)
+
+    def test_ignores_user_defined_hash_method(self):
+        """
+          if it should be unhashable, the '__hash__' method is replaced.
+        """
+
+        # Set the method name to a sentinel and check that it has not been
+        # overwritten afterwards.
+        sentinel = object()
+
+        class C(object):
+            x = attr.ib()
+
+        setattr(C, "__hash__", sentinel)
+
+        C = attr.s(C)
+
+        assert getattr(C, "__hash__") is None
 
 
 class TestMakeCmp:


### PR DESCRIPTION
Hey,

I was browsing through the open issues searching for something I could take a stab at implementing.
I came across #324 and thought i would like to try that.

As a a set of 'specifications' i took last comment form @hynek on that issue:

>The more I think about it the more I think we should just skip methods that have been defined and be done with it. That allows people to customize their classes even better. 

I thought about putting that logic into the `attrs` method, however I wouldn't have fine enough control over all methods added by `add_cmp` so decided to move that logic into the `ClassBuilder`.

I can imagine people are used to `attrs` overwriting methods by default even if they are defined, thus I would suggest a feature switch (which I haven't implemented yet.).

The tests gave me a bit of trouble, especially when running against Python2.7, since it seems like `unbound` and `bound` methods are not eq (please correct me if i misunderstood this).

Furthermore if the Class should be `unhashable` any user written method is still ignored. However the argument, "A `__hash__` method has been supplied, thus the class should be considered hashable" also makes sense to me. 

This PR is still very much work in progress, before I spend more time on this, I would greatly appreciated some feedback.


Cheers, 

Philipp


# Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](http://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

- [X] Added **tests** for changed code.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/strategies.py).
- [ ] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
- [ ] Updated **documentation** for changed code.
- [ ] Documentation in `.rst` files is written using [semantic newlines](http://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).