### PR TITLE
Use an overload to get better type checking on default_if_none

### DIFF
--- a/src/attr/converters.pyi
+++ b/src/attr/converters.pyi
@@ -1,4 +1,4 @@
-from typing import TypeVar, Optional, Callable
+from typing import TypeVar, Optional, Callable, overload
 from . import _ConverterType
 
 _T = TypeVar("_T")
@@ -6,6 +6,7 @@ _T = TypeVar("_T")
 def optional(
     converter: _ConverterType[_T]
 ) -> _ConverterType[Optional[_T]]: ...
-def default_if_none(
-    default: _T = ..., factory: Callable[[], _T] = ...
-) -> _ConverterType[_T]: ...
+@overload
+def default_if_none(default: _T) -> _ConverterType[_T]: ...
+@overload
+def default_if_none(*, factory: Callable[[], _T]) -> _ConverterType[_T]: ...


### PR DESCRIPTION
While working on adding this to the mypy plugin I came up with this annotation which helps capture errors better.  I don't think the change merits a changelog entry.

# Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](http://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

- [ ] Added **tests** for changed code.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/strategies.py).
- [ ] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
- [ ] Updated **documentation** for changed code.
- [ ] Documentation in `.rst` files is written using [semantic newlines](http://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
