### PR TITLE
docs: fix double negative

### DIFF
--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1226,7 +1226,7 @@ def attrs(
         inherited from some base class).
 
         So for example by implementing ``__eq__`` on a class yourself,
-        ``attrs`` will deduce ``eq=False`` and won't create *neither*
+        ``attrs`` will deduce ``eq=False`` and won't create *either*
         ``__eq__`` *nor* ``__ne__`` (but Python classes come with a sensible
         ``__ne__`` by default, so it *should* be enough to only implement
         ``__eq__`` in most cases).

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1226,7 +1226,7 @@ def attrs(
         inherited from some base class).
 
         So for example by implementing ``__eq__`` on a class yourself,
-        ``attrs`` will deduce ``eq=False`` and won't create *either*
+        ``attrs`` will deduce ``eq=False`` and will create *neither*
         ``__eq__`` *nor* ``__ne__`` (but Python classes come with a sensible
         ``__ne__`` by default, so it *should* be enough to only implement
         ``__eq__`` in most cases).


### PR DESCRIPTION
E.g. (from https://grammar.yourdictionary.com/grammar-rules-and-tips/double-negative-trouble.html):
> > Neither fish nor chicken weren't at the party.
>
> This sentence contains a double negative because "neither" and "weren't" are both negatives. "Neither fish nor chicken were at the party" would be fine, as would "Fish and chicken weren't at the party.