### PR TITLE
Add documentation about string annotations

### DIFF
--- a/docs/types.rst
+++ b/docs/types.rst
@@ -35,8 +35,13 @@ Attributes that only carry a class annotation do not have that object so trying 
 
 Please note that types -- however added -- are *only metadata* that can be queried from the class and they aren't used for anything out of the box!
 
-In practice, their biggest usefulness shows in combination with mypy_ or pytype_ that both have dedicated support for ``attrs`` classes.
+Because Python does not allow references to a class object before the class is defined,
+types may be defined as string literals, so-called *forward references*.
+Also, starting in Python 3.10 (:pep:`526`) **all** annotations will be string literals.
+When this happens, ``attrs`` will simply put these string literals into the ``type`` attributes.
+If you need to resolve these to real types, you can call `attr.resolve_types` which will update the attribute in place.
 
+In practice, their biggest usefulness shows in combination with mypy_ or pytype_ that both have dedicated support for ``attrs`` classes.
 
 mypy
 ----


### PR DESCRIPTION
# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.

- [x] Added **tests** for changed code.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [x] ...and used in the stub test file `tests/typing_example.py`.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/master/src/attr/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
