### PR TITLE
Fix possible typo in init.rst

### DIFF
--- a/docs/init.rst
+++ b/docs/init.rst
@@ -362,7 +362,7 @@ If you need to set attributes on a frozen class, you'll have to resort to the `s
    >>> Frozen(1)
    Frozen(x=1, y=2)
 
-Note that you *must not* access the hash code of the object in ``__attrs_post__init__`` if ``cache_hash=True``.
+Note that you *must not* access the hash code of the object in ``__attrs_post_init__`` if ``cache_hash=True``.
 
 
 Order of Execution


### PR DESCRIPTION
# Pull Request Check List

I'm new to the project, but I noticed that one of references to `__attrs_post_init__` had _two underscores_ after the `post` like `__attrs_post__init__`. This seems like a typo because elsewhere it only has one underscore there.

----

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.  If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.

- [ ] Added **tests** for changed code.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/master/tests/strategies.py).
- [ ] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [ ] ...and used in the stub test file `tests/typing_example.py`.
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/master/src/attr/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/master/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
