### PR TITLE
Make `zope` a semi-optional test dependency

### DIFF
--- a/changelog.d/685.change.rst
+++ b/changelog.d/685.change.rst
@@ -1,0 +1,1 @@
+``zope.interface`` is now a "soft dependency" when running the test suite; if ``zope.interface`` is not installed when running the test suite, the interface-related tests will be automatically skipped.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ multi_line_output=3
 use_parentheses=true
 
 known_first_party="attr"
-known_third_party=["attr", "hypothesis", "pytest", "setuptools", "six", "zope"]
+known_third_party=["attr", "hypothesis", "pytest", "setuptools", "six"]
 
 
 [tool.towncrier]

--- a/setup.py
+++ b/setup.py
@@ -38,16 +38,16 @@ CLASSIFIERS = [
 INSTALL_REQUIRES = []
 EXTRAS_REQUIRE = {
     "docs": ["sphinx", "sphinx-rtd-theme", "zope.interface"],
-    "tests": [
+    "tests_no_zope": [
         # 5.0 introduced toml; parallel was broken until 5.0.2
         "coverage[toml]>=5.0.2",
         "hypothesis",
         "pympler",
         "pytest>=4.3.0",  # 4.3.0 dropped last use of `convert`
         "six",
-        "zope.interface",
     ],
 }
+EXTRAS_REQUIRE["tests"] = EXTRAS_REQUIRE["tests_no_zope"] + ["zope.interface"]
 EXTRAS_REQUIRE["dev"] = (
     EXTRAS_REQUIRE["tests"] + EXTRAS_REQUIRE["docs"] + ["pre-commit"]
 )

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -30,8 +30,13 @@ from .utils import simple_attr
 
 @pytest.fixture(scope="module")
 def zope():
-    import zope
-    import zope.interface
+    try:
+        import zope
+        import zope.interface
+    except ImportError:
+        raise pytest.skip(
+            "zope-related tests skipped when zope.interface is not installed"
+        )
 
     return zope
 
@@ -239,7 +244,6 @@ def ifoo(zope):
     return IFoo
 
 
-@pytest.mark.zope
 class TestProvides(object):
     """
     Tests for `provides`.

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -29,16 +29,16 @@ from .utils import simple_attr
 
 
 @pytest.fixture(scope="module")
-def zope():
+def zope_interface():
+    """Provides ``zope.interface`` if available, skipping the test if not."""
     try:
-        import zope
         import zope.interface
     except ImportError:
         raise pytest.skip(
             "zope-related tests skipped when zope.interface is not installed"
         )
 
-    return zope
+    return zope.interface
 
 
 class TestInstanceOf(object):
@@ -230,8 +230,10 @@ class TestAnd(object):
 
 
 @pytest.fixture(scope="module")
-def ifoo(zope):
-    class IFoo(zope.interface.Interface):
+def ifoo(zope_interface):
+    """Provides a test ``zope.interface.Interface`` in ``zope`` tests."""
+
+    class IFoo(zope_interface.Interface):
         """
         An interface.
         """
@@ -255,12 +257,12 @@ class TestProvides(object):
         """
         assert provides.__name__ in validator_module.__all__
 
-    def test_success(self, zope, ifoo):
+    def test_success(self, zope_interface, ifoo):
         """
         Nothing happens if value provides requested interface.
         """
 
-        @zope.interface.implementer(ifoo)
+        @zope_interface.implementer(ifoo)
         class C(object):
             def f(self):
                 pass

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [pytest]
 addopts = -ra
 testpaths = tests
-markers = zope
 filterwarnings =
     once::Warning
     ignore:::pympler[.*]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [pytest]
 addopts = -ra
 testpaths = tests
+markers = zope
 filterwarnings =
     once::Warning
     ignore:::pympler[.*]


### PR DESCRIPTION
For the admittedly small number of people who don't care about support for `zope.interface`, it is unnecessary extra work to support even a test-only dependency on `zope`.

The `zope`-specific tests are relatively contained, however, and with judicious use of pytest fixtures, we can make it so that `zope` is not a required dependency when skipping tests marked with `pytest.mark.zope`.

This allows users to test everything but the `zope`-specific tests with no `zope` dependency with:

```
$ TOX_AP_TEST_EXTRAS="tests_no_zope" tox -e <env> -- -m 'not zope'
```

I realize that this is unusual and maybe not a maintenance burden you want to carry upstream, but it would smooth the process of importing `attrs` upstream into a certain large company's monorepo... I'm fine with a response that's basically "Enough with your weird nonsense, Paul".

I didn't bother with documentation or a news fragment yet because I figured there's a high likelihood that this wouldn't be accepted.

# Pull Request Check List

- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).