### PR TITLE
Fix default values that are not comparable with '=='

### DIFF
--- a/changelog.d/585.change.rst
+++ b/changelog.d/585.change.rst
@@ -1,0 +1,1 @@
+Fixed ``auto_attribs`` usage when default values cannot be compared directly with ``==``, such as ``numpy`` arrays.

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -509,7 +509,7 @@ class _ClassBuilder(object):
             for name in self._attr_names:
                 if (
                     name not in base_names
-                    and getattr(cls, name, _sentinel) != _sentinel
+                    and getattr(cls, name, _sentinel) is not _sentinel
                 ):
                     try:
                         delattr(cls, name)

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -282,3 +282,18 @@ class TestAnnotations:
 
         with pytest.raises(AttributeError):
             C.y
+
+    def test_non_comparable_defaults(self):
+        """
+        Regression test for #585: objects that are not directly comparable
+        (for example numpy arrays) would cause a crash when used as
+        default values of an attrs auto-attrib class.
+        """
+
+        class NonComparable:
+            def __eq__(self, other):
+                raise ValueError
+
+        @attr.s(auto_attribs=True)
+        class C:
+            x: typing.Any = NonComparable()


### PR DESCRIPTION
Fix #585

