### PR TITLE
Add new feature: attred. Docs and tests are included.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist
 docs/_build/
 htmlcov
 pip-wheel-metadata
+venv/

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -141,6 +141,21 @@ Core
       C(x=[1, 2, 3], y={1, 2, 3})
 
 
+.. autofunction:: attr.ed
+
+   It is a decorator. Takes any number of keyword arguments and applies those key-values to decorated callable
+
+   For example:
+
+   .. doctest::
+
+      >>> @attr.ed(verbose_name='make_request')
+      ... def mkreq(*args, **kwargs):
+      ...     ...
+      >>> mkreq.verbose_name
+      make_request
+
+
 Exceptions
 ----------
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -283,6 +283,31 @@ Other times, all you want is a tuple and ``attrs`` won't let you down:
    True
 
 
+Attred
+------
+
+Sometimes you want to set some attributes on function, for example, when working with django admin.
+You normally do something like this:
+
+.. doctest::
+
+   >>> def full_name(user):
+   ...     return "{} {}".format(user.first_name, user.last_name)
+   >>> full_name.short_description = "Full Name"
+
+And here is the way you can do it with attr.ed:
+
+.. doctest::
+
+   >>> @attr.ed(short_description="Full Name")
+   ... def full_name(user):
+   ...     return "{} {}".format(user.first_name, user.last_name)
+
+The result is the same.
+
+Attr.ed also works on classes (also affects their instances), methods, etc.
+
+
 Defaults
 --------
 

--- a/src/attr/__init__.py
+++ b/src/attr/__init__.py
@@ -67,4 +67,5 @@ __all__ = [
     "set_run_validators",
     "validate",
     "validators",
+    "ed",
 ]

--- a/src/attr/__init__.py
+++ b/src/attr/__init__.py
@@ -17,6 +17,7 @@ from ._make import (
     validate,
 )
 from ._version_info import VersionInfo
+from .attred import attred
 
 
 __version__ = "20.1.0.dev0"
@@ -37,6 +38,7 @@ __copyright__ = "Copyright (c) 2015 Hynek Schlawack"
 
 s = attributes = attrs
 ib = attr = attrib
+ed = attred
 dataclass = partial(attrs, auto_attribs=True)  # happy Easter ;)
 
 

--- a/src/attr/attred.py
+++ b/src/attr/attred.py
@@ -1,0 +1,10 @@
+from typing import Callable
+
+
+def attred(**attrs):
+    def inner(callabl: Callable):
+        for attr_name, attr_value in attrs.items():
+            setattr(callabl, attr_name, attr_value)
+        return callabl
+
+    return inner

--- a/src/attr/attred.py
+++ b/src/attr/attred.py
@@ -2,6 +2,12 @@ from typing import Callable
 
 
 def attred(**attrs):
+    """
+    Takes any number of keyword arguments and applies those key-values to
+    decorated callable
+
+    .. versionadded:: 20.1.0
+    """
     def inner(callabl: Callable):
         for attr_name, attr_value in attrs.items():
             setattr(callabl, attr_name, attr_value)

--- a/src/attr/attred.py
+++ b/src/attr/attred.py
@@ -8,6 +8,7 @@ def attred(**attrs):
 
     .. versionadded:: 20.1.0
     """
+
     def inner(callabl: Callable):
         for attr_name, attr_value in attrs.items():
             setattr(callabl, attr_name, attr_value)

--- a/tests/test_attred.py
+++ b/tests/test_attred.py
@@ -1,0 +1,34 @@
+import attr
+
+
+class TestAttred(object):
+    def test_on_function(self):
+        @attr.ed(short_description="Full Name")
+        def example_django_admin_function_full_name():
+            first_name = "Attr"
+            last_name = "Ed"
+            return "{} {}".format(first_name, last_name)
+
+        assert (
+            "Full Name"
+            == example_django_admin_function_full_name.short_description
+        )
+
+    def test_on_method(self):
+        class Model:
+            first_name = "Attr"
+            last_name = "Ed"
+
+            @attr.ed(short_description="Full Name")
+            def get_full_name(self):
+                return "{} {}".format(self.first_name, self.last_name)
+
+        assert "Full Name" == Model().get_full_name.short_description
+
+    def test_on_class_and_instance(self):
+        @attr.ed(short_description="Full Name")
+        class AttrEd:
+            ...
+
+        assert "Full Name" == AttrEd.short_description
+        assert "Full Name" == AttrEd().short_description


### PR DESCRIPTION
# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-atts/attrs/blob/master/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [x] ...and used in the stub test file `tests/typing_example.py`.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/master/src/attr/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!

----------------

First of all, I marked as done check-list item about hypothesis, about stubs and changelog just because template says "check it anyway", but I didn't make them.

So, **attred** is a decorator that takes any number of kwargs and apply key-vakue pairs to decorated callable object. Docs and tests are included.
