### PR TITLE
WIP: Add an auto-converter, converters and validators

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -436,6 +436,102 @@ Validators
         attr.exceptions.NotCallableError: 'x' must be callable (got 'not a callable' that is a <class 'str'>).
 
 
+.. autofunction:: attr.validators.lt
+
+    For example:
+
+    .. doctest::
+
+        >>> @attr.s
+        ... class C(object):
+        ...     x = attr.ib(validator=attr.validators.lt(3))
+        ...
+        >>> C(2)
+        C(x=2)
+        >>> C(3)
+        Traceback (most recent call last):
+            ...
+        ValueError: 'x' must be < 3: 3
+
+
+.. autofunction:: attr.validators.le
+
+    For example:
+
+    .. doctest::
+
+        >>> @attr.s
+        ... class C(object):
+        ...     x = attr.ib(validator=attr.validators.le(3))
+        ...
+        >>> C(3)
+        C(x=3)
+        >>> C(4)
+        Traceback (most recent call last):
+            ...
+        ValueError: 'x' must be <= 3: 4
+
+
+.. autofunction:: attr.validators.ge
+
+    For example:
+
+    .. doctest::
+
+        >>> @attr.s
+        ... class C(object):
+        ...     x = attr.ib(validator=attr.validators.ge(3))
+        ...
+        >>> C(3)
+        C(x=3)
+        >>> C(2)
+        Traceback (most recent call last):
+            ...
+        ValueError: 'x' must be >= 3: 2
+
+
+.. autofunction:: attr.validators.gt
+
+    For example:
+
+    .. doctest::
+
+        >>> @attr.s
+        ... class C(object):
+        ...     x = attr.ib(validator=attr.validators.gt(3))
+        ...
+        >>> C(4)
+        C(x=4)
+        >>> C(3)
+        Traceback (most recent call last):
+            ...
+        ValueError: 'x' must be > 3: 3
+
+
+.. autofunction:: attr.validators.maxlen
+
+    For example:
+
+    .. doctest::
+
+        >>> @attr.s
+        ... class C(object):
+        ...     x = attr.ib(validator=attr.validators.maxlen(4))
+        ...
+        >>> C('spam')
+        C(x='spam')
+        >>> C(list(range(4)))
+        C(x=[0, 1, 2, 3])
+        >>> C('bacon')
+        Traceback (most recent call last):
+            ...
+        ValueError: Lenght of 'x' must be <= 4: 5
+        >>> C(list(range(5)))
+        Traceback (most recent call last):
+            ...
+        ValueError: Lenght of 'x' must be <= 4: 5
+
+
 .. autofunction:: attr.validators.matches_re
 
     For example:
@@ -548,6 +644,29 @@ Converters
       >>> C(None)
       C(x='')
 
+
+.. autofunction:: attr.converters.to_attrs
+
+.. autofunction:: attr.converters.to_dt
+
+.. autofunction:: attr.converters.to_iterable
+
+.. autofunction:: attr.converters.to_tuple
+
+.. autofunction:: attr.converters.to_mapping
+
+.. autofunction:: attr.converters.to_union
+
+Hooks
+-----
+
+Hooks for automatic data conversion based on type annotations.
+
+.. autofunction:: attr.hooks.make_auto_converter
+
+.. autofunction:: attr.hooks.auto_convert
+
+.. autofunction:: attr.hooks.auto_serialize
 
 .. _api_setters:
 

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -228,6 +228,21 @@ A more realistic example would be to automatically convert data that you, e.g., 
    Data(a=3, b='spam', c=datetime.datetime(2020, 5, 4, 13, 37))
 
 
+Automatically convert data
+++++++++++++++++++++++++++
+
+todo
+
+
+Extend the auto converter
++++++++++++++++++++++++++
+
+todo
+
+
+
+
+
 Customize Value Serialization in ``asdict()``
 ---------------------------------------------
 

