### PR TITLE
WIP: Switch over to a global hash cache

### DIFF
--- a/src/attr/_hash_cache.py
+++ b/src/attr/_hash_cache.py
@@ -1,0 +1,39 @@
+import functools
+import weakref
+
+
+# Cache mapping the results of id() to its hash
+HASH_CACHE = {}
+
+if getattr(weakref, "finalize", None) is not None:
+
+    def cache_hash(obj, obj_hash):
+        global HASH_CACHE
+        id_ = id(obj)
+        cleanup_cache = functools.partial(HASH_CACHE.pop, id_, None)
+        finalizer = weakref.finalize(obj, cleanup_cache)
+
+        # At exit this will clean itself up - these finalizers are just to
+        # avoid memory leaks
+        finalizer.atexit = False
+
+        # Use `setdefault` for thread-safety
+        HASH_CACHE.setdefault(id_, obj_hash)
+
+
+else:
+    _WEAK_REFS = {}
+
+    def _cleanup_weakref(obj_id):
+        global HASH_CACHE
+        global _WEAK_REFS
+        HASH_CACHE.pop(obj_id, None)
+        _WEAK_REFS.pop(obj_id, None)
+
+    def cache_hash(obj, obj_hash):
+        id_ = id(obj)
+        cleanup_cache = functools.partial(_cleanup_weakref, id_)
+
+        r = weakref.ref(obj, cleanup_cache)
+        _WEAK_REFS.setdefault(id_, r)
+        HASH_CACHE.setdefault(id_, obj_hash)

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -569,6 +569,28 @@ class TestAddHash(object):
         assert original_hash == hash(obj)
         assert original_hash != hash(obj_rt)
 
+    @pytest.mark.parametrize("frozen", [True, False])
+    def test_copy_two_arg_reduce(self, frozen):
+        """
+        If __getstate__ returns None, the tuple returned by object.__reduce__
+        won't contain the state dictionary; this test ensures that the custom
+        __reduce__ generated when cache_hash=True works in that case.
+        """
+
+        @attr.s(frozen=frozen, cache_hash=True, hash=True)
+        class C(object):
+            x = attr.ib()
+
+            def __getstate__(self):
+                return None
+
+        # By the nature of this test it doesn't really create an object that's
+        # in a valid state - it basically does the equivalent of
+        # `object.__new__(C)`, so it doesn't make much sense to assert anything
+        # about the result of the copy. This test will just check that it
+        # doesn't raise an *error*.
+        copy.deepcopy(C(1))
+
     def _roundtrip_pickle(self, obj):
         pickle_str = pickle.dumps(obj)
         return pickle.loads(pickle_str)

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -1466,16 +1466,66 @@ class TestClassBuilder(object):
 
         assert [C2] == C.__subclasses__()
 
-    def test_cache_hash_with_frozen_serializes(self):
+    def _get_copy_kwargs(include_slots=True):
         """
-        Frozen classes with cache_hash should be serializable.
+        Generate a list of compatible attr.s arguments for the `copy` tests.
+        """
+        options = ["frozen", "hash", "cache_hash"]
+
+        if include_slots:
+            options.extend(["slots", "weakref_slot"])
+
+        out_kwargs = []
+        for args in itertools.product([True, False], repeat=len(options)):
+            kwargs = dict(zip(options, args))
+
+            kwargs["hash"] = kwargs["hash"] or None
+
+            if kwargs["cache_hash"] and not (
+                kwargs["frozen"] or kwargs["hash"]
+            ):
+                continue
+
+            out_kwargs.append(kwargs)
+
+        return out_kwargs
+
+    @pytest.mark.parametrize("kwargs", _get_copy_kwargs())
+    def test_copy(self, kwargs):
+        """
+        Ensure that an attrs class can be copied successfully.
         """
 
-        @attr.s(cache_hash=True, frozen=True)
+        @attr.s(eq=True, **kwargs)
         class C(object):
-            pass
+            x = attr.ib()
 
-        copy.deepcopy(C())
+        a = C(1)
+        b = copy.deepcopy(a)
+
+        assert a == b
+
+    @pytest.mark.parametrize("kwargs", _get_copy_kwargs(include_slots=False))
+    def test_copy_custom_setstate(self, kwargs):
+        """
+        Ensure that non-slots classes respect a custom __setstate__.
+        """
+
+        @attr.s(eq=True, **kwargs)
+        class C(object):
+            x = attr.ib()
+
+            def __getstate__(self):
+                return self.__dict__
+
+            def __setstate__(self, state):
+                state["x"] *= 5
+                self.__dict__.update(state)
+
+        expected = C(25)
+        actual = copy.copy(C(5))
+
+        assert actual == expected
 
 
 class TestMakeOrder:


### PR DESCRIPTION
This uses an alternate approach to hash caching than the current master or #615. Rather than trying to store the hash cache on the object itself, we create a global hash cache object mapping the id of the object to its hash.

This pretty dramatically simplifies the code. The two biggest downsides:

1. This introduces weak references and mutable global state into the code. I think I've got a thread-safe implementation, but it's very hard to test for that. Even if we weren't worried about memory leaks, we definitely need the cache lifecycle tied to the object's lifecycle, because otherwise the interpreter might assign another `cache_hash=True` object the same `id()` value.

2. At least the way I've implemented it (and I don't know if there's a much faster way to do it), this method adds what I would consider a lot of overhead, compare the speed for this version of the code (both using Python 3.7.4):

```python
>>> import attr
>>> @attr.s(cache_hash=True, hash=True)
... class C:
...     x = attr.ib()
...
>>> %timeit hash(C(1))
6.2 µs ± 176 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
>>> x = C(1)
>>> %timeit hash(x)
1.3 µs ± 7.58 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

To the speed of the equivalent code using #615 

```python
>>> import attr
>>> @attr.s(cache_hash=True, hash=True)
... class C:
...     x = attr.ib()
...
>>> %timeit hash(C(1))
684 ns ± 9.06 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
>>> x = C(1)
>>> %timeit hash(x)
207 ns ± 1.42 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

For a more complicated class (where `cache_hash=True` might be more valuable), the "create-and-hash" numbers narrow *a bit*, but there's still a pretty significant difference for the "lookup in hash" case:

```python
>>> import attr
>>> @attr.s(cache_hash=True, hash=True)
... class C:
...     x = attr.ib(default="qbert")
...     y = attr.ib(default="hi")
...     z = attr.ib(default=2**120)
...     a = attr.ib(default=tuple(["a"] * 500))
...     b = attr.ib(default=b"A" * 100000)
...     c = attr.ib(default=200)
...
>>> %timeit hash(C())
8.85 µs ± 72.4 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
>>> x = C()
>>> %timeit hash(x)
1.24 µs ± 19.1 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)
```

#615 version:

```python
>>> @attr.s(cache_hash=True, hash=True)
... class C:
...     x = attr.ib(default="qbert")
...     y = attr.ib(default="hi")
...     z = attr.ib(default=2**120)
...     a = attr.ib(default=tuple(["a"] * 500))
...     b = attr.ib(default=b"A" * 100000)
...     c = attr.ib(default=200)
...
>>> %timeit hash(C())
3.13 µs ± 156 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
>>> x = C()
>>> %timeit hash(x)
212 ns ± 3.54 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
```

I have spent less time working on this version, so it could probably be optimized somewhat, but I doubt we'll get the first-hash time down much, and I think this way will always be slower.

Fixes #613.
Fixes #494.

# Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] Updated **documentation** for changed code.
- [ ] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).