### PR TITLE
Ignore inherited field when comparing Attributes

### DIFF
--- a/changelog.d/684.change.rst
+++ b/changelog.d/684.change.rst
@@ -1,0 +1,1 @@
+The ``inherited`` field of ``attr.Attribute`` (introduced in 20.1.0) instances is not considered when hashing and comparing anymore.

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -2185,6 +2185,8 @@ class Attribute(object):
 
     .. versionadded:: 20.1.0 *inherited*
     .. versionadded:: 20.1.0 *on_setattr*
+    .. versionchanged:: 20.2.0 *inherited* is not taken into account for
+        equality checks and hashing anymore.
 
     For the full version history of the fields, see `attr.ib`.
     """
@@ -2354,8 +2356,11 @@ _a = [
 ]
 
 Attribute = _add_hash(
-    _add_eq(_add_repr(Attribute, attrs=_a), attrs=_a),
-    attrs=[a for a in _a if a.hash],
+    _add_eq(
+        _add_repr(Attribute, attrs=_a),
+        attrs=[a for a in _a if a.name != "inherited"],
+    ),
+    attrs=[a for a in _a if a.hash and a.name != "inherited"],
 )
 
 

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -691,6 +691,26 @@ class TestAttributes(object):
             class C(object):
                 x = attr.ib(factory=Factory(list))
 
+    def test_inherited_does_not_affect_hashing_and_equality(self):
+        """
+        Whether or not an Attribute has been inherited doesn't affect how it's
+        hashed and compared.
+        """
+
+        @attr.s
+        class BaseClass(object):
+            x = attr.ib()
+
+        @attr.s
+        class SubClass(BaseClass):
+            pass
+
+        ba = attr.fields(BaseClass)[0]
+        sa = attr.fields(SubClass)[0]
+
+        assert ba == sa
+        assert hash(ba) == hash(sa)
+
 
 @pytest.mark.skipif(PY2, reason="keyword-only arguments are PY3-only.")
 class TestKeywordOnlyAttributes(object):


### PR DESCRIPTION
Although technically, `inherited` is part of the structure, practically it exposes a very confusing behavior because by subclassing the attribute suddenly doesn't compare equal although it _is_ equal by all logical standards.

fixes #682
