### PR TITLE
Fix closure cell rewriting on 3.8

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,10 +30,9 @@ jobs:
         py37:
           python.version: '3.7'
           tox.env: py37
-        # Our cell rewriting is currently broken on 3.8.
-        # py38:
-        #   python.version: '3.8'
-        #   tox.env: py38
+        py38:
+          python.version: '3.8'
+          tox.env: py38
 
         pypy2:
           python.version: 'pypy2'

--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -163,36 +163,30 @@ def make_set_closure_cell():
 
         # Convert this code object to a code object that sets the
         # function's first _freevar_ (not cellvar) to the argument.
+        args = [co.co_argcount]
         if sys.version_info >= (3, 8):
-            # CPython 3.8+ has an incompatible CodeType signature
-            # (added a posonlyargcount argument) but also added
-            # CodeType.replace() to do this without counting parameters.
-            set_first_freevar_code = co.replace(
-                co_cellvars=co.co_freevars, co_freevars=co.co_cellvars
-            )
-        else:
-            args = [co.co_argcount]
-            if not PY2:
-                args.append(co.co_kwonlyargcount)
-            args.extend(
-                [
-                    co.co_nlocals,
-                    co.co_stacksize,
-                    co.co_flags,
-                    co.co_code,
-                    co.co_consts,
-                    co.co_names,
-                    co.co_varnames,
-                    co.co_filename,
-                    co.co_name,
-                    co.co_firstlineno,
-                    co.co_lnotab,
-                    # These two arguments are reversed:
-                    co.co_cellvars,
-                    co.co_freevars,
-                ]
-            )
-            set_first_freevar_code = types.CodeType(*args)
+            args.append(co.co_posonlyargcount)
+        if not PY2:
+            args.append(co.co_kwonlyargcount)
+        args.extend(
+            [
+                co.co_nlocals,
+                co.co_stacksize,
+                co.co_flags,
+                co.co_code,
+                co.co_consts,
+                co.co_names,
+                co.co_varnames,
+                co.co_filename,
+                co.co_name,
+                co.co_firstlineno,
+                co.co_lnotab,
+                # These two arguments are reversed:
+                co.co_cellvars,
+                co.co_freevars,
+            ]
+        )
+        set_first_freevar_code = types.CodeType(*args)
 
         def set_closure_cell(cell, value):
             # Create a function using the set_first_freevar_code,

--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -163,28 +163,36 @@ def make_set_closure_cell():
 
         # Convert this code object to a code object that sets the
         # function's first _freevar_ (not cellvar) to the argument.
-        args = [co.co_argcount]
-        if not PY2:
-            args.append(co.co_kwonlyargcount)
-        args.extend(
-            [
-                co.co_nlocals,
-                co.co_stacksize,
-                co.co_flags,
-                co.co_code,
-                co.co_consts,
-                co.co_names,
-                co.co_varnames,
-                co.co_filename,
-                co.co_name,
-                co.co_firstlineno,
-                co.co_lnotab,
-                # These two arguments are reversed:
-                co.co_cellvars,
-                co.co_freevars,
-            ]
-        )
-        set_first_freevar_code = types.CodeType(*args)
+        if sys.version_info >= (3, 8):
+            # CPython 3.8+ has an incompatible CodeType signature
+            # (added a posonlyargcount argument) but also added
+            # CodeType.replace() to do this without counting parameters.
+            set_first_freevar_code = co.replace(
+                co_cellvars=co.co_freevars, co_freevars=co.co_cellvars
+            )
+        else:
+            args = [co.co_argcount]
+            if not PY2:
+                args.append(co.co_kwonlyargcount)
+            args.extend(
+                [
+                    co.co_nlocals,
+                    co.co_stacksize,
+                    co.co_flags,
+                    co.co_code,
+                    co.co_consts,
+                    co.co_names,
+                    co.co_varnames,
+                    co.co_filename,
+                    co.co_name,
+                    co.co_firstlineno,
+                    co.co_lnotab,
+                    # These two arguments are reversed:
+                    co.co_cellvars,
+                    co.co_freevars,
+                ]
+            )
+            set_first_freevar_code = types.CodeType(*args)
 
         def set_closure_cell(cell, value):
             # Create a function using the set_first_freevar_code,


### PR DESCRIPTION
CodeType in 3.8 newly takes a posonlyargcount argument. (It also will add a replace() method that can be used to simplify this logic, but not until 3.8.0b1, which is too new for attrs' CI at the moment.) Fixes #538.

# Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Added **tests** for changed code. -- N/A
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/strategies.py). -- N/A
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``). -- N/A
    - [x] ...and used in the stub test file `tests/typing_example.py`. -- N/A
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand. -- N/A
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too. -- N/A
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded). -- N/A
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/). -- N/A
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d). -- N/A, change with the bug was never released so no need to document the bug fix

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
