### PR TITLE
Allow user to customize Attribute comparison by supplying a *cmpspec*

### DIFF
--- a/changelog.d/435.change.rst
+++ b/changelog.d/435.change.rst
@@ -1,0 +1,18 @@
+Added ``cmpspec`` to ``Attribute`` and ``attr.ib()`` (`#435 <https://github.com/python-attrs/attrs/issues/435>`_).
+
+``CmpSpec`` must be a class that wraps a value and implements equality and ordering methods.
+
+This change was motivated by the fact that some popular packages (``pandas dataframes``,
+``numpy arrays``) overload equality and ordering methods to return values that are not boolean,
+which makes sense in their specific domains (data science), but breaks generic functions
+that rely on the protocol ``__eq__(self, other) -> bool``.
+
+Under this change, the user will be able to specify *how* an ``Attribute`` is compared by
+supplying a *comparison class*.
+
+This change will also allow users to customize ``Attribute`` comparison in more
+intuitive scenarios, e.g. *case insensitive strings*, or simply using a sort-like *key*
+as requested in (`#624 <https://github.com/python-attrs/attrs/issues/624>`_).
+
+Finally, we provide a few off-the-shelf ``CmpSpec`` classes in the package ``attr.cmpspec``
+that users can use in the most common cases, or use as template to implement their own.

