### PR TITLE
Fix auto-detection of eq/ne in NG APIs

### DIFF
--- a/src/attr/_next_gen.py
+++ b/src/attr/_next_gen.py
@@ -28,7 +28,7 @@ def define(
     kw_only=False,
     cache_hash=False,
     auto_exc=True,
-    eq=True,
+    eq=None,
     order=False,
     auto_detect=True,
     getstate_setstate=None,

--- a/tests/test_next_gen.py
+++ b/tests/test_next_gen.py
@@ -133,3 +133,18 @@ class TestNextGen:
 
         with pytest.raises(attr.exceptions.FrozenInstanceError):
             f.x = 2
+
+    def test_auto_detect_eq(self):
+        """
+        auto_detect=True works for eq.
+
+        Regression test for #670.
+        """
+
+        @attr.define
+        class C:
+            def __eq__(self, o):
+                raise ValueError()
+
+        with pytest.raises(ValueError):
+            C() == C()


### PR DESCRIPTION
By setting eq to True by default, it forces `__eq__`/`__ne__` to be written. Setting to None fixes it.

fixes #670