### PR TITLE
minor typo in attr.s docstring

### DIFF
--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -815,7 +815,7 @@ def attrs(
         ``__ne__`` methods that check two instances for equality.
 
         They compare the instances as if they were tuples of their ``attrs``
-        attributes, but only if the types of both classes are *identical*!
+        attributes if and only if the types of both classes are *identical*!
     :type eq: `bool` or `None`
     :param bool order: If ``True``, add ``__lt__``, ``__le__``, ``__gt__``,
         and ``__ge__`` methods that behave like *eq* above and allow instances

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -815,7 +815,7 @@ def attrs(
         ``__ne__`` methods that check two instances for equality.
 
         They compare the instances as if they were tuples of their ``attrs``
-        attributes, but only iff the types of both classes are *identical*!
+        attributes, but only if the types of both classes are *identical*!
     :type eq: `bool` or `None`
     :param bool order: If ``True``, add ``__lt__``, ``__le__``, ``__gt__``,
         and ``__ge__`` methods that behave like *eq* above and allow instances


### PR DESCRIPTION
# Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Added **tests** for changed code.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [x] ...and used in the stub test file `tests/typing_example.py`.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
