### PR TITLE
Replace black link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@
    :alt: Test Coverage
 
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-   :target: https://github.com/ambv/black
+   :target: https://github.com/python/black
    :alt: Code style: black
 
 .. teaser-begin


### PR DESCRIPTION
I changed black link in readme, because black moved it under the PSF umbrella and link changed.