--- a/src/attr/__init__.py
+++ b/src/attr/__init__.py
@@ -4,7 +4,7 @@ import sys
 
 from functools import partial
 
-from . import converters, exceptions, filters, setters, validators
+from . import converters, exceptions, filters, hooks, setters, validators
 from ._config import get_run_validators, set_run_validators
 from ._funcs import asdict, assoc, astuple, evolve, has, resolve_types
 from ._make import (
@@ -19,6 +19,7 @@ from ._make import (
     validate,
 )
 from ._version_info import VersionInfo
+from .hooks import auto_convert, auto_serialize
 
 
 __version__ = "20.3.0.dev0"
@@ -52,6 +53,8 @@ __all__ = [
     "attrib",
     "attributes",
     "attrs",
+    "auto_convert",
+    "auto_serialize",
     "converters",
     "evolve",
     "exceptions",
@@ -60,6 +63,7 @@ __all__ = [
     "filters",
     "get_run_validators",
     "has",
+    "hooks",
     "ib",
     "make_class",
     "resolve_types",

--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -18,6 +18,17 @@ else:
     ordered_dict = OrderedDict
 
 
+if sys.version_info[:2] >= (3, 6):
+    from typing import get_args, get_origin
+else:
+
+    def get_args(t):
+        return getattr(t, "__args__", None)
+
+    def get_origin(t):
+        return getattr(t, "__origin__", None)
+
+
 if PY2:
     from collections import Mapping, Sequence
 

--- a/src/attr/converters.py
+++ b/src/attr/converters.py
@@ -4,14 +4,25 @@ Commonly useful converters.
 
 from __future__ import absolute_import, division, print_function
 
+from datetime import datetime
+
 from ._make import NOTHING, Factory, pipe
 
 
 __all__ = [
-    "pipe",
-    "optional",
     "default_if_none",
+    "optional",
+    "pipe",
+    "to_attrs",
+    "to_dt",
+    "to_iterable",
+    "to_mapping",
+    "to_tuple",
+    "to_union",
 ]
+
+
+NoneType = type(None)
 
 
 def optional(converter):
@@ -83,3 +94,164 @@ def default_if_none(default=NOTHING, factory=None):
             return default
 
     return default_if_none_converter
+
+
+def to_attrs(cls):
+    """
+    A converter that creates an instance of *cls* from a dict but leaves
+    instances of that class as they are.
+
+    Classes can define a ``from_dict()`` classmethod which will be called
+    instead of the their `__init__()`.  This can be useful if you want to
+    create different sub classes of *cls* depending on the data (e.g.,
+    a ``Cat`` or a ``Dog`` inheriting ``Animal``).
+
+    :param type cls: The class to convert data to.
+    :returns: The converter function for *cls*.
+    :rtype: callable
+
+    .. versionadded:: 20.3.0
+
+    """
+    type_ = cls.from_dict if hasattr(cls, "from_dict") else cls
+
+    def convert(val):
+        if not isinstance(val, (cls, dict)):
+            raise TypeError(
+                f'Invalid type "{type(val).__name__}"; expected '
+                f'"{cls.__name__}" or "dict".'
+            )
+        return type_(**val) if isinstance(val, dict) else val
+
+    n = cls.__name__
+    convert.__doc__ = f"""
+        Convert *data* to an intance of {n} if it is not already an instance
+        of it.
+
+        :param Union[dict, {n}] data: The input data
+        :returns: The converted data
+        :rtype: {n}
+        :raises TypeError: if *data* is neither a dict nor an instance of {n}.
+        """
+
+    return convert
+
+
+def to_dt(val):
+    """
+    Convert an ISO formatted string to :class:`datetime.datetime`.  Leave the
+    input untouched if it is already a datetime.
+
+    See: :func:`datetime.datetime.fromisoformat`
+
+    :param Union[str, datetime.datetime] data: The input data
+    :returns: A parsed datetime object
+    :rtype: datetime.datetime
+    :raises TypeError: If *val* is neither a str nor a datetime.
+
+    .. versionadded:: 20.3.0
+    """
+    if not isinstance(val, (datetime, str)):
+        raise TypeError(
+            f'Invalid type "{type(val).__name__}"; expected "datetime" or '
+            f'"str".'
+        )
+    return datetime.fromisoformat(val) if isinstance(val, str) else val
+
+
+def to_iterable(cls, converter):
+    """
+    A converter that creates a *cls* iterable (e.g., ``list``) and calls
+    *converter* for each element.
+
+    :param Type[Iterable] cls: The type of the iterable to create
+    :param callable converter: The converter to apply to all items of the
+        input data.
+    :returns: The converter function
+    :rtype: callable
+    """
+
+    def convert(val):
+        return cls(converter(d) for d in val)
+
+    return convert
+
+
+def to_tuple(cls, converters):
+    """
+    A converter that creates a struct-like tuple (or namedtuple or similar)
+    and converts each item via the corresponding converter from *converters*
+
+    The input value must have exactly as many elements as there are converters.
+
+    :param Type[Tuple] cls: The type of the tuple to create
+    :param List[callable] converters: The respective converters for each tuple
+        item.
+    :returns: The converter function
+    :rtype: callable
+    """
+
+    def convert(val):
+        if len(val) != len(converters):
+            raise TypeError(
+                "Value must have {} items but has: {}".format(
+                    len(converters), len(val)
+                )
+            )
+        return cls(c(v) for c, v in zip(converters, val))
+
+    return convert
+
+
+def to_mapping(cls, key_converter, val_converter):
+    """
+    A converter that creates a mapping and converts all keys and values using
+    the respective converters.
+
+    :param Type[Mapping] cls: The mapping type to create (e.g., ``dict``).
+    :param callable key_converter: The converter function to apply to all keys.
+    :param callable val_converter: The converter function to apply to all
+        values.
+    :returns: The converter function
+    :rtype: callable
+    """
+
+    def convert(val):
+        return cls(
+            (key_converter(k), val_converter(v)) for k, v in val.items()
+        )
+
+    return convert
+
+
+def to_union(converters):
+    """
+    A converter that applies a number of converters to the input value and
+    returns the result of the first converter that does not raise a
+    :exc:`TypeError` or :exc:`ValueError`.
+
+    If the input value already has one of the required types, it will be
+    returned unchanged.
+
+    :param List[callable] converters: A list of converters to try on the input.
+    :returns: The converter function
+    :rtype: callable
+
+    """
+
+    def convert(val):
+        if type(val) in converters:
+            # Preserve val as-is if it already has a matching type.
+            # Otherwise float(3.2) would be converted to int
+            # if the converters are [int, float].
+            return val
+        for converter in converters:
+            try:
+                return converter(val)
+            except (TypeError, ValueError):
+                pass
+        raise ValueError(
+            "Failed to convert value to any Union type: {}".format(val)
+        )
+
+    return convert

--- a/src/attr/hooks.py
+++ b/src/attr/hooks.py
@@ -1,0 +1,135 @@
+"""
+Commonly useful hooks.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import sys
+
+from datetime import datetime
+from enum import Enum
+
+from ._compat import get_args, get_origin
+from .converters import (
+    to_attrs,
+    to_dt,
+    to_iterable,
+    to_mapping,
+    to_tuple,
+    to_union,
+)
+
+
+if sys.version_info[:2] >= (3, 6):
+    from typing import Union, get_type_hints
+else:
+    get_type_hints = None
+
+
+__all__ = [
+    "auto_convert",
+    "auto_serialize",
+    "make_auto_converter",
+]
+
+
+def make_auto_converter(converters):
+    """
+    Return a
+
+    """
+    if get_type_hints is None:
+        raise RuntimeError("This function only works from Python 3.6 upwards")
+
+    def auto_convert(cls, attribs):
+        """
+        A field transformer that tries to convert all attribs of a class to their
+        annotated type.
+        """
+        # We cannot use attrs.resolve_types() here,
+        # because "cls" is not yet a finished attrs class:
+        type_hints = get_type_hints(cls)
+        results = []
+        for attrib in attribs:
+            # Do not override explicitly defined converters!
+            if attrib.converter is None:
+                converter = _get_converter(type_hints[attrib.name], converters)
+                attrib = attrib.assoc(converter=converter)
+            results.append(attrib)
+
+        return results
+
+    return auto_convert
+
+
+def _get_converter(
+    type_,
+    converters,
+    iterable_types=frozenset({list, set, frozenset}),
+    tuple_types=frozenset({tuple}),
+    mapping_types=frozenset({dict}),
+):
+    """
+    Recursively resolves concrete and generic types and return a proper converter.
+    """
+    # Detect whether "type_" is a container type.  Currently we need
+    # to check, e.g., for "typing.List".  From python 3.9, we also
+    # need to check for "list" directly.
+    origin = get_origin(type_)
+    if origin is None:
+        # Get converter for concrete type
+        if getattr(type_, "__attrs_attrs__", None) is not None:
+            # Attrs classes
+            converter = to_attrs(type_)
+        else:
+            # Check if type is in converters dict
+            for convert_type, convert_func in converters.items():
+                if issubclass(type_, convert_type):
+                    converter = convert_func
+                    break
+            else:
+                # Fall back to simple types like bool, int, float, str, Enum, ...
+                converter = type_
+    else:
+        # Get converter for generic type
+        args = get_args(type_)
+        if origin in iterable_types:
+            item_converter = _get_converter(args[0], converters)
+            converter = to_iterable(origin, item_converter)
+        elif origin in tuple_types:
+            if len(args) == 2 and args[1] == ...:
+                # "frozen list" variant of tuple
+                item_converter = _get_converter(args[0], converters)
+                converter = to_iterable(tuple, item_converter)
+            else:
+                # "struct" variant of tuple
+                item_converters = [_get_converter(t, converters) for t in args]
+                converter = to_tuple(tuple, item_converters)
+        elif origin in mapping_types:
+            key_converter = _get_converter(args[0], converters)
+            val_converter = _get_converter(args[1], converters)
+            converter = to_mapping(dict, key_converter, val_converter)
+        elif origin is Union:
+            item_converters = [_get_converter(t, converters) for t in args]
+            converter = to_union(item_converters)
+        else:
+            raise TypeError(
+                f"Cannot create converter for generic type: {type_}"
+            )
+
+    return converter
+
+
+auto_convert = make_auto_converter({datetime: to_dt})
+"""Auto-convert :class:`datetime.datetime` as well as other stuff."""
+
+
+def auto_serialize(inst, attrib, value):
+    """Inverse hook to :func:`auto_convert` for use with
+    :func:`attrs.asdict()`.
+    """
+    if isinstance(value, datetime):
+        return datetime.isoformat(value)
+    if isinstance(value, Enum):
+        return value.value
+    return value

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -4,6 +4,9 @@ Tests for `attr.converters`.
 
 from __future__ import absolute_import
 
+import sys
+
+from datetime import datetime, timedelta, timezone
 from distutils.util import strtobool
 
 import pytest
@@ -11,7 +14,17 @@ import pytest
 import attr
 
 from attr import Factory, attrib
-from attr.converters import default_if_none, optional, pipe
+from attr.converters import (
+    default_if_none,
+    optional,
+    pipe,
+    to_attrs,
+    to_dt,
+    to_iterable,
+    to_mapping,
+    to_tuple,
+    to_union,
+)
 
 
 class TestOptional(object):
@@ -99,6 +112,221 @@ class TestDefaultIfNone(object):
         c = default_if_none(default=Factory(list))
 
         assert [] == c(None)
+
+
+class TestToAttrs:
+    """Tests for to_attrs()."""
+
+    def test_from_data(self):
+        """
+        Dicts can be converted to class instances.
+        """
+
+        @attr.s
+        class C:
+            x = attr.ib()
+            y = attr.ib()
+
+        converter = to_attrs(C)
+        assert converter({"x": 2, "y": 3}) == C(2, 3)
+
+    def test_from_inst(self):
+        """
+        Existing instances remain unchanged.
+        """
+
+        @attr.s
+        class C:
+            x = attr.ib()
+            y = attr.ib()
+
+        inst = C(2, 3)
+        converter = to_attrs(C)
+        assert converter(inst) is inst
+
+    @pytest.mark.skipif(
+        sys.version_info < (3, 6),
+        reason="__init_subclass__ is not yet supported",
+    )
+    def test_from_dict_factory(self):
+        """
+        Classes can specify a "from_dict" factory that will be called.
+        """
+
+        @attr.s
+        class Animal:
+            type = attr.ib()
+            __classes__ = {}
+
+            def __init_subclass__(cls, **kwargs):
+                super().__init_subclass__(**kwargs)
+                cls.__classes__[cls.__name__] = cls
+
+            @classmethod
+            def from_dict(cls, **attribs):
+                cls_name = attribs["type"]
+                return cls.__classes__[cls_name](**attribs)
+
+        @attr.s(kw_only=True)
+        class Cat(Animal):
+            x = attr.ib()
+
+        @attr.s(kw_only=True)
+        class Dog(Animal):
+            x = attr.ib()
+            y = attr.ib(default=3)
+
+        converter = to_attrs(Animal)
+        assert converter({"type": "Cat", "x": 2}) == Cat(type="Cat", x=2)
+        assert converter({"type": "Dog", "x": 2}) == Dog(type="Dog", x=2, y=3)
+
+    def test_invalid_cls(self):
+        """
+        Raise TypeError when neither a dict nor an instance of the class is
+        passed.
+        """
+
+        @attr.s
+        class C:
+            x = attr.ib()
+            y = attr.ib()
+
+        converter = to_attrs(C)
+        with pytest.raises(TypeError):
+            converter([2, 3])
+
+
+class TestToDt:
+    """Tests for to_dt()."""
+
+    def test_from_dt(self):
+        """
+        Existing datetimes are returned unchanged.
+        """
+        dt = datetime(2020, 5, 4, 13, 37)
+        result = to_dt(dt)
+        assert result is dt
+
+    @pytest.mark.parametrize(
+        "input, expected",
+        [
+            ("2020-05-04 13:37:00", datetime(2020, 5, 4, 13, 37)),
+            ("2020-05-04T13:37:00", datetime(2020, 5, 4, 13, 37)),
+            # (
+            #     "2020-05-04T13:37:00Z",
+            #     datetime(2020, 5, 4, 13, 37, tzinfo=timezone.utc)),
+            # ),
+            (
+                "2020-05-04T13:37:00+00:00",
+                datetime(2020, 5, 4, 13, 37, tzinfo=timezone.utc),
+            ),
+            (
+                "2020-05-04T13:37:00+02:00",
+                datetime(
+                    2020,
+                    5,
+                    4,
+                    13,
+                    37,
+                    tzinfo=timezone(timedelta(seconds=7200)),
+                ),
+            ),
+        ],
+    )
+    def test_from_str(self, input, expected):
+        """
+        Existing datetimes are returned unchanged.
+        """
+        result = to_dt(input)
+        assert result == expected
+
+    def test_invalid_input(self):
+        """
+        Invalid inputs raises a TypeError.
+        """
+        with pytest.raises(TypeError):
+            to_dt(3)
+
+
+class TestToIterable:
+    """Tests for to_iterable()."""
+
+    @pytest.mark.parametrize("cls", [list, set, tuple])
+    def test_to_iterable(self, cls):
+        """
+        An iterable's data and the iterable itself can be converted to
+        different types.
+        """
+        converter = to_iterable(cls, int)
+        assert converter(["1", "2", "3"]) == cls([1, 2, 3])
+
+
+class TestToTuple:
+    """Tests for to_tuple()."""
+
+    @pytest.mark.parametrize("cls", [tuple])
+    def test_to_tuple(self, cls):
+        """
+        Struct-like tuples can contain different data types.
+        """
+        converter = to_tuple(cls, [int, float, str])
+        assert converter(["1", "2.2", "s"]) == cls([1, 2.2, "s"])
+
+    @pytest.mark.parametrize("val", [["1", "2.2", "s"], ["1"]])
+    def test_tuple_wrong_input_length(self, val):
+        """
+        Input data must have exactly as many elements as the tuple definition
+        has converters.
+        """
+        converter = to_tuple(tuple, [int, float])
+        with pytest.raises(
+            TypeError,
+            match="Value must have 2 items but has: {}".format(len(val)),
+        ):
+            converter(val)
+
+
+class TestToMapping:
+    """Tests for to_mapping()."""
+
+    @pytest.mark.parametrize("cls", [dict])
+    def test_to_dict(self, cls):
+        """
+        Keys and values of dicts can be converted to (different) types.
+        """
+        converter = to_mapping(cls, int, float)
+        assert converter({"1": "2", "2": "2.5"}) == cls([(1, 2.0), (2, 2.5)])
+
+
+class TestToUnion:
+    """Tests for to_union()."""
+
+    @pytest.mark.parametrize(
+        "types, val, expected_type, expected_val",
+        [
+            ([type(None), int], None, type(None), None),
+            ([type(None), int], "3", int, 3),
+            ([int, float], "3", int, 3),
+            ([int, float], 3.2, float, 3.2),  # Do not cast 3.2 to int!
+            ([int, float], "3.2", float, 3.2),
+            ([int, float, str], "3.2s", str, "3.2s"),
+            ([int, float, bool, str], "3.2", str, "3.2"),
+            ([int, float, bool, str], True, bool, True),
+            ([int, float, bool, str], "True", str, "True"),
+            ([int, float, bool, str], "", str, ""),
+        ],
+    )
+    def test_to_union(self, types, val, expected_type, expected_val):
+        """
+        Union data is converted to the first matching type.  If the input data
+        already has a valid type, it is returned without conversion.  For
+        example, floats will not be converted to ints when the type is
+        "Union[int, float]".
+        """
+        converter = to_union(types)
+        result = converter(val)
+        assert type(result) is expected_type
+        assert result == expected_val
 
 
 class TestPipe(object):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -10,17 +10,22 @@ import pytest
 
 import attr
 
-from attr import has
+from attr import fields, has
 from attr import validators as validator_module
 from attr._compat import PY2, TYPE
 from attr.validators import (
     and_,
     deep_iterable,
     deep_mapping,
+    ge,
+    gt,
     in_,
     instance_of,
     is_callable,
+    le,
+    lt,
     matches_re,
+    maxlen,
     optional,
     provides,
 )
@@ -93,6 +98,157 @@ class TestInstanceOf(object):
         ) == repr(v)
 
 
+class TestLtLeGeGt(object):
+    """
+    Tests for `maxlen`.
+    """
+
+    BOUND = 4
+
+    def test_in_all(self):
+        """
+        validator is in ``__all__``.
+        """
+        assert all(
+            f.__name__ in validator_module.__all__ for f in [lt, le, ge, gt]
+        )
+
+    @pytest.mark.parametrize("v", [lt, le, ge, gt])
+    def test_retrieve_bound(self, v):
+        """
+        The configured bound for the comparison can be extracted from the
+        Attribute.
+        """
+
+        @attr.s
+        class Tester(object):
+            value = attr.ib(validator=v(self.BOUND))
+
+        assert fields(Tester).value.validator.bound == self.BOUND
+
+    @pytest.mark.parametrize(
+        "v, value",
+        [
+            (lt, 3),
+            (le, 3),
+            (le, 4),
+            (ge, 4),
+            (ge, 5),
+            (gt, 5),
+        ],
+    )
+    def test_check_valid(self, v, value):
+        """Silent if value {op} bound."""
+
+        @attr.s
+        class Tester(object):
+            value = attr.ib(validator=v(self.BOUND))
+
+        Tester(value)  # shouldn't raise exceptions
+
+    @pytest.mark.parametrize(
+        "v, value",
+        [
+            (lt, 4),
+            (le, 5),
+            (ge, 3),
+            (gt, 4),
+        ],
+    )
+    def test_check_invalid(self, v, value):
+        """Raise ValueError if value {op} bound."""
+
+        @attr.s
+        class Tester(object):
+            value = attr.ib(validator=v(self.BOUND))
+
+        with pytest.raises(ValueError):
+            Tester(value)
+
+    @pytest.mark.parametrize("v", [lt, le, ge, gt])
+    def test_repr(self, v):
+        """
+        __repr__ is meaningful.
+        """
+        nv = v(23)
+        assert repr(nv) == "<Validator for x {op} {bound}>".format(
+            op=nv.compare_op, bound=23
+        )
+
+
+class TestMaxlen(object):
+    """
+    Tests for `maxlen`.
+    """
+
+    MAX_LENGTH = 4
+
+    def test_in_all(self):
+        """
+        validator is in ``__all__``.
+        """
+        assert maxlen.__name__ in validator_module.__all__
+
+    def test_retrieve_maxlen(self):
+        """
+        The configured max. length can be extracted from the Attribute
+        """
+
+        @attr.s
+        class Tester(object):
+            value = attr.ib(validator=maxlen(self.MAX_LENGTH))
+
+        assert fields(Tester).value.validator.max_length == self.MAX_LENGTH
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "foo",
+            "spam",
+            [],
+            list(range(MAX_LENGTH)),
+            {"spam": 3, "eggs": 4},
+        ],
+    )
+    def test_check_valid(self, value):
+        """
+        Silent if len(value) <= maxlen.
+        Values can be strings and other iterables.
+        """
+
+        @attr.s
+        class Tester(object):
+            value = attr.ib(validator=maxlen(self.MAX_LENGTH))
+
+        Tester(value)  # shouldn't raise exceptions
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "bacon",
+            list(range(6)),
+        ],
+    )
+    def test_check_invalid(self, value):
+        """
+        Raise ValueError if len(value) > maxlen.
+        """
+
+        @attr.s
+        class Tester(object):
+            value = attr.ib(validator=maxlen(self.MAX_LENGTH))
+
+        with pytest.raises(ValueError):
+            Tester(value)
+
+    def test_repr(self):
+        """
+        __repr__ is meaningful.
+        """
+        assert repr(maxlen(23)) == "<maxlen validator for 23>"
+
+
 class TestMatchesRe(object):
     """
     Tests for `matches_re`.
@@ -153,13 +309,11 @@ class TestMatchesRe(object):
         if not PY2:
             assert (
                 "'func' must be one of None, fullmatch, match, search."
-                == ei.value.args[0]
-            )
+            ) == ei.value.args[0]
         else:
             assert (
                 "'func' must be one of None, match, search."
-                == ei.value.args[0]
-            )
+            ) == ei.value.args[0]
 
     @pytest.mark.parametrize(
         "func", [None, getattr(re, "fullmatch", None), re.match, re.search]


### PR DESCRIPTION
Fixes: #649

# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.  If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.

- [ ] Added **tests** for changed code.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/strategies.py).
- [ ] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [ ] ...and used in the stub test file `tests/typing_example.py`.
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/master/src/attr/__init__.py) file.
- [ ] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
