### PR TITLE
doc: fix typo in default_if_none doc

### DIFF
--- a/src/attr/converters.py
+++ b/src/attr/converters.py
@@ -67,7 +67,7 @@ def default_if_none(default=NOTHING, factory=None):
     :param default: Value to be used if ``None`` is passed. Passing an instance
        of `attr.Factory` is supported, however the ``takes_self`` option
        is *not*.
-    :param callable factory: A callable that takes not parameters whose result
+    :param callable factory: A callable that takes no parameters whose result
        is used if ``None`` is passed.
 
     :raises TypeError: If **neither** *default* or *factory* is passed.


### PR DESCRIPTION
# Pull Request Check List

Just noticed this while reading through the docs. It's a 1 character change, so if you'd prefer to fix this in a bigger commit, feel free to close this. 

If you want to pull this in, I believe the docs auto-pull from the docstrings, but let me know if I need to do anything other than this. 

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.  If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.

- [x] Added **tests** for changed code.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [x] ...and used in the stub test file `tests/typing_example.py`.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/master/src/attr/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
