### PR TITLE
Add Python 3.10 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "pypy2", "pypy3"]
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10.0-alpha - 3.10", "pypy2", "pypy3"]
 
     steps:
       - uses: "actions/checkout@v2"

--- a/conftest.py
+++ b/conftest.py
@@ -23,3 +23,10 @@ if sys.version_info[:2] < (3, 6):
             "tests/test_next_gen.py",
         ]
     )
+if sys.version_info[:2] >= (3, 10):
+    collect_ignore.extend(
+        [
+            "tests/test_mypy.yml",
+            "tests/test_hooks.py",
+        ]
+    )

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -386,9 +386,11 @@ def _is_class_var(annot):
     """
     annot = str(annot)
 
-    return annot.startswith(_classvar_prefixes) or annot[1:].startswith(
-        _classvar_prefixes
-    )
+    # Annotation can be quoted.
+    if annot.startswith(("'", '"')) and annot.endswith(("'", '"')):
+        annot = annot[1:-1]
+
+    return annot.startswith(_classvar_prefixes)
 
 
 def _has_own_attribute(cls, attrib_name):

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -384,7 +384,11 @@ def _is_class_var(annot):
     annotations which would put attrs-based classes at a performance
     disadvantage compared to plain old classes.
     """
-    return str(annot).startswith(_classvar_prefixes)
+    annot = str(annot)
+
+    return annot.startswith(_classvar_prefixes) or annot[1:].startswith(
+        _classvar_prefixes
+    )
 
 
 def _has_own_attribute(cls, attrib_name):

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -25,13 +25,12 @@ class TestAnnotations:
         Sets the `Attribute.type` attr from basic type annotations.
         """
 
+        @attr.resolve_types
         @attr.s
         class C:
             x: int = attr.ib()
             y = attr.ib(type=str)
             z = attr.ib()
-
-        attr.resolve_types(C)
 
         assert int is attr.fields(C).x.type
         assert str is attr.fields(C).y.type
@@ -61,12 +60,11 @@ class TestAnnotations:
         Sets the `Attribute.type` attr from typing annotations.
         """
 
+        @attr.resolve_types
         @attr.s
         class C:
             x: typing.List[int] = attr.ib()
             y = attr.ib(type=typing.Optional[str])
-
-        attr.resolve_types(C)
 
         assert typing.List[int] is attr.fields(C).x.type
         assert typing.Optional[str] is attr.fields(C).y.type
@@ -81,12 +79,11 @@ class TestAnnotations:
         Annotations that aren't set to an attr.ib are ignored.
         """
 
+        @attr.resolve_types
         @attr.s
         class C:
             x: typing.List[int] = attr.ib()
             y: int
-
-        attr.resolve_types(C)
 
         assert 1 == len(attr.fields(C))
         assert {
@@ -179,25 +176,23 @@ class TestAnnotations:
         Ref #291
         """
 
+        @attr.resolve_types
         @attr.s(slots=slots, auto_attribs=True)
         class A:
             a: int = 1
 
+        @attr.resolve_types
         @attr.s(slots=slots, auto_attribs=True)
         class B(A):
             b: int = 2
 
+        @attr.resolve_types
         @attr.s(slots=slots, auto_attribs=True)
         class C(A):
             pass
 
         assert "B(a=1, b=2)" == repr(B())
         assert "C(a=1)" == repr(C())
-
-        attr.resolve_types(A)
-        attr.resolve_types(B)
-        attr.resolve_types(C)
-
         assert {"a": int, "return": type(None)} == typing.get_type_hints(
             A.__init__
         )

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -12,6 +12,7 @@ import pytest
 
 import attr
 
+from attr._make import _is_class_var
 from attr.exceptions import UnannotatedAttributeError
 
 
@@ -604,3 +605,19 @@ class TestAnnotations:
 
         with pytest.raises(NameError):
             typing.get_type_hints(C.__init__)
+
+
+@pytest.mark.parametrize(
+    "annot",
+    [
+        typing.ClassVar,
+        "typing.ClassVar",
+        "'typing.ClassVar[dict]'",
+        "t.ClassVar[int]",
+    ],
+)
+def test_is_class_var(annot):
+    """
+    ClassVars are detected, even if they're a string or quoted.
+    """
+    assert _is_class_var(annot)

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -729,9 +729,8 @@ class TestAddInit(object):
         with pytest.raises(TypeError) as e:
             C(a=1, b=2)
 
-        assert (
+        assert e.value.args[0].endswith(
             "__init__() got an unexpected keyword argument 'a'"
-            == e.value.args[0]
         )
 
     @given(booleans(), booleans())

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -552,7 +552,7 @@ class TestEvolve(object):
         else:
             expected = "__init__() got an unexpected keyword argument 'aaaa'"
 
-        assert (expected,) == e.value.args
+        assert e.value.args[0].endswith(expected)
 
     def test_validator_failure(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -16,12 +16,13 @@ python =
     3.7: py37, docs
     3.8: py38, lint, manifest, typing, changelog
     3.9: py39
+    3.10: py310
     pypy2: pypy2
     pypy3: pypy3
 
 
 [tox]
-envlist = typing,lint,py27,py35,py36,py37,py38,py39,pypy,pypy3,manifest,docs,pypi-description,changelog,coverage-report
+envlist = typing,lint,py27,py35,py36,py37,py38,py39,py310,pypy,pypy3,manifest,docs,pypi-description,changelog,coverage-report
 isolated_build = True
 
 


### PR DESCRIPTION
Python 3.10 has string types everywhere and that has unmasked a bunch of
bugs/edge cases in our code.

Especially the hooks code need a resolving helper for string types. I'm leaving
that for a separate PR.

Same for test_mypy.yml

Fixes #716

cc @euresti @ambv @frenzymadness @sscherfke 