### PR TITLE
Use 'i' and 'k' to better distinguish variables in an example

### DIFF
--- a/docs/init.rst
+++ b/docs/init.rst
@@ -107,9 +107,9 @@ Please note that as with function and method signatures, ``default=[]`` will *no
    ... class C(object):
    ...     x = attr.ib(default=[])
    >>> i = C()
-   >>> j = C()
+   >>> k = C()
    >>> i.x.append(42)
-   >>> j.x
+   >>> k.x
    [42]
 
 


### PR DESCRIPTION
It took me a moment of staring at this example to realise that `i` and `j` were actually different variables. They're not very different in the monospaced font!

I'm hoping that `i` and `k` will make them stand out more, and this example easier to read.

(Most letters seem to have a use already in this file, or I'd have picked an even more different pair of letters.)

—

# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.  If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.

- [x] Added **tests** for changed code.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [x] ...and used in the stub test file `tests/typing_example.py`.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/master/src/attr/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!