### PR TITLE
Narrower typing on Factory called with takes_self

### DIFF
--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -4,6 +4,7 @@ from typing import (
     Dict,
     Generic,
     List,
+    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -64,9 +65,15 @@ NOTHING: object
 def Factory(factory: Callable[[], _T]) -> _T: ...
 @overload
 def Factory(
-    factory: Union[Callable[[Any], _T], Callable[[], _T]],
-    takes_self: bool = ...,
+    factory: Callable[[Any], _T],
+    takes_self: Literal[True],
 ) -> _T: ...
+@overload
+def Factory(
+    factory: Callable[[], _T],
+    takes_self: Literal[False],
+) -> _T: ...
+
 
 class Attribute(Generic[_T]):
     name: str

--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -1,10 +1,10 @@
+import sys
 from typing import (
     Any,
     Callable,
     Dict,
     Generic,
     List,
-    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -61,18 +61,29 @@ NOTHING: object
 # NOTE: Factory lies about its return type to make this possible:
 # `x: List[int] # = Factory(list)`
 # Work around mypy issue #4554 in the common case by using an overload.
-@overload
-def Factory(factory: Callable[[], _T]) -> _T: ...
-@overload
-def Factory(
-    factory: Callable[[Any], _T],
-    takes_self: Literal[True],
-) -> _T: ...
-@overload
-def Factory(
-    factory: Callable[[], _T],
-    takes_self: Literal[False],
-) -> _T: ...
+if sys.version_info >= (3, 8):
+    from typing import Literal
+
+    @overload
+    def Factory(factory: Callable[[], _T]) -> _T: ...
+    @overload
+    def Factory(
+        factory: Callable[[Any], _T],
+        takes_self: Literal[True],
+    ) -> _T: ...
+    @overload
+    def Factory(
+        factory: Callable[[], _T],
+        takes_self: Literal[False],
+    ) -> _T: ...
+else:
+    @overload
+    def Factory(factory: Callable[[], _T]) -> _T: ...
+    @overload
+    def Factory(
+        factory: Union[Callable[[Any], _T], Callable[[], _T]],
+        takes_self: bool = ...,
+    ) -> _T: ...
 
 
 class Attribute(Generic[_T]):

--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -1,4 +1,5 @@
 import sys
+
 from typing import (
     Any,
     Callable,

--- a/tests/typing_example.py
+++ b/tests/typing_example.py
@@ -250,3 +250,10 @@ a.evolve(repr=False)
 @attr.s(collect_by_mro=True)
 class MRO:
     pass
+
+
+@attr.s
+class FactoryTest:
+    a: List[int] = attr.ib(default=attr.Factory(list))
+    b: List[Any] = attr.ib(default=attr.Factory(list, False))
+    c: List[int] = attr.ib(default=attr.Factory((lambda s: s.a), True))


### PR DESCRIPTION
This changes the annotations for `attr.Factory` so that the acceptable type of the callable changes based on `takes_self`.
Theoretically, MyPy will let you do this:

```py
attr.ib(default=attr.Factory(list, takes_self=True)
attr.ib(default=attr.Factory((lambda self: []), takes_self=False)
```

The change in annotations will prevent that from happening.

As written I *think* these annotations would require the type checker to be running on Python 3.8 because of the use of `Literal`. There are a couple ways around this, if necessary.


# Pull Request Check List

- [x] Added **tests** for changed code.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [x] ...and used in the stub test file `tests/typing_example.py`.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/main/src/attr/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
