### PR TITLE
Fixed frozen and cache_hash incompatibility

### DIFF
--- a/changelog.d/611.change.rst
+++ b/changelog.d/611.change.rst
@@ -1,0 +1,1 @@
+Fixed serialization of classes with ``frozen=True`` and ``cache_hash=True``, which has been broken since 19.1.0.

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -537,9 +537,17 @@ class _ClassBuilder(object):
                     "See https://github.com/python-attrs/attrs/issues/494 ."
                 )
 
-            def cache_hash_set_state(chss_self, _):
-                # clear hash code cache
-                setattr(chss_self, _hash_cache_field, None)
+            # Clears the cached hash state on serialization; for frozen
+            # classes we need to bypass the class's setattr method.
+            if self._frozen:
+
+                def cache_hash_set_state(chss_self, _):
+                    object.__setattr__(chss_self, _hash_cache_field, None)
+
+            else:
+
+                def cache_hash_set_state(chss_self, _):
+                    setattr(chss_self, _hash_cache_field, None)
 
             cls.__setstate__ = cache_hash_set_state
 

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -1466,6 +1466,18 @@ class TestClassBuilder(object):
 
         assert [C2] == C.__subclasses__()
 
+    @pytest.mark.xfail(raises=attr.exceptions.FrozenInstanceError)
+    def test_cache_hash_with_frozen_serializes(self):
+        """
+        Frozen classes with cache_hash should be serializable.
+        """
+
+        @attr.s(cache_hash=True, frozen=True)
+        class C(object):
+            pass
+
+        copy.deepcopy(C())
+
 
 class TestMakeOrder:
     """

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -1466,7 +1466,6 @@ class TestClassBuilder(object):
 
         assert [C2] == C.__subclasses__()
 
-    @pytest.mark.xfail(raises=attr.exceptions.FrozenInstanceError)
     def test_cache_hash_with_frozen_serializes(self):
         """
         Frozen classes with cache_hash should be serializable.


### PR DESCRIPTION
This uses the same mechanism to clear the cache hash as `__hash__` uses to set the cache hash in frozen classes - bypassing the object's `__setattr__` in favor of `object.__setattr__`. Neat trick.

Fixes #611.

# Pull Request Check List

This is just a reminder about the most common mistakes.  Please make sure that you tick all *appropriate* boxes.  But please read our [contribution guide](https://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing to do.

- [x] Added **tests** for changed code.
- (N/A) New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/strategies.py).
- (N/A) Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
- (N/A) Updated **documentation** for changed code.
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
