### PR TITLE
Mention attr.fields() after __attrs_attrs__ in 'How does it work'

### DIFF
--- a/docs/how-does-it-work.rst
+++ b/docs/how-does-it-work.rst
@@ -40,7 +40,7 @@ No magic, no meta programming, no expensive introspection at runtime.
 Everything until this point happens exactly *once* when the class is defined.
 As soon as a class is done, it's done.
 And it's just a regular Python class like any other, except for a single ``__attrs_attrs__`` attribute that ``attrs`` uses internally.
-Much of the information is accessible via :meth:`attr.fields()` and other functions which can be used for introspection or for writing your own tools and decorators on top of ``attrs`` (like `attr.asdict`).
+Much of the information is accessible via `attr.fields` and other functions which can be used for introspection or for writing your own tools and decorators on top of ``attrs`` (like `attr.asdict`).
 
 And once you start instantiating your classes, ``attrs`` is out of your way completely.
 

--- a/docs/how-does-it-work.rst
+++ b/docs/how-does-it-work.rst
@@ -40,7 +40,7 @@ No magic, no meta programming, no expensive introspection at runtime.
 Everything until this point happens exactly *once* when the class is defined.
 As soon as a class is done, it's done.
 And it's just a regular Python class like any other, except for a single ``__attrs_attrs__`` attribute that ``attrs`` uses internally.
-Much of the information is accessible via :meth:`attrs.fields()` and other functions which can be used for introspection or for writing your own tools and decorators on top of ``attrs`` (like `attr.asdict`).
+Much of the information is accessible via :meth:`attr.fields()` and other functions which can be used for introspection or for writing your own tools and decorators on top of ``attrs`` (like `attr.asdict`).
 
 And once you start instantiating your classes, ``attrs`` is out of your way completely.
 

--- a/docs/how-does-it-work.rst
+++ b/docs/how-does-it-work.rst
@@ -39,7 +39,8 @@ No magic, no meta programming, no expensive introspection at runtime.
 
 Everything until this point happens exactly *once* when the class is defined.
 As soon as a class is done, it's done.
-And it's just a regular Python class like any other, except for a single ``__attrs_attrs__`` attribute that ``attrs`` uses internally.  Much of the information is accessible via :meth:`attrs.fields()` and other functions which can be used for introspection or for writing your own tools and decorators on top of ``attrs`` (like `attr.asdict`).
+And it's just a regular Python class like any other, except for a single ``__attrs_attrs__`` attribute that ``attrs`` uses internally.
+Much of the information is accessible via :meth:`attrs.fields()` and other functions which can be used for introspection or for writing your own tools and decorators on top of ``attrs`` (like `attr.asdict`).
 
 And once you start instantiating your classes, ``attrs`` is out of your way completely.
 

--- a/docs/how-does-it-work.rst
+++ b/docs/how-does-it-work.rst
@@ -39,7 +39,7 @@ No magic, no meta programming, no expensive introspection at runtime.
 
 Everything until this point happens exactly *once* when the class is defined.
 As soon as a class is done, it's done.
-And it's just a regular Python class like any other, except for a single ``__attrs_attrs__`` attribute that can be used for introspection or for writing your own tools and decorators on top of ``attrs`` (like `attr.asdict`).
+And it's just a regular Python class like any other, except for a single ``__attrs_attrs__`` attribute that ``attrs`` uses internally.  Much of the information is accessible via :meth:`attrs.fields()` and other functions which can be used for introspection or for writing your own tools and decorators on top of ``attrs`` (like `attr.asdict`).
 
 And once you start instantiating your classes, ``attrs`` is out of your way completely.
 


### PR DESCRIPTION
The mentioning of __attrs_attrs__ in a 'how does it work' document makes sense but it seems important to mention that there are good non-dunder ways to access the data.

WIP for:
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Checking doc rendering for the attrs.fields() link
