### PR TITLE
Use a wrapper class for cache hash to prevent cache serialization

### DIFF
--- a/changelog.d/611.change.rst
+++ b/changelog.d/611.change.rst
@@ -1,1 +1,0 @@
-Fixed serialization of classes with ``frozen=True`` and ``cache_hash=True``, which has been broken since 19.1.0.

--- a/changelog.d/620.change.rst
+++ b/changelog.d/620.change.rst
@@ -1,0 +1,8 @@
+Fixed serialization behavior of non-slots classes with ``cache_hash=True``.
+The hash cache will be cleared on operations which make "deep copies" of instances of classes with hash caching,
+though the cache will not be cleared with shallow copies like those made by ``copy.copy()``.
+
+Previously, ``copy.deepcopy()`` or serialization and deserialization with ``pickle`` would result in an un-initialized object.
+
+This change also allows the creation of ``cache_hash=True`` classes with a custom ``__setstate__``,
+which was previously forbidden (`#494 <https://github.com/python-attrs/attrs/issues/494>`_).

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -77,7 +77,7 @@ class _CacheHashWrapper(int):
     This is used for non-slots classes with ``cache_hash=True``, to avoid
     serializing a potentially (even likely) invalid hash value. Since ``None``
     is the default value for uncalculated hashes, whenever this is copied,
-    the copy's value for hte hash should automatically reset.
+    the copy's value for the hash should automatically reset.
 
     See GH #613 for more details.
     """

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -70,6 +70,31 @@ Sentinel to indicate the lack of a value when ``None`` is ambiguous.
 """
 
 
