### PR TITLE
Consistently use "base class" and "subclass"

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,4 +8,4 @@ The development is kindly supported by `Variomedia AG <https://www.variomedia.de
 A full list of contributors can be found in `GitHub's overview <https://github.com/python-attrs/attrs/graphs/contributors>`_.
 
 It’s the spiritual successor of `characteristic <https://characteristic.readthedocs.io/>`_ and aspires to fix some of it clunkiness and unfortunate decisions.
-Both were inspired by Twisted’s `FancyEqMixin <https://twistedmatrix.com/documents/current/api/twisted.python.util.FancyEqMixin.html>`_ but both are implemented using class decorators because `sub-classing is bad for you <https://www.youtube.com/watch?v=3MNVP9-hglc>`_, m’kay?
+Both were inspired by Twisted’s `FancyEqMixin <https://twistedmatrix.com/documents/current/api/twisted.python.util.FancyEqMixin.html>`_ but both are implemented using class decorators because `subclassing is bad for you <https://www.youtube.com/watch?v=3MNVP9-hglc>`_, m’kay?

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -192,7 +192,7 @@ Changes
   (`#198 <https://github.com/python-attrs/attrs/issues/198>`_)
 - ``attr.Factory`` is hashable again.
   (`#204 <https://github.com/python-attrs/attrs/issues/204>`_)
-- Subclasses now can overwrite attribute definitions of their superclass.
+- Subclasses now can overwrite attribute definitions of their base classes.
 
   That means that you can -- for example -- change the default value for an attribute by redefining it.
   (`#221 <https://github.com/python-attrs/attrs/issues/221>`_, `#229 <https://github.com/python-attrs/attrs/issues/229>`_)

--- a/changelog.d/431.change.rst
+++ b/changelog.d/431.change.rst
@@ -1,1 +1,1 @@
-It is now possible to override a superclass' class variable using only class annotations.
+It is now possible to override a base class' class variable using only class annotations.

--- a/docs/how-does-it-work.rst
+++ b/docs/how-does-it-work.rst
@@ -13,7 +13,7 @@ But its **declarative** approach combined with **no runtime overhead** lets it s
 Once you apply the ``@attr.s`` decorator to a class, ``attrs`` searches the class object for instances of ``attr.ib``\ s.
 Internally they're a representation of the data passed into ``attr.ib`` along with a counter to preserve the order of the attributes.
 
-In order to ensure that sub-classing works as you'd expect it to work, ``attrs`` also walks the class hierarchy and collects the attributes of all super-classes.
+In order to ensure that subclassing works as you'd expect it to work, ``attrs`` also walks the class hierarchy and collects the attributes of all base classes.
 Please note that ``attrs`` does *not* call ``super()`` *ever*.
 It will write dunder methods to work on *all* of those attributes which also has performance benefits due to fewer function calls.
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -165,7 +165,7 @@ class TestAnnotations:
     @pytest.mark.parametrize("slots", [True, False])
     def test_auto_attribs_subclassing(self, slots):
         """
-        Attributes from superclasses are inherited, it doesn't matter if the
+        Attributes from base classes are inherited, it doesn't matter if the
         subclass has annotations or not.
 
         Ref #291
@@ -251,9 +251,9 @@ class TestAnnotations:
         assert c.x == 0
         assert c.y == 1
 
-    def test_super_class_variable(self):
+    def test_base_class_variable(self):
         """
-        Superclass class variables can be overridden with an attribute
+        Base class' class variables can be overridden with an attribute
         without resorting to using an explicit `attr.ib()`.
         """
 

--- a/tests/test_dark_magic.py
+++ b/tests/test_dark_magic.py
@@ -47,7 +47,7 @@ class C2Slots(object):
 
 
 @attr.s
-class Super(object):
+class Base(object):
     x = attr.ib()
 
     def meth(self):
@@ -55,7 +55,7 @@ class Super(object):
 
 
 @attr.s(slots=True)
-class SuperSlots(object):
+class BaseSlots(object):
     x = attr.ib()
 
     def meth(self):
@@ -63,12 +63,12 @@ class SuperSlots(object):
 
 
 @attr.s
-class Sub(Super):
+class Sub(Base):
     y = attr.ib()
 
 
 @attr.s(slots=True)
-class SubSlots(SuperSlots):
+class SubSlots(BaseSlots):
     y = attr.ib()
 
 
@@ -203,7 +203,7 @@ class TestDarkMagic(object):
     @pytest.mark.parametrize("cls", [Sub, SubSlots])
     def test_subclassing_with_extra_attrs(self, cls):
         """
-        Sub-classing (where the subclass has extra attrs) does what you'd hope
+        Subclassing (where the subclass has extra attrs) does what you'd hope
         for.
         """
         obj = object()
@@ -215,10 +215,10 @@ class TestDarkMagic(object):
         else:
             assert "SubSlots(x={obj}, y=2)".format(obj=obj) == repr(i)
 
-    @pytest.mark.parametrize("base", [Super, SuperSlots])
+    @pytest.mark.parametrize("base", [Base, BaseSlots])
     def test_subclass_without_extra_attrs(self, base):
         """
-        Sub-classing (where the subclass does not have extra attrs) still
+        Subclassing (where the subclass does not have extra attrs) still
         behaves the same as a subclass with extra attrs.
         """
 
@@ -259,8 +259,8 @@ class TestDarkMagic(object):
             C1Slots,
             C2,
             C2Slots,
-            Super,
-            SuperSlots,
+            Base,
+            BaseSlots,
             Sub,
             SubSlots,
             Frozen,
@@ -283,8 +283,8 @@ class TestDarkMagic(object):
             C1Slots,
             C2,
             C2Slots,
-            Super,
-            SuperSlots,
+            Base,
+            BaseSlots,
             Sub,
             SubSlots,
             Frozen,
@@ -342,11 +342,11 @@ class TestDarkMagic(object):
     @pytest.mark.parametrize("weakref_slot", [True, False])
     def test_attrib_overwrite(self, slots, frozen, weakref_slot):
         """
-        Subclasses can overwrite attributes of their superclass.
+        Subclasses can overwrite attributes of their base class.
         """
 
         @attr.s(slots=slots, frozen=frozen, weakref_slot=weakref_slot)
-        class SubOverwrite(Super):
+        class SubOverwrite(Base):
             x = attr.ib(default=attr.Factory(list))
 
         assert SubOverwrite([]) == SubOverwrite()
@@ -419,9 +419,9 @@ class TestDarkMagic(object):
 
         assert hash(C()) != hash(C())
 
-    def test_overwrite_super(self):
+    def test_overwrite_base(self):
         """
-        Superclasses can overwrite each other and the attributes are added
+        Base classes can overwrite each other and the attributes are added
         in the order they are defined.
         """
 

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -264,9 +264,9 @@ class TestTransformAttrs(object):
         All `_CountingAttr`s are transformed into `Attribute`s.
         """
         C = make_tc()
-        attrs, super_attrs, _ = _transform_attrs(C, None, False, False)
+        attrs, base_attrs, _ = _transform_attrs(C, None, False, False)
 
-        assert [] == super_attrs
+        assert [] == base_attrs
         assert 3 == len(attrs)
         assert all(isinstance(a, Attribute) for a in attrs)
 
@@ -292,11 +292,11 @@ class TestTransformAttrs(object):
 
     def test_kw_only(self):
         """
-        Converts all attributes, including superclass attributes, if `kw_only`
+        Converts all attributes, including base class' attributes, if `kw_only`
         is provided. Therefore, `kw_only` allows attributes with defaults to
         preceed mandatory attributes.
 
-        Updates in the subclass *don't* affect the superclass attributes.
+        Updates in the subclass *don't* affect the base class attributes.
         """
 
         @attr.s
@@ -310,10 +310,10 @@ class TestTransformAttrs(object):
             x = attr.ib(default=None)
             y = attr.ib()
 
-        attrs, super_attrs, _ = _transform_attrs(C, None, False, True)
+        attrs, base_attrs, _ = _transform_attrs(C, None, False, True)
 
         assert len(attrs) == 3
-        assert len(super_attrs) == 1
+        assert len(base_attrs) == 1
 
         for a in attrs:
             assert a.kw_only is True
@@ -323,7 +323,7 @@ class TestTransformAttrs(object):
 
     def test_these(self):
         """
-        If these is passed, use it and ignore body and superclasses.
+        If these is passed, use it and ignore body and base classes.
         """
 
         class Base(object):
@@ -332,11 +332,11 @@ class TestTransformAttrs(object):
         class C(Base):
             y = attr.ib()
 
-        attrs, super_attrs, _ = _transform_attrs(
+        attrs, base_attrs, _ = _transform_attrs(
             C, {"x": attr.ib()}, False, False
         )
 
-        assert [] == super_attrs
+        assert [] == base_attrs
         assert (simple_attr("x"),) == attrs
 
     def test_these_leave_body(self):


### PR DESCRIPTION
Thanks to ABCs, "base class" is more Python than "superclass" and the latter is
also slightly confusing by alluding to "super" and/or being judgy.

Harmonize “subclass” while at it too.