### PR TITLE
Rename remaining validator/default decorator examples with unclear names

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -73,11 +73,11 @@ Core
       ...     x = attr.ib()
       ...     y = attr.ib()
       ...     @x.validator
-      ...     def name_can_be_anything(self, attribute, value):
+      ...     def _any_name_except_a_name_of_an_attribute(self, attribute, value):
       ...         if value < 0:
       ...             raise ValueError("x must be positive")
       ...     @y.default
-      ...     def name_does_not_matter(self):
+      ...     def _any_name_except_a_name_of_an_attribute(self):
       ...         return self.x + 1
       >>> C(1)
       C(x=1, y=2)

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -341,7 +341,7 @@ The method receives the partially initialized instance which enables you to base
    ...     x = attr.ib(default=1)
    ...     y = attr.ib()
    ...     @y.default
-   ...     def name_does_not_matter(self):
+   ...     def _any_name_except_a_name_of_an_attribute(self):
    ...         return self.x + 1
    >>> C()
    C(x=1, y=2)


### PR DESCRIPTION
The documentation already explains well why validator or default decorated methods
must not have the name of existing attributes (because they would be overridden).

This replaces the last remaining examples not using the explicit explanatory name.