### PR TITLE
Update closure cell rewriting to use CodeType.replace() on 3.8

### DIFF
--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -163,30 +163,36 @@ def make_set_closure_cell():
 
         # Convert this code object to a code object that sets the
         # function's first _freevar_ (not cellvar) to the argument.
-        args = [co.co_argcount]
         if sys.version_info >= (3, 8):
-            args.append(co.co_posonlyargcount)
-        if not PY2:
-            args.append(co.co_kwonlyargcount)
-        args.extend(
-            [
-                co.co_nlocals,
-                co.co_stacksize,
-                co.co_flags,
-                co.co_code,
-                co.co_consts,
-                co.co_names,
-                co.co_varnames,
-                co.co_filename,
-                co.co_name,
-                co.co_firstlineno,
-                co.co_lnotab,
-                # These two arguments are reversed:
-                co.co_cellvars,
-                co.co_freevars,
-            ]
-        )
-        set_first_freevar_code = types.CodeType(*args)
+            # CPython 3.8+ has an incompatible CodeType signature
+            # (added a posonlyargcount argument) but also added
+            # CodeType.replace() to do this without counting parameters.
+            set_first_freevar_code = co.replace(
+                co_cellvars=co.co_freevars, co_freevars=co.co_cellvars
+            )
+        else:
+            args = [co.co_argcount]
+            if not PY2:
+                args.append(co.co_kwonlyargcount)
+            args.extend(
+                [
+                    co.co_nlocals,
+                    co.co_stacksize,
+                    co.co_flags,
+                    co.co_code,
+                    co.co_consts,
+                    co.co_names,
+                    co.co_varnames,
+                    co.co_filename,
+                    co.co_name,
+                    co.co_firstlineno,
+                    co.co_lnotab,
+                    # These two arguments are reversed:
+                    co.co_cellvars,
+                    co.co_freevars,
+                ]
+            )
+            set_first_freevar_code = types.CodeType(*args)
 
         def set_closure_cell(cell, value):
             # Create a function using the set_first_freevar_code,

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -2,6 +2,7 @@
 Unit tests for slots-related functionality.
 """
 
+import sys
 import types
 import weakref
 
@@ -413,6 +414,10 @@ class TestClosureCellRewriting(object):
         assert D.statmethod() is D
 
     @pytest.mark.skipif(PYPY, reason="set_closure_cell always works on PyPy")
+    @pytest.mark.skipif(
+        sys.version_info >= (3, 8),
+        reason="can't break CodeType.replace() via monkeypatch",
+    )
     def test_code_hack_failure(self, monkeypatch):
         """
         Keeps working if function/code object introspection doesn't work


### PR DESCRIPTION
This was deferred from #539 because our CI didn't have a new enough 3.8 release at the time. `CodeType.replace()` is more forward-compatible, and the only 3.8 releases that don't support it are alpha releases with which we need not maintain compatibility.

# Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Added **tests** for changed code.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [x] ...and used in the stub test file `tests/typing_example.py`.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
