### PR TITLE
[RFC] kw_only python 2 backport

### DIFF
--- a/changelog.d/700.change.rst
+++ b/changelog.d/700.change.rst
@@ -1,0 +1,1 @@
+``kw_only=True`` now works on Python 2.

--- a/changelog.d/700.changing.rst
+++ b/changelog.d/700.changing.rst
@@ -1,0 +1,1 @@
+Added support for `kw_only=True` on Python 2.

--- a/changelog.d/700.changing.rst
+++ b/changelog.d/700.changing.rst
@@ -1,1 +1,0 @@
-Added support for `kw_only=True` on Python 2.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -146,7 +146,7 @@ On Python 3 it overrides the implicit detection.
 Keyword-only Attributes
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-You can also add `keyword-only <https://docs.python.org/3/glossary.html#keyword-only-parameter>`_ attributes:
+You can also add `keyword-only <https://docs.python.org/3/glossary.html#keyword-only-parameter>`_ attributes (even on Python 2):
 
 .. doctest::
 
@@ -159,8 +159,6 @@ You can also add `keyword-only <https://docs.python.org/3/glossary.html#keyword-
     TypeError: A() missing 1 required keyword-only argument: 'a'
     >>> A(a=1)
     A(a=1)
-
-``attrs`` supports ``kw_only`` attributes even on Python 2, though error messages are default python error messages and may be a bit confusing.
 
 ``kw_only`` may also be specified at via ``attr.s``, and will apply to all attributes:
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -146,7 +146,7 @@ On Python 3 it overrides the implicit detection.
 Keyword-only Attributes
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-When using ``attrs`` on Python 3, you can also add `keyword-only <https://docs.python.org/3/glossary.html#keyword-only-parameter>`_ attributes:
+You can also add `keyword-only <https://docs.python.org/3/glossary.html#keyword-only-parameter>`_ attributes:
 
 .. doctest::
 
@@ -159,6 +159,8 @@ When using ``attrs`` on Python 3, you can also add `keyword-only <https://docs.p
     TypeError: A() missing 1 required keyword-only argument: 'a'
     >>> A(a=1)
     A(a=1)
+
+``attrs`` supports ``kw_only`` attributes even on Python 2, though error messages are default python error messages and may be a bit confusing.
 
 ``kw_only`` may also be specified at via ``attr.s``, and will apply to all attributes:
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -146,7 +146,7 @@ On Python 3 it overrides the implicit detection.
 Keyword-only Attributes
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-You can also add `keyword-only <https://docs.python.org/3/glossary.html#keyword-only-parameter>`_ attributes (even on Python 2):
+You can also add `keyword-only <https://docs.python.org/3/glossary.html#keyword-only-parameter>`_ attributes:
 
 .. doctest::
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1947,10 +1947,8 @@ if PY2:
         """
         assert kw_only_args
         lines = ["try:"]
-        lines += [
-            "    " + _unpack_kw_only_py2(*arg.split("="))
-            for arg in kw_only_args
-        ]
+        for arg in kw_only_args:
+            lines.append("    " + _unpack_kw_only_py2(*arg.split("=")))
         lines += """\
 except KeyError as _key_error:
     _msg = '__init__() missing required keyword-only argument: %s'

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1905,29 +1905,35 @@ def _assign_with_converter(attr_name, value_var, has_on_setattr):
     )
 
 
-def _unpack_kw_only_py2(attr_name, default=None):
-    """
-    Unpack *attr_name* for _kw_only dict. Used to support kw_only arguments in py2.
-    """
-    if default is not None:
-        arg_default = ", %s" % default
-    else:
-        arg_default = ""
-    return "%s = _kw_only.pop('%s'%s)" % (attr_name, attr_name, arg_default)
+if PY2:
 
+    def _unpack_kw_only_py2(attr_name, default=None):
+        """
+        Unpack *attr_name* for _kw_only dict. Used to support kw_only arguments in py2.
+        """
+        if default is not None:
+            arg_default = ", %s" % default
+        else:
+            arg_default = ""
+        return "%s = _kw_only.pop('%s'%s)" % (
+            attr_name,
+            attr_name,
+            arg_default,
+        )
 
