### PR TITLE
Fix typo in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 def read(*parts):
     """
-    Build an absolute path from *parts* and and return the contents of the
+    Build an absolute path from *parts* and return the contents of the
     resulting file.  Assume UTF-8 encoding.
     """
     with codecs.open(os.path.join(HERE, *parts), "rb", "utf-8") as f:


### PR DESCRIPTION
This typo was noticed when copy/pasting the `read` function into my own
`setup.py`.

Thanks a lot, Hynek!

modified:   setup.py

# Pull Request Check List

- [-] Added **tests** for changed code.
- [-] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/strategies.py).
- [-] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [-] ...and used in the stub test file `tests/typing_example.py`.
- [-] Updated **documentation** for changed code.
    - [-] New functions/classes have to be added to `docs/api.rst` by hand.
    - [-] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [-] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/master/src/attr/__init__.py) file.
- [-] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [-] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
