### PR TITLE
Fix test_hooks for Python 3.10 and str annotations

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -27,6 +27,5 @@ if sys.version_info[:2] >= (3, 10):
     collect_ignore.extend(
         [
             "tests/test_mypy.yml",
-            "tests/test_hooks.py",
         ]
     )


### PR DESCRIPTION
This makes all tests pass but it shows how clunky the hooks become, once string annotations comes into play. So I wouldn't say it's a resolution for #766, but just a step towards clarity.