+class _CacheHashWrapper(int):
+    """
+    An integer subclass that pickles / copies as None
+
+    This is used for non-slots classes with ``cache_hash=True``, to avoid
+    serializing a potentially (even likely) invalid hash value. Since ``None``
+    is the default value for uncalculated hashes, whenever this is copied,
+    the copy's value for hte hash should automatically reset.
+
+    See GH #613 for more details.
+    """
+
+    if PY2:
+        # For some reason `type(None)` isn't callable in Python 2, but we don't
+        # actually need a constructor for None objects, we just need any
+        # available function that returns None.
+        def __reduce__(self, _none_constructor=getattr, _args=(0, "", None)):
+            return _none_constructor, _args
+
+    else:
+
+        def __reduce__(self, _none_constructor=type(None), _args=()):
+            return _none_constructor, _args
+
+
 def attrib(
     default=NOTHING,
     validator=None,
@@ -522,34 +547,6 @@ class _ClassBuilder(object):
         # Attach our dunder methods.
         for name, value in self._cls_dict.items():
             setattr(cls, name, value)
-
-        # Attach __setstate__. This is necessary to clear the hash code
-        # cache on deserialization. See issue
-        # https://github.com/python-attrs/attrs/issues/482 .
-        # Note that this code only handles setstate for dict classes.
-        # For slotted classes, see similar code in _create_slots_class .
-        if self._cache_hash:
-            existing_set_state_method = getattr(cls, "__setstate__", None)
-            if existing_set_state_method:
-                raise NotImplementedError(
-                    "Currently you cannot use hash caching if "
-                    "you specify your own __setstate__ method."
-                    "See https://github.com/python-attrs/attrs/issues/494 ."
-                )
-
-            # Clears the cached hash state on serialization; for frozen
-            # classes we need to bypass the class's setattr method.
-            if self._frozen:
-
-                def cache_hash_set_state(chss_self, _):
-                    object.__setattr__(chss_self, _hash_cache_field, None)
-
-            else:
-
-                def cache_hash_set_state(chss_self, _):
-                    setattr(chss_self, _hash_cache_field, None)
-
-            cls.__setstate__ = cache_hash_set_state
 
         return cls
 
@@ -1103,7 +1100,23 @@ def _make_hash(cls, attrs, frozen, cache_hash):
     unique_filename = _generate_unique_filename(cls, "hash")
     type_hash = hash(unique_filename)
 
-    method_lines = ["def __hash__(self):"]
+    hash_def = "def __hash__(self"
+    hash_func = "hash(("
+    closing_braces = "))"
+    if not cache_hash:
+        hash_def += "):"
+    else:
+        if not PY2:
+            hash_def += ", *"
+
+        hash_def += (
+            ", _cache_wrapper="
+            + "__import__('attr._make')._make._CacheHashWrapper):"
+        )
+        hash_func = "_cache_wrapper(" + hash_func
+        closing_braces += ")"
+
+    method_lines = [hash_def]
 
     def append_hash_computation_lines(prefix, indent):
         """
@@ -1111,14 +1124,18 @@ def _make_hash(cls, attrs, frozen, cache_hash):
         Below this will either be returned directly or used to compute
         a value which is then cached, depending on the value of cache_hash
         """
+
         method_lines.extend(
-            [indent + prefix + "hash((", indent + "        %d," % (type_hash,)]
+            [
+                indent + prefix + hash_func,
+                indent + "        %d," % (type_hash,),
+            ]
         )
 
         for a in attrs:
             method_lines.append(indent + "        self.%s," % a.name)
 
-        method_lines.append(indent + "    ))")
+        method_lines.append(indent + "    " + closing_braces)
 
     if cache_hash:
         method_lines.append(tab + "if self.%s is None:" % _hash_cache_field)

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -609,11 +609,10 @@ class _ClassBuilder(object):
             __bound_setattr = _obj_setattr.__get__(self, Attribute)
             for name, value in zip(state_attr_names, state):
                 __bound_setattr(name, value)
-            # Clearing the hash code cache on deserialization is needed
-            # because hash codes can change from run to run. See issue
-            # https://github.com/python-attrs/attrs/issues/482 .
-            # Note that this code only handles setstate for slotted classes.
-            # For dict classes, see similar code in _patch_original_class .
+
+            # The hash code cache is not included when the object is
+            # serialized, but it still needs to be initialized to None to
+            # indicate that the first call to __hash__ should be a cache miss.
             if hash_caching_enabled:
                 __bound_setattr(_hash_cache_field, None)
 

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -569,6 +569,28 @@ class TestAddHash(object):
         assert original_hash == hash(obj)
         assert original_hash != hash(obj_rt)
 
+    @pytest.mark.parametrize("frozen", [True, False])
+    def test_copy_two_arg_reduce(self, frozen):
+        """
+        If __getstate__ returns None, the tuple returned by object.__reduce__
+        won't contain the state dictionary; this test ensures that the custom
+        __reduce__ generated when cache_hash=True works in that case.
+        """
+
+        @attr.s(frozen=frozen, cache_hash=True, hash=True)
+        class C(object):
+            x = attr.ib()
+
+            def __getstate__(self):
+                return None
+
+        # By the nature of this test it doesn't really create an object that's
+        # in a valid state - it basically does the equivalent of
+        # `object.__new__(C)`, so it doesn't make much sense to assert anything
+        # about the result of the copy. This test will just check that it
+        # doesn't raise an *error*.
+        copy.deepcopy(C(1))
+
     def _roundtrip_pickle(self, obj):
         pickle_str = pickle.dumps(obj)
         return pickle.loads(pickle_str)

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -1466,16 +1466,66 @@ class TestClassBuilder(object):
 
         assert [C2] == C.__subclasses__()
 
-    def test_cache_hash_with_frozen_serializes(self):
+    def _get_copy_kwargs(include_slots=True):
         """
-        Frozen classes with cache_hash should be serializable.
+        Generate a list of compatible attr.s arguments for the `copy` tests.
+        """
+        options = ["frozen", "hash", "cache_hash"]
+
+        if include_slots:
+            options.extend(["slots", "weakref_slot"])
+
+        out_kwargs = []
+        for args in itertools.product([True, False], repeat=len(options)):
+            kwargs = dict(zip(options, args))
+
+            kwargs["hash"] = kwargs["hash"] or None
+
+            if kwargs["cache_hash"] and not (
+                kwargs["frozen"] or kwargs["hash"]
+            ):
+                continue
+
+            out_kwargs.append(kwargs)
+
+        return out_kwargs
+
+    @pytest.mark.parametrize("kwargs", _get_copy_kwargs())
+    def test_copy(self, kwargs):
+        """
+        Ensure that an attrs class can be copied successfully.
         """
 
-        @attr.s(cache_hash=True, frozen=True)
+        @attr.s(eq=True, **kwargs)
         class C(object):
-            pass
+            x = attr.ib()
 
-        copy.deepcopy(C())
+        a = C(1)
+        b = copy.deepcopy(a)
+
+        assert a == b
+
+    @pytest.mark.parametrize("kwargs", _get_copy_kwargs(include_slots=False))
+    def test_copy_custom_setstate(self, kwargs):
+        """
+        Ensure that non-slots classes respect a custom __setstate__.
+        """
+
+        @attr.s(eq=True, **kwargs)
+        class C(object):
+            x = attr.ib()
+
+            def __getstate__(self):
+                return self.__dict__
+
+            def __setstate__(self, state):
+                state["x"] *= 5
+                self.__dict__.update(state)
+
+        expected = C(25)
+        actual = copy.copy(C(5))
+
+        assert actual == expected
 
 
 class TestMakeOrder:


### PR DESCRIPTION
When reviewing #615, @godlygeek came up with this brilliant alternative suggestion: use an `int` subclass that always pickles as `None`, so that unless someone goes out of their way to capture the cache value and include it in a `__reduce__` or `__setstate__`, the cache will be cleared on any copy operation.

My main fears (both of which turned out to be unsubstantiated) were:

1. This might slow down `hash()` in favor of correctness in serialization/deserialization for people implementing their own `__reduce__` functions, which seems like a very niche concern.
2. Returning a `_CacheHashValue` from `__hash__` might cause other problems, like if someone were taking the hash value of something and pickling or copying it for some deliberate reason (i.e. not copying the object it's stored on, but copying the return value of `hash(x)`).

In terms of performance, it seems like the only performance impact this has is on the *first* call to `hash()`, with:

```python
import attr
@attr.s(frozen=True, cache_hash=True)
class A:
    x = attr.ib()
```

For `%timeit hash(A(1))`, I get around 800ns with the current version of attrs and ~1-1.2μs with this change, so about a 300-400ns cost on cache misses. It's a decently high percentage of the hash for this class, but it is kinda stupid to use `cache_hash` for this class if you're mostly getting cache misses anyway...

For `a = A(1)`, `%timeit hash(a)`, I get around 220-250ns per call with the old and new versions.

Regarding point 2, returning an integer subclass here instead of an integer doesn't seem to be a problem, because `hash()` casts the value of `__hash__` to `int` anyway, at least on CPython.

One alternate implementation I tried out is to use a 1-slot slots class instead of an integer subclass for `_CacheHashWrapper`, and unwrap the value on every call to `__hash__`. This was a bit slower than the integer subclass version in both the cache miss and cache hit cases. It was around 275ns in the cache hit case instead of 220-250ns.

One last thing to note: There is one use case that this is likely to break, which is people who are creating an `attrs` class with one version of `attrs`, pickling it, and then unpickling it in another version. Pickles made on Python 3 even with the same attrs version cannot be unpickled in Python 2 (though Python 2 pickles will probably work in Python 3). Since using pickle other than to send data between identical Python environments is unsupported and a bad idea, I think we can discount this concern.

I think this is probably the best approach. If you give me the green light I'll tweak whatever documentation needs to be tweaked and add a changelog. I actually don't expect many if any documentation changes with this version since there should be nothing to caution people about - we would just need to remove any language about #494.

This PR includes the additional tests added in #615.

Fixes #613.
Fixes #494.

# Pull Request Check List

- [x] Added **tests** for changed code.
- [x] Updated **documentation** for changed code.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).