### PR TITLE
Remove some extraneous # noqa comments

### DIFF
--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -20,7 +20,7 @@ else:
 
 if PY2:
     from UserDict import IterableUserDict
-    from collections import Mapping, Sequence  # noqa
+    from collections import Mapping, Sequence
 
     # We 'bundle' isclass instead of using inspect as importing inspect is
     # fairly expensive (order of 10-15 ms for a modern machine in 2016)

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -233,14 +233,14 @@ class TestAsTuple(object):
                 elif isinstance(field_val, (list, tuple)):
                     # This field holds a sequence of something.
                     expected_type = type(obj_tuple[index])
-                    assert type(field_val) is expected_type  # noqa: E721
+                    assert type(field_val) is expected_type
                     for obj_e, obj_tuple_e in zip(field_val, obj_tuple[index]):
                         if has(obj_e.__class__):
                             assert_proper_col_class(obj_e, obj_tuple_e)
                 elif isinstance(field_val, dict):
                     orig = field_val
                     tupled = obj_tuple[index]
-                    assert type(orig) is type(tupled)  # noqa: E721
+                    assert type(orig) is type(tupled)
                     for obj_e, obj_tuple_e in zip(
                         orig.items(), tupled.items()
                     ):

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -40,7 +40,7 @@ class C1(object):
     if not PY2:
 
         def my_class(self):
-            return __class__  # NOQA: F821
+            return __class__
 
         def my_super(self):
             """Just to test out the no-arg super."""
@@ -66,7 +66,7 @@ class C1Slots(object):
     if not PY2:
 
         def my_class(self):
-            return __class__  # NOQA: F821
+            return __class__
 
         def my_super(self):
             """Just to test out the no-arg super."""
@@ -367,12 +367,12 @@ class TestClosureCellRewriting(object):
         @attr.s
         class C2(C1):
             def my_subclass(self):
-                return __class__  # NOQA: F821
+                return __class__
 
         @attr.s
         class C2Slots(C1Slots):
             def my_subclass(self):
-                return __class__  # NOQA: F821
+                return __class__
 
         non_slot_instance = C2(x=1, y="test")
         slot_instance = C2Slots(x=1, y="test")
@@ -400,7 +400,7 @@ class TestClosureCellRewriting(object):
         class C:
             @classmethod
             def clsmethod(cls):
-                return __class__  # noqa: F821
+                return __class__
 
         assert C.clsmethod() is C
 
@@ -408,7 +408,7 @@ class TestClosureCellRewriting(object):
         class D:
             @staticmethod
             def statmethod():
-                return __class__  # noqa: F821
+                return __class__
 
         assert D.statmethod() is D
 


### PR DESCRIPTION
Automated using [yesqa](https://github.com/asottile/yesqa/) with the following command:

```bash
pre-commit try-repo https://github.com/asottile/yesqa/ --all-files
```

# Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Added **tests** for changed code. **(N/A)**
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/strategies.py). **(N/A)**
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``). **(N/A)**
    - [x] ...and used in the stub test file `tests/typing_example.py`. **(N/A)**
- [x] Updated **documentation** for changed code. **(N/A)**
    - [x] New functions/classes have to be added to `docs/api.rst` by hand. **(N/A)**
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too. **(N/A)**
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded). **(N/A)**
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/). **(N/A)**
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d). **(N/A)**

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
