### PR TITLE
Officially drop Python 3.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,7 +130,7 @@ Project Information
 its documentation lives at `Read the Docs <https://www.attrs.org/>`_,
 the code on `GitHub <https://github.com/python-attrs/attrs>`_,
 and the latest release on `PyPI <https://pypi.org/project/attrs/>`_.
-It’s rigorously tested on Python 2.7, 3.4+, and PyPy.
+It’s rigorously tested on Python 2.7, 3.5+, and PyPy.
 
 We collect information on **third-party extensions** in our `wiki <https://github.com/python-attrs/attrs/wiki/Extensions-to-attrs>`_.
 Feel free to browse and add your own!

--- a/changelog.d/608.breaking.rst
+++ b/changelog.d/608.breaking.rst
@@ -1,0 +1,5 @@
+Python 3.4 is not supported anymore.
+It has been unsupported by the Python core team for a while now, its PyPI downloads are negligible, and our CI provider removed it as a supported option.
+
+It's very unlikely that ``attrs`` will break under 3.4 anytime soon, which is why we do *not* block its installation on Python 3.4.
+But we don't test it anymore and will block it once someone reports breakage.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 2",
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ filterwarnings =
 
 
 [tox]
-envlist = typing,lint,py27,py34,py35,py36,py37,py38,pypy,pypy3,manifest,docs,pypi-description,changelog,coverage-report
+envlist = typing,lint,py27,py35,py36,py37,py38,pypy,pypy3,manifest,docs,pypi-description,changelog,coverage-report
 isolated_build = True
 
 


### PR DESCRIPTION
AP dropped it and there's really no reason to support it anymore. Xenial is on 3.5.