-def _unpack_kw_only_lines_py2(kw_only_args):
-    lines = ["try:"]
-    lines += [
-        "    " + _unpack_kw_only_py2(*arg.split("=")) for arg in kw_only_args
-    ]
-    lines += [
-        "except KeyError as _key_error:",
-        "    raise TypeError('__init__() missing required keyword-only argument: %s' % _key_error)",
-        "if _kw_only:",
-        "    raise TypeError('__init__() got an unexpected keyword argument %r' % next(iter(_kw_only)))",
-    ]
-    return lines
+    def _unpack_kw_only_lines_py2(kw_only_args):
+        lines = ["try:"]
+        lines += [
+            "    " + _unpack_kw_only_py2(*arg.split("="))
+            for arg in kw_only_args
+        ]
+        lines += [
+            "except KeyError as _key_error:",
+            "    raise TypeError('__init__() missing required keyword-only argument: %s' % _key_error)",
+            "if _kw_only:",
+            "    raise TypeError('__init__() got an unexpected keyword argument %r' % next(iter(_kw_only)))",
+        ]
+        return lines
 
 
 def _attrs_to_init_script(

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1948,7 +1948,7 @@ if PY2:
         assert kw_only_args
         lines = ["try:"]
         lines.extend(
-            lines.append("    " + _unpack_kw_only_py2(*arg.split("=")))
+            "    " + _unpack_kw_only_py2(*arg.split("="))
             for arg in kw_only_args
         )
         lines += """\

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1945,11 +1945,21 @@ if PY2:
         """
         Unpack all *kw_only_args* from _kw_only dict and handle errors.
 
-        Given a list of strings "{attr_name}" and "{attr_name}={attr_default}"
-        generate a list of lines "{attr_name} = _kw_only.pop('{attr_name}')"
-        and "{attr_name} = _kw_only.pop('{attr_name}', {attr_default}).
-        If required attr is missing in _kw_only dict or extra key is passed
-        - generated code raises TypeError similar to python builtin.
+        Given a list of strings {attr_name} and {attr_name}={default}
+        generates list of lines of code that pop attrs from _kw_only dict and
+        raise TypeError similar to builtin if required attr is missing or
+        extra key is passed.
+
+        >>> print("\n".join(_unpack_kw_only_lines_py2(["a", "b=42"])))
+        try:
+            a = _kw_only.pop('a')
+            b = _kw_only.pop('b', 42)
+        except KeyError as _key_error:
+            raise TypeError(
+                ...
+        if _kw_only:
+            raise TypeError(
+                ...
         """
         lines = ["try:"]
         lines.extend(

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1945,7 +1945,7 @@ if PY2:
         """
         Unpack all *kw_only_args* from _kw_only dict and handle errors.
 
-        Given a list of strings {attr_name} and {attr_name}={default}
+        Given a list of strings "{attr_name}" and "{attr_name}={default}"
         generates list of lines of code that pop attrs from _kw_only dict and
         raise TypeError similar to builtin if required attr is missing or
         extra key is passed.

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1945,6 +1945,7 @@ if PY2:
         """
         Unpack all *kw_only_args* from _kw_only dict and handle errors.
         """
+        assert kw_only_args
         lines = ["try:"]
         lines += [
             "    " + _unpack_kw_only_py2(*arg.split("="))

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1944,8 +1944,13 @@ if PY2:
     def _unpack_kw_only_lines_py2(kw_only_args):
         """
         Unpack all *kw_only_args* from _kw_only dict and handle errors.
+
+        Given a list of strings "{attr_name}" and "{attr_name}={attr_default}"
+        generate a list of lines "{attr_name} = _kw_only.pop('{attr_name}')"
+        and "{attr_name} = _kw_only.pop('{attr_name}', {attr_default}).
+        If required attr is missing in _kw_only dict or extra key is passed
+        - generated code raises TypeError with TypeError similar to builtins.
         """
-        assert kw_only_args
         lines = ["try:"]
         lines.extend(
             "    " + _unpack_kw_only_py2(*arg.split("="))
@@ -1953,11 +1958,14 @@ if PY2:
         )
         lines += """\
 except KeyError as _key_error:
-    _msg = '__init__() missing required keyword-only argument: %s'
-    raise TypeError(_msg % _key_error)
+    raise TypeError(
+        '__init__() missing required keyword-only argument: %s' % _key_error
+    )
 if _kw_only:
-    _msg = '__init__() got an unexpected keyword argument %r'
-    raise TypeError(_msg % next(iter(_kw_only)))
+    raise TypeError(
+        '__init__() got an unexpected keyword argument %r' 
+        % next(iter(_kw_only))
+    )
 """.split(
             "\n"
         )

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1947,8 +1947,10 @@ if PY2:
         """
         assert kw_only_args
         lines = ["try:"]
-        for arg in kw_only_args:
+        lines.extend(
             lines.append("    " + _unpack_kw_only_py2(*arg.split("=")))
+            for arg in kw_only_args
+        )
         lines += """\
 except KeyError as _key_error:
     _msg = '__init__() missing required keyword-only argument: %s'

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1949,7 +1949,7 @@ if PY2:
         generate a list of lines "{attr_name} = _kw_only.pop('{attr_name}')"
         and "{attr_name} = _kw_only.pop('{attr_name}', {attr_default}).
         If required attr is missing in _kw_only dict or extra key is passed
-        - generated code raises TypeError with TypeError similar to builtins.
+        - generated code raises TypeError similar to python builtin.
         """
         lines = ["try:"]
         lines.extend(

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1963,7 +1963,7 @@ except KeyError as _key_error:
     )
 if _kw_only:
     raise TypeError(
-        '__init__() got an unexpected keyword argument %r' 
+        '__init__() got an unexpected keyword argument %r'
         % next(iter(_kw_only))
     )
 """.split(

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1907,6 +1907,7 @@ def _assign_with_converter(attr_name, value_var, has_on_setattr):
 
 
 if PY2:
+
     def _unpack_kw_only_py2(attr_name, default=None):
         """
         Unpack *attr_name* from _kw_only dict.
@@ -1920,7 +1921,6 @@ if PY2:
             attr_name,
             arg_default,
         )
-
 
     def _unpack_kw_only_lines_py2(kw_only_args):
         """
@@ -1938,7 +1938,9 @@ except KeyError as _key_error:
 if _kw_only:
     _msg = '__init__() got an unexpected keyword argument %r'
     raise TypeError(_msg % next(iter(_kw_only)))
-""".split('\n')
+""".split(
+            "\n"
+        )
         return lines
 
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -223,6 +223,7 @@ def attrib(
     .. deprecated:: 19.2.0 *cmp* Removal on or after 2021-06-01.
     .. versionadded:: 19.2.0 *eq* and *order*
     .. versionadded:: 20.1.0 *on_setattr*
+    .. versionchanged:: 20.3.0 *kw_only* supported on python 2
     """
     eq, order = _determine_eq_order(cmp, eq, order, True)
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -223,7 +223,7 @@ def attrib(
     .. deprecated:: 19.2.0 *cmp* Removal on or after 2021-06-01.
     .. versionadded:: 19.2.0 *eq* and *order*
     .. versionadded:: 20.1.0 *on_setattr*
-    .. versionchanged:: 20.3.0 *kw_only* supported on python 2
+    .. versionchanged:: 20.3.0 *kw_only* backported to Python 2
     """
     eq, order = _determine_eq_order(cmp, eq, order, True)
 
@@ -1906,31 +1906,32 @@ def _assign_with_converter(attr_name, value_var, has_on_setattr):
     )
 
 
-def _unpack_kw_only_py2(attr_name, default=None):
-    """
-    Unpack *attr_name* from _kw_only dict.
-    """
-    if default is not None:
-        arg_default = ", %s" % default
-    else:
-        arg_default = ""
-    return "%s = _kw_only.pop('%s'%s)" % (
-        attr_name,
-        attr_name,
-        arg_default,
-    )
+if PY2:
+    def _unpack_kw_only_py2(attr_name, default=None):
+        """
+        Unpack *attr_name* from _kw_only dict.
+        """
+        if default is not None:
+            arg_default = ", %s" % default
+        else:
+            arg_default = ""
+        return "%s = _kw_only.pop('%s'%s)" % (
+            attr_name,
+            attr_name,
+            arg_default,
+        )
 
 
-def _unpack_kw_only_lines_py2(kw_only_args):
-    """
-    Unpack all *kw_only_args* from _kw_only dict and handle errors.
-    """
-    lines = ["try:"]
-    lines += [
-        "    " + _unpack_kw_only_py2(*arg.split("="))
-        for arg in kw_only_args
-    ]
-    lines += """\
+    def _unpack_kw_only_lines_py2(kw_only_args):
+        """
+        Unpack all *kw_only_args* from _kw_only dict and handle errors.
+        """
+        lines = ["try:"]
+        lines += [
+            "    " + _unpack_kw_only_py2(*arg.split("="))
+            for arg in kw_only_args
+        ]
+        lines += """\
 except KeyError as _key_error:
     _msg = '__init__() missing required keyword-only argument: %s'
     raise TypeError(_msg % _key_error)
@@ -1938,7 +1939,7 @@ if _kw_only:
     _msg = '__init__() got an unexpected keyword argument %r'
     raise TypeError(_msg % next(iter(_kw_only)))
 """.split('\n')
-    return lines
+        return lines
 
 
 def _attrs_to_init_script(

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -773,6 +773,23 @@ class TestKeywordOnlyAttributes(object):
                 "missing 1 required keyword-only argument: 'x'"
             ) in e.value.args[0]
 
+    def test_keyword_only_attributes_unexpected(self):
+        """
+        Raises `TypeError` when unexpected keyword argument passed.
+        """
+
+        @attr.s
+        class C(object):
+            x = attr.ib(kw_only=True)
+
+        with pytest.raises(TypeError) as e:
+            C(x=5, y=10)
+
+        assert(
+            "got an unexpected keyword argument 'y'"
+        ) in e.value.args[0]
+
+
     def test_keyword_only_attributes_can_come_in_any_order(self):
         """
         Mandatory vs non-mandatory attr order only matters when they are part

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -766,7 +766,7 @@ class TestKeywordOnlyAttributes(object):
 
         if PY2:
             assert (
-                "__attrs_unpack_kw_only__() takes exactly 1 argument (0 given)"
+                "missing required keyword-only argument: 'x'"
             ) in e.value.args[0]
         else:
             assert (

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -789,7 +789,7 @@ class TestKeywordOnlyAttributes(object):
         with pytest.raises(TypeError) as e:
             C(x=5, y=10)
 
-        assert ("got an unexpected keyword argument 'y'") in e.value.args[0]
+        assert "got an unexpected keyword argument 'y'" in e.value.args[0]
 
     def test_keyword_only_attributes_can_come_in_any_order(self):
         """

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -712,7 +712,6 @@ class TestAttributes(object):
         assert hash(ba) == hash(sa)
 
 
-@pytest.mark.skipif(PY2, reason="keyword-only arguments are PY3-only.")
 class TestKeywordOnlyAttributes(object):
     """
     Tests for keyword-only attributes.
@@ -724,7 +723,7 @@ class TestKeywordOnlyAttributes(object):
         """
 
         @attr.s
-        class C:
+        class C(object):
             a = attr.ib()
             b = attr.ib(default=2, kw_only=True)
             c = attr.ib(kw_only=True)
@@ -743,7 +742,7 @@ class TestKeywordOnlyAttributes(object):
         """
 
         @attr.s
-        class C:
+        class C(object):
             x = attr.ib(init=False, default=0, kw_only=True)
             y = attr.ib()
 
@@ -759,15 +758,20 @@ class TestKeywordOnlyAttributes(object):
         """
 
         @attr.s
-        class C:
+        class C(object):
             x = attr.ib(kw_only=True)
 
         with pytest.raises(TypeError) as e:
             C()
 
-        assert (
-            "missing 1 required keyword-only argument: 'x'"
-        ) in e.value.args[0]
+        if PY2:
+            assert (
+                "__attrs_unpack_kw_only__() takes exactly 1 argument (0 given)"
+            ) in e.value.args[0]
+        else:
+            assert (
+                "missing 1 required keyword-only argument: 'x'"
+            ) in e.value.args[0]
 
     def test_keyword_only_attributes_can_come_in_any_order(self):
         """
@@ -778,7 +782,7 @@ class TestKeywordOnlyAttributes(object):
         """
 
         @attr.s
-        class C:
+        class C(object):
             a = attr.ib(kw_only=True)
             b = attr.ib(kw_only=True, default="b")
             c = attr.ib(kw_only=True)
@@ -807,7 +811,7 @@ class TestKeywordOnlyAttributes(object):
         """
 
         @attr.s
-        class Base:
+        class Base(object):
             x = attr.ib(default=0)
 
         @attr.s
@@ -826,7 +830,7 @@ class TestKeywordOnlyAttributes(object):
         """
 
         @attr.s(kw_only=True)
-        class C:
+        class C(object):
             x = attr.ib()
             y = attr.ib(kw_only=True)
 
@@ -845,7 +849,7 @@ class TestKeywordOnlyAttributes(object):
         """
 
         @attr.s
-        class Base:
+        class Base(object):
             x = attr.ib(default=0)
 
         @attr.s(kw_only=True)
@@ -868,7 +872,7 @@ class TestKeywordOnlyAttributes(object):
         """
 
         @attr.s
-        class KwArgBeforeInitFalse:
+        class KwArgBeforeInitFalse(object):
             kwarg = attr.ib(kw_only=True)
             non_init_function_default = attr.ib(init=False)
             non_init_keyword_default = attr.ib(
@@ -896,7 +900,7 @@ class TestKeywordOnlyAttributes(object):
         """
 
         @attr.s
-        class KwArgBeforeInitFalseParent:
+        class KwArgBeforeInitFalseParent(object):
             kwarg = attr.ib(kw_only=True)
 
         @attr.s
@@ -922,23 +926,6 @@ class TestKeywordOnlyAttributesOnPy2(object):
     """
     Tests for keyword-only attribute behavior on py2.
     """
-
-    def test_syntax_error(self):
-        """
-        Keyword-only attributes raise Syntax error on ``__init__`` generation.
-        """
-
-        with pytest.raises(PythonTooOldError):
-
-            @attr.s(kw_only=True)
-            class ClassLevel(object):
-                a = attr.ib()
-
-        with pytest.raises(PythonTooOldError):
-
-            @attr.s()
-            class AttrLevel(object):
-                a = attr.ib(kw_only=True)
 
     def test_no_init(self):
         """

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -785,10 +785,7 @@ class TestKeywordOnlyAttributes(object):
         with pytest.raises(TypeError) as e:
             C(x=5, y=10)
 
-        assert(
-            "got an unexpected keyword argument 'y'"
-        ) in e.value.args[0]
-
+        assert ("got an unexpected keyword argument 'y'") in e.value.args[0]
 
     def test_keyword_only_attributes_can_come_in_any_order(self):
         """


### PR DESCRIPTION
Hello!

Thank you for bringing an awesome package and supporting Python 2 in 2020!

In my experience I find kw_only attributes really addictive, as they allow to inherit from classes ignoring attributes with defaults. Unfortunately, they don't work on Python 2, so it's actually impossible to write some compatible code. 

Even writing `__init__` by hand:
```python
@attr.s(kw_only=not PY2)
class Base(object):
    kw_only1 = attr.ib(default=None)
    kw_only2 = attr.ib(default=42)

@attr.s(init=not PY2)
class Child(Base):
    attr1 = attr.ib()
    attr2 = attr.ib()

    if PY2:
        def __init__(self, attr1, attr2, **kwargs):
            super(Child, self).__init__(**kwargs)
            self.attr1, self.attr2 = attr1, attr2
```
Will fail, as `attrs` disallows mandatory attributes after an attribute with a default value or factory. Even this non-working code snippet seems as boilerplate, so in this PR I propose a backport of kw_only `attr.ib` to Python 2.

There are four approaches to implementation that I've tested:
1. Just move kw_only attributes to the end of `__init__`. It's the fastest approach, on my benckmark (3 positional args, 3 kw_only args) it's about ~100ns for argument parsing. However, it doesn't allow kw_only attributes without default values and also doesn't make them real kw_only.
2. Pop from a dictionary of kwargs. This is the slowest approach with a somewhat-reasonable error message, ~400ns for argument parsing.
3. On every `__init__` call create a function that takes kw_only attributes and returns a tuple of unpacked arguments (implemented in this PR). It's slightly faster than previous approach, ~390ns for argument parsing.
4. Cache that function on class instance - it saves ~40-50ns, giving 340ns. I plan to rewrite this PR to use this approach. 

Both approaches with function have error message lacking some information, however it's a default py2 error and the constructor call should be somewhere in the stacktrace.

Is this a desired feature or should it not happen? Should I add some fancy error handling? 

P.S. I'm unfamiliar with changelog.d - should I just add an rst file to the dir? 

# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.  If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.

- [x] Added **tests** for changed code.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [x] ...and used in the stub test file `tests/typing_example.py`.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/master/src/attr/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