--- a/src/attr/__init__.py
+++ b/src/attr/__init__.py
@@ -19,7 +19,7 @@ from ._make import (
 from ._version_info import VersionInfo
 
 
-__version__ = "20.1.0.dev0"
+__version__ = "20.1.0.dev0_botant"
 __version_info__ = VersionInfo._from_version_string(__version__)
 
 __title__ = "attrs"

--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -113,6 +113,7 @@ def attrib(
     kw_only: bool = ...,
     eq: Optional[bool] = ...,
     order: Optional[bool] = ...,
+    cmpspec: Optional[type] = ...,
 ) -> Any: ...
 
 # This form catches an explicit None or no default and infers the type from the other arguments.
@@ -131,6 +132,7 @@ def attrib(
     kw_only: bool = ...,
     eq: Optional[bool] = ...,
     order: Optional[bool] = ...,
+    cmpspec: Optional[type] = ...,
 ) -> _T: ...
 
 # This form catches an explicit default argument.
@@ -149,6 +151,7 @@ def attrib(
     kw_only: bool = ...,
     eq: Optional[bool] = ...,
     order: Optional[bool] = ...,
+    cmpspec: Optional[type] = ...,
 ) -> _T: ...
 
 # This form covers type=non-Type: e.g. forward references (str), Any
@@ -167,6 +170,7 @@ def attrib(
     kw_only: bool = ...,
     eq: Optional[bool] = ...,
     order: Optional[bool] = ...,
+    cmpspec: Optional[type] = ...,
 ) -> Any: ...
 @overload
 def attrs(

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1190,45 +1190,70 @@ def __ne__(self, other):
 
 
 def _make_eq(cls, attrs):
+    """
+    Create equality methods.
+    """
     attrs = [a for a in attrs if a.eq]
 
-    unique_filename = _generate_unique_filename(cls, "eq")
-    lines = [
-        "def __eq__(self, other):",
-        "    if other.__class__ is not self.__class__:",
-        "        return NotImplemented",
-    ]
-    # We can't just do a big self.x = other.x and... clause due to
-    # irregularities like nan == nan is false but (nan,) == (nan,) is true.
-    if attrs:
-        lines.append("    return  (")
-        others = ["    ) == ("]
-        for a in attrs:
-            lines.append("        self.%s," % (a.name,))
-            others.append("        other.%s," % (a.name,))
+    def attrs_to_tuple(obj):
+        """
+        Save us some typing.
+        """
+        return _attrs_to_tuple(obj, attrs)
 
-        lines += others + ["    )"]
-    else:
-        lines.append("    return True")
+    def __eq__(self, other):
+        """
+        Automatically created by attrs.
+        """
+        if other.__class__ is self.__class__:
+            return attrs_to_tuple(self) == attrs_to_tuple(other)
 
-    script = "\n".join(lines)
-    globs = {}
-    locs = {}
-    bytecode = compile(script, unique_filename, "exec")
-    eval(bytecode, globs, locs)
+        return NotImplemented
 
-    # In order of debuggers like PDB being able to step through the code,
-    # we add a fake linecache entry.
-    linecache.cache[unique_filename] = (
-        len(script),
-        None,
-        script.splitlines(True),
-        unique_filename,
-    )
-    return locs["__eq__"], __ne__
+    return __eq__, __ne__
+
+    # unique_filename = _generate_unique_filename(cls, "eq")
+
+    # lines = [
+    #     "def __eq__(self, other):",
+    #     "    if other.__class__ is not self.__class__:",
+    #     "        return NotImplemented",
+    # ]
+
+    # # We can't just do a big self.x = other.x and... clause due to
+    # # irregularities like nan == nan is false but (nan,) == (nan,) is true.
+    # if attrs:
+    #     lines.append("    return  (")
+    #     others = ["    ) == ("]
+    #     for a in attrs:
+    #         lines.append("        self.%s," % (a.name,))
+    #         others.append("        other.%s," % (a.name,))
+
+    #     lines += others + ["    )"]
+    # else:
+    #     lines.append("    return True")
+
+    # script = "\n".join(lines)
+    # globs = {}
+    # locs = {}
+    # bytecode = compile(script, unique_filename, "exec")
+    # eval(bytecode, globs, locs)
+
+    # # In order of debuggers like PDB being able to step through the code,
+    # # we add a fake linecache entry.
+    # linecache.cache[unique_filename] = (
+    #     len(script),
+    #     None,
+    #     script.splitlines(True),
+    #     unique_filename,
+    # )
+    # return locs["__eq__"], __ne__
 
 
 def _make_order(cls, attrs):
+    """
+    Create ordering methods.
+    """
     attrs = [a for a in attrs if a.order]
 
     def attrs_to_tuple(obj):
@@ -1364,6 +1389,9 @@ def _add_repr(cls, ns=None, attrs=None):
 def _make_init(
     cls, attrs, post_init, frozen, slots, cache_hash, base_attr_map, is_exc
 ):
+    """
+    Add an init method to *cls*.
+    """
     attrs = [a for a in attrs if a.init or a.default is not NOTHING]
 
     unique_filename = _generate_unique_filename(cls, "init")

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1210,30 +1210,55 @@ def __ne__(self, other):
 
 
 def _make_eq(cls, attrs):
-    """
-    Create equality methods.
-    """
-    attrs = [a for a in attrs if a.eq]
+    attrs = [a for a in attrs if a.eq or a.cmpspec]
 
-    def attrs_to_tuple(obj):
-        """
-        Save us some typing.
-        """
-        return _attrs_to_cmp_tuple(obj, attrs)
-
+    unique_filename = _generate_unique_filename(cls, "eq")
+    cached_args = []
+    lines = [
+        "def __eq__(self, other):",
+        "    if other.__class__ is not self.__class__:",
+        "        return NotImplemented",
+    ]
     # We can't just do a big self.x = other.x and... clause due to
     # irregularities like nan == nan is false but (nan,) == (nan,) is true.
+    locs = {}
+    if attrs:
+        lines.append("    return  (")
+        others = ["    ) == ("]
+        for a in attrs:
+            if a.cmpspec:
+                cmp_name = "%s_cmp" % (a.name,)
+                locs[cmp_name] = a.cmpspec
+                cached_args.append("_%s=%s" % (cmp_name, cmp_name))
+                lines.append("        _%s(self.%s)," % (cmp_name, a.name,))
+                others.append("        _%s(other.%s)," % (cmp_name, a.name,))
+            else:
+                lines.append("        self.%s," % (a.name,))
+                others.append("        other.%s," % (a.name,))
 
-    def __eq__(self, other):
-        """
-        Automatically created by attrs.
-        """
-        if other.__class__ is self.__class__:
-            return attrs_to_tuple(self) == attrs_to_tuple(other)
+        lines += others + ["    )"]
+    else:
+        lines.append("    return True")
 
-        return NotImplemented
+    if locs:
+        # If we need references to the cmpspecs, add them in the func sig
+        cached_args_list = ', '.join(cached_args)
+        lines[0] = "def __eq__(self, other, %s):" % (cached_args_list,)
 
-    return __eq__, __ne__
+    script = "\n".join(lines)
+    globs = {}
+    bytecode = compile(script, unique_filename, "exec")
+    eval(bytecode, globs, locs)
+
+    # In order of debuggers like PDB being able to step through the code,
+    # we add a fake linecache entry.
+    linecache.cache[unique_filename] = (
+        len(script),
+        None,
+        script.splitlines(True),
+        unique_filename,
+    )
+    return locs["__eq__"], __ne__
 
 
 def _make_order(cls, attrs):

--- a/tests/test_cmp.py
+++ b/tests/test_cmp.py
@@ -1,0 +1,42 @@
+"""
+Tests for equality and ordering methods from `attrib._make`
+when a CompSpec object is specified.
+"""
+
+import pytest
+
+import attr
+
+from .utils import simple_class
+
+
+EqC = simple_class(eq=True)
+EqCSlots = simple_class(eq=True, slots=True)
+
+
+# ObjRequiringCustomEq is a simple object that throw an ValueError when
+# we naively try obj1 == obj2. This simulates what happens when we compare
+# numpy arrays or pandas dataframes.
+@attr.s(eq=False)
+class ObjRequiringCustomEq(object):
+
+    value = attr.ib()
+
+    def __eq__(self, other):
+        raise ValueError("Can't compare ObjRequiringCustomEq using __eq__")
+
+
+class TestCmpSpec(object):
+    """
+    Tests for equality and ordering when a CompSpec object is specified.
+    """
+
+    @pytest.mark.parametrize("cls", [EqC, EqCSlots])
+    def test_eq_exception(self, cls):
+        """
+        Test for eq method when attribute does not conform to default protocol.
+        """
+        with pytest.raises(ValueError):
+            cls(ObjRequiringCustomEq(1), 2) == cls(ObjRequiringCustomEq(1), 2)
+        with pytest.raises(ValueError):
+            cls(ObjRequiringCustomEq(1), 2) != cls(ObjRequiringCustomEq(1), 2)

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -832,12 +832,20 @@ class TestFilenames(object):
             == "<attrs generated init tests.test_dunders.C>"
         )
         assert (
+            OriginalC.__eq__.__code__.co_filename
+            == "<attrs generated eq tests.test_dunders.C>"
+        )
+        assert (
             OriginalC.__hash__.__code__.co_filename
             == "<attrs generated hash tests.test_dunders.C>"
         )
         assert (
             C.__init__.__code__.co_filename
             == "<attrs generated init tests.test_dunders.C-2>"
+        )
+        assert (
+            C.__eq__.__code__.co_filename
+            == "<attrs generated eq tests.test_dunders.C-2>"
         )
         assert (
             C.__hash__.__code__.co_filename

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -832,20 +832,12 @@ class TestFilenames(object):
             == "<attrs generated init tests.test_dunders.C>"
         )
         assert (
-            OriginalC.__eq__.__code__.co_filename
-            == "<attrs generated eq tests.test_dunders.C>"
-        )
-        assert (
             OriginalC.__hash__.__code__.co_filename
             == "<attrs generated hash tests.test_dunders.C>"
         )
         assert (
             C.__init__.__code__.co_filename
             == "<attrs generated init tests.test_dunders.C-2>"
-        )
-        assert (
-            C.__eq__.__code__.co_filename
-            == "<attrs generated eq tests.test_dunders.C-2>"
         )
         assert (
             C.__hash__.__code__.co_filename

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -218,7 +218,7 @@ class TestTransformAttrs(object):
             "No mandatory attributes allowed after an attribute with a "
             "default value or factory.  Attribute in question: Attribute"
             "(name='y', default=NOTHING, validator=None, repr=True, "
-            "eq=True, order=True, hash=None, init=True, "
+            "eq=True, order=True, cmpspec=None, hash=None, init=True, "
             "metadata=mappingproxy({}), type=None, converter=None, "
             "kw_only=False)",
         ) == e.value.args


### PR DESCRIPTION
I've implemented the initial part of issue #435. I wanted to stop at this point and get some feedback in case you guys think I'm going in the wrong direction.

The main idea of how this feature would be used can be found in ``test_cmp.py``.

I did the basics of the check list below, and I tried my best to update the ``.pyi`` but I'm not sure whether what I did is correct. If this goes through, I'll update the documentation once we have all features down.

- [x] Added **tests** for changed code.
- [**?**] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [**not yet**] ...and used in the stub test file `tests/typing_example.py`.
- [**not yet**] Updated **documentation** for changed code.
    - [**not yet**] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/master/src/attr/__init__.py) file.
- [**not yet**] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).
