### PR TITLE
Implement @converter decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .cache
 .coverage*
 .hypothesis
+.idea/
 .mypy_cache
 .pytest_cache
 .tox
@@ -11,3 +12,5 @@ dist
 docs/_build/
 htmlcov
 pip-wheel-metadata
+Pipfile
+Pipfile.lock

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -2384,6 +2384,7 @@ class Attribute(object):
             not in (
                 "name",
                 "validator",
+                "converter",
                 "default",
                 "type",
                 "inherited",
@@ -2392,6 +2393,7 @@ class Attribute(object):
         return cls(
             name=name,
             validator=ca._validator,
+            converter=ca._converter,
             default=ca._default,
             type=type,
             cmp=None,
@@ -2500,7 +2502,7 @@ class _CountingAttr(object):
         "init",
         "metadata",
         "_validator",
-        "converter",
+        "_converter",
         "type",
         "kw_only",
         "on_setattr",
@@ -2568,7 +2570,7 @@ class _CountingAttr(object):
         self.counter = _CountingAttr.cls_counter
         self._default = default
         self._validator = validator
-        self.converter = converter
+        self._converter = converter
         self.repr = repr
         self.eq = eq
         self.order = order
@@ -2591,6 +2593,20 @@ class _CountingAttr(object):
             self._validator = meth
         else:
             self._validator = and_(self._validator, meth)
+        return meth
+
+    def converter(self, meth):
+        """
+        Decorator that adds *meth* to the list of converters.
+
+        Returns *meth* unchanged.
+
+        .. versionadded:: # TODO: TBD
+        """
+        if self._converter is None:
+            self._converter = meth
+        else:
+            self._converter = pipe(self._converter, meth)
         return meth
 
     def default(self, meth):

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -120,6 +120,36 @@ class TestCountingAttr(object):
 
         assert _AndValidator((v, v2)) == a._validator
 
+    def test_converter_decorator_single(self):
+        """
+        If _CountingAttr.converter is used as a decorator and there is no
+        decorator set, the decorated method is used as the converter.
+        """
+        a = attr.ib()
+
+        @a.converter
+        def c():
+            pass
+
+        assert c == a._converter
+
+    def test_converter_decorator(self):
+        """
+        If _CountingAttr.converter is used as a decorator and there is already
+        a decorator set, the decorators are composed using `pipe`.
+        """
+
+        def c(val):
+            return ('c', val)
+
+        a = attr.ib(converter=c)
+
+        @a.converter
+        def c2(val):
+            return ('c2', val)
+
+        assert ('c2', ('c', 'foo')) == a._converter('foo')
+
     def test_default_decorator_already_set(self):
         """
         Raise DefaultAlreadySetError if the decorator is used after a default


### PR DESCRIPTION
Implement @converter decorator as described in #240. If you like this approach, I'll be happy to update the documentation etc.

This is a less sophisticated approach than #404, which has been in draft since 2018 and supports self arguments.

# Pull Request Check List

- [x] Added **tests** for changed code.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/strategies.py).
- [ ] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [ ] ...and used in the stub test file `tests/typing_example.py`.
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/master/src/attr/__init__.py) file.
- [ ] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
