### PR TITLE
[WIP] fix coverage reporting on 3.8

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,7 +86,7 @@ jobs:
           which python
           python -m pip install -U pip setuptools
           python -m pip install coverage
-          pip list -v
+          python -m pip list -v
           which coverage
           python -m coverage combine
           $(pyTools.pythonLocation)/bin/codecov

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -84,6 +84,7 @@ jobs:
 
       - script: |
           python -m pip install coverage
+          which coverage
           python -m coverage combine
           $(pyTools.pythonLocation)/bin/codecov
         env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,14 +83,14 @@ jobs:
         displayName: run tox -e $(tox.env)
 
       - script: |
-          python -V
-          which python
+          python3 -V
+          which python3
           which python3.8
-          python -m pip install -U pip setuptools
-          python -m pip install coverage
-          python -m pip list -v
+          python3 -m pip install -U pip setuptools
+          python3 -m pip install coverage
+          python3 -m pip list -v
           which coverage
-          python -m coverage combine
+          python3 -m coverage combine
           $(pyTools.pythonLocation)/bin/codecov
         env:
           CODECOV_TOKEN: $(codecov.token)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,14 +83,13 @@ jobs:
         displayName: run tox -e $(tox.env)
 
       - script: |
-          python3 -V
-          which python3
-          which python3.8
-          python3 -m pip install -U pip setuptools
-          python3 -m pip install coverage
-          python3 -m pip list -v
+          PY=python${python.version}
+          which $PY
+          $PY -m pip install -U pip setuptools
+          $PY -m pip install coverage
+          $PY -m pip list -v
           which coverage
-          python3 -m coverage combine
+          $PY -m coverage combine
           $(pyTools.pythonLocation)/bin/codecov
         env:
           CODECOV_TOKEN: $(codecov.token)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,7 +83,7 @@ jobs:
         displayName: run tox -e $(tox.env)
 
       - script: |
-          PY=python${python.version}
+          PY=python$(python.version)
           which $PY
           $PY -m pip install -U pip setuptools
           $PY -m pip install coverage

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,7 +83,9 @@ jobs:
         displayName: run tox -e $(tox.env)
 
       - script: |
+          python -V
           which python
+          which python3.8
           python -m pip install -U pip setuptools
           python -m pip install coverage
           python -m pip list -v

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,7 +83,10 @@ jobs:
         displayName: run tox -e $(tox.env)
 
       - script: |
+          which python
+          python -m pip install -U pip setuptools
           python -m pip install coverage
+          pip list -v
           which coverage
           python -m coverage combine
           $(pyTools.pythonLocation)/bin/codecov

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -86,8 +86,6 @@ jobs:
           PY=python$(python.version)
           which $PY
           $PY -m pip install coverage
-          $PY -m pip list -v
-          which coverage
           $PY -m coverage combine
           $(pyTools.pythonLocation)/bin/codecov
         env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,7 +85,6 @@ jobs:
       - script: |
           PY=python$(python.version)
           which $PY
-          $PY -m pip install -U pip setuptools
           $PY -m pip install coverage
           $PY -m pip list -v
           which coverage


### PR DESCRIPTION
Since the python is installed differently, there seem to be problems finding it.

Codecov itself runs coverage from $PATH.