### PR TITLE
WIP: Implement __reduce__ with cache_hash

### DIFF
--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -449,7 +449,9 @@ def _cache_hash_reduce(self):
         state = obj_reduce[2]
 
         if isinstance(state, dict) and _hash_cache_field in state:
+            state = copy.copy(state)
             state[_hash_cache_field] = None
+            obj_reduce = obj_reduce[0:2] + (state,) + obj_reduce[3:]
 
     return obj_reduce
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -46,6 +46,23 @@ _empty_metadata_singleton = metadata_proxy({})
 _sentinel = object()
 
 
+if PY2 and object.__reduce__ is not int.__reduce__:  # pragma: no cover
+    # In pypy2.7, you can't use `is` on methods, but we want to use whichever
+    # method tells us `object.__reduce__` equals `int.__reduce__`.
+    #
+    # Note: This section is not expected to be covered in the current CI
+    # configuration because coverage is too slow on pypy; if coverage is
+    # ever turned back on for pypy, please remove the no cover pragma.
+    def _method_eq(a, b):
+        return a == b
+
+
+else:
+
+    def _method_eq(a, b):
+        return a is b
+
+
 class _Nothing(object):
     """
     Sentinel class to indicate the lack of a value when ``None`` is ambiguous.
@@ -496,8 +513,8 @@ class _ClassBuilder(object):
 
         if (
             cache_hash
-            and cls.__reduce__ is object.__reduce__
-            and cls.__reduce_ex__ is object.__reduce_ex__
+            and _method_eq(cls.__reduce__, object.__reduce__)
+            and _method_eq(cls.__reduce_ex__, object.__reduce_ex__)
         ):
             self._cls_dict["__reduce__"] = _cache_hash_reduce
 

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -569,6 +569,28 @@ class TestAddHash(object):
         assert original_hash == hash(obj)
         assert original_hash != hash(obj_rt)
 
+    @pytest.mark.parametrize("frozen", [True, False])
+    def test_copy_two_arg_reduce(self, frozen):
+        """
+        If __getstate__ returns None, the tuple returned by object.__reduce__
+        won't contain the state dictionary; this test ensures that the custom
+        __reduce__ generated when cache_hash=True works in that case.
+        """
+
+        @attr.s(frozen=frozen, cache_hash=True, hash=True)
+        class C(object):
+            x = attr.ib()
+
+            def __getstate__(self):
+                return None
+
+        # By the nature of this test it doesn't really create an object that's
+        # in a valid state - it basically does the equivalent of
+        # `object.__new__(C)`, so it doesn't make much sense to assert anything
+        # about the result of the copy. This test will just check that it
+        # doesn't raise an *error*.
+        copy.deepcopy(C(1))
+
     def _roundtrip_pickle(self, obj):
         pickle_str = pickle.dumps(obj)
         return pickle.loads(pickle_str)

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -1466,16 +1466,66 @@ class TestClassBuilder(object):
 
         assert [C2] == C.__subclasses__()
 
-    def test_cache_hash_with_frozen_serializes(self):
+    def _get_copy_kwargs(include_slots=True):
         """
-        Frozen classes with cache_hash should be serializable.
+        Generate a list of compatible attr.s arguments for the `copy` tests.
+        """
+        options = ["frozen", "hash", "cache_hash"]
+
+        if include_slots:
+            options.extend(["slots", "weakref_slot"])
+
+        out_kwargs = []
+        for args in itertools.product([True, False], repeat=len(options)):
+            kwargs = dict(zip(options, args))
+
+            kwargs["hash"] = kwargs["hash"] or None
+
+            if kwargs["cache_hash"] and not (
+                kwargs["frozen"] or kwargs["hash"]
+            ):
+                continue
+
+            out_kwargs.append(kwargs)
+
+        return out_kwargs
+
+    @pytest.mark.parametrize("kwargs", _get_copy_kwargs())
+    def test_copy(self, kwargs):
+        """
+        Ensure that an attrs class can be copied successfully.
         """
 
-        @attr.s(cache_hash=True, frozen=True)
+        @attr.s(eq=True, **kwargs)
         class C(object):
-            pass
+            x = attr.ib()
 
-        copy.deepcopy(C())
+        a = C(1)
+        b = copy.deepcopy(a)
+
+        assert a == b
+
+    @pytest.mark.parametrize("kwargs", _get_copy_kwargs(include_slots=False))
+    def test_copy_custom_setstate(self, kwargs):
+        """
+        Ensure that non-slots classes respect a custom __setstate__.
+        """
+
+        @attr.s(eq=True, **kwargs)
+        class C(object):
+            x = attr.ib()
+
+            def __getstate__(self):
+                return self.__dict__
+
+            def __setstate__(self, state):
+                state["x"] *= 5
+                self.__dict__.update(state)
+
+        expected = C(25)
+        actual = copy.copy(C(5))
+
+        assert actual == expected
 
 
 class TestMakeOrder:


### PR DESCRIPTION
It turns out that the hash cache-clearing implementation for non-slots classes was flawed and never quite worked properly. This switches away from using `__setstate__` and instead adds a custom `__reduce__` that removes the cached hash value from the default serialized output.

This commit also refactors some of the tests a bit, to try and more cleanly organize the tests related to this issue.

Fixes #613.
Fixes #494.

# Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
- [ ] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).