### PR TITLE
Doc typo: into -> in

### DIFF
--- a/docs/init.rst
+++ b/docs/init.rst
@@ -131,7 +131,7 @@ This is why ``attrs`` comes with factory options.
 Validators
 ----------
 
-Another thing that definitely *does* belong into ``__init__`` is checking the resulting instance for invariants.
+Another thing that definitely *does* belong in ``__init__`` is checking the resulting instance for invariants.
 This is why ``attrs`` has the concept of validators.
 
 


### PR DESCRIPTION
- [x] Added **tests** for changed code.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [x] ...and used in the stub test file `tests/typing_example.py`.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/master/src/attr/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).
