### PR TITLE
New attr.cmp_using helper function

### DIFF
--- a/src/attr/__init__.py
+++ b/src/attr/__init__.py
@@ -5,6 +5,7 @@ import sys
 from functools import partial
 
 from . import converters, exceptions, filters, setters, validators
+from ._cmp import cmp_using
 from ._config import get_run_validators, set_run_validators
 from ._funcs import asdict, assoc, astuple, evolve, has, resolve_types
 from ._make import (
@@ -52,6 +53,7 @@ __all__ = [
     "attrib",
     "attributes",
     "attrs",
+    "cmp_using",
     "converters",
     "evolve",
     "exceptions",

--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -49,11 +49,7 @@ _OnSetAttrType = Callable[[Any, Attribute[Any], Any], Any]
 _OnSetAttrArgType = Union[
     _OnSetAttrType, List[_OnSetAttrType], setters._NoOpType
 ]
-_FieldTransformer = Callable[
-    [type, List[Attribute[Any]]], List[Attribute[Any]]
-]
-_CompareWithType = Callable[[Any, Any], bool]
-
+_FieldTransformer = Callable[[type, List[Attribute[Any]]], List[Attribute[Any]]]
 # FIXME: in reality, if multiple validators are passed they must be in a list
 # or tuple, but those are invariant and so would prevent subtypes of
 # _ValidatorType from working when passed in a list or tuple.
@@ -68,6 +64,7 @@ NOTHING: object
 # Work around mypy issue #4554 in the common case by using an overload.
 if sys.version_info >= (3, 8):
     from typing import Literal
+
     @overload
     def Factory(factory: Callable[[], _T]) -> _T: ...
     @overload
@@ -80,7 +77,6 @@ if sys.version_info >= (3, 8):
         factory: Callable[[], _T],
         takes_self: Literal[False],
     ) -> _T: ...
-
 else:
     @overload
     def Factory(factory: Callable[[], _T]) -> _T: ...
@@ -89,6 +85,7 @@ else:
         factory: Union[Callable[[Any], _T], Callable[[], _T]],
         takes_self: bool = ...,
     ) -> _T: ...
+
 
 class Attribute(Generic[_T]):
     name: str
@@ -105,6 +102,7 @@ class Attribute(Generic[_T]):
     type: Optional[Type[_T]]
     kw_only: bool
     on_setattr: _OnSetAttrType
+
     def evolve(self, **changes: Any) -> "Attribute[Any]": ...
 
 # NOTE: We had several choices for the annotation to use for type arg:
@@ -431,9 +429,7 @@ def asdict(
     filter: Optional[_FilterType[Any]] = ...,
     dict_factory: Type[Mapping[Any, Any]] = ...,
     retain_collection_types: bool = ...,
-    value_serializer: Optional[
-        Callable[[type, Attribute[Any], Any], Any]
-    ] = ...,
+    value_serializer: Optional[Callable[[type, Attribute[Any], Any], Any]] = ...,
 ) -> Dict[str, Any]: ...
 
 # TODO: add support for returning NamedTuple from the mypy plugin

--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -49,7 +49,11 @@ _OnSetAttrType = Callable[[Any, Attribute[Any], Any], Any]
 _OnSetAttrArgType = Union[
     _OnSetAttrType, List[_OnSetAttrType], setters._NoOpType
 ]
-_FieldTransformer = Callable[[type, List[Attribute[Any]]], List[Attribute[Any]]]
+_FieldTransformer = Callable[
+    [type, List[Attribute[Any]]], List[Attribute[Any]]
+]
+_CompareWithType = Callable[[Any, Any], bool]
+
 # FIXME: in reality, if multiple validators are passed they must be in a list
 # or tuple, but those are invariant and so would prevent subtypes of
 # _ValidatorType from working when passed in a list or tuple.
@@ -64,7 +68,6 @@ NOTHING: object
 # Work around mypy issue #4554 in the common case by using an overload.
 if sys.version_info >= (3, 8):
     from typing import Literal
-
     @overload
     def Factory(factory: Callable[[], _T]) -> _T: ...
     @overload
@@ -77,6 +80,7 @@ if sys.version_info >= (3, 8):
         factory: Callable[[], _T],
         takes_self: Literal[False],
     ) -> _T: ...
+
 else:
     @overload
     def Factory(factory: Callable[[], _T]) -> _T: ...
@@ -85,7 +89,6 @@ else:
         factory: Union[Callable[[Any], _T], Callable[[], _T]],
         takes_self: bool = ...,
     ) -> _T: ...
-
 
 class Attribute(Generic[_T]):
     name: str
@@ -102,7 +105,6 @@ class Attribute(Generic[_T]):
     type: Optional[Type[_T]]
     kw_only: bool
     on_setattr: _OnSetAttrType
-
     def evolve(self, **changes: Any) -> "Attribute[Any]": ...
 
 # NOTE: We had several choices for the annotation to use for type arg:
@@ -429,7 +431,9 @@ def asdict(
     filter: Optional[_FilterType[Any]] = ...,
     dict_factory: Type[Mapping[Any, Any]] = ...,
     retain_collection_types: bool = ...,
-    value_serializer: Optional[Callable[[type, Attribute[Any], Any], Any]] = ...,
+    value_serializer: Optional[
+        Callable[[type, Attribute[Any], Any], Any]
+    ] = ...,
 ) -> Dict[str, Any]: ...
 
 # TODO: add support for returning NamedTuple from the mypy plugin

--- a/src/attr/_cmp.py
+++ b/src/attr/_cmp.py
@@ -1,0 +1,162 @@
+from __future__ import absolute_import, division, print_function
+
+import functools
+
+from ._make import _make_ne, attrib, attrs
+
+
+_operation_names = {"eq": "==", "lt": "<", "le": "<=", "gt": ">", "ge": ">="}
+
+
+def cmp_using(
+    eq=None,
+    lt=None,
+    le=None,
+    gt=None,
+    ge=None,
+    require_same_type=True,
+    class_name=None,
+):
+    """
+    Utility function that creates a class with customized equality and
+    ordering methods.
+
+    The resulting class will have a full set of ordering methods if
+    at least one of ``{lt, le, gt, ge}`` and ``eq``  are provided.
+
+    :param Optional[callable] eq: `callable` used to evaluate equality
+        of two objects.
+    :param Optional[callable] lt: `callable` used to evaluate whether
+        one object is less than another object.
+    :param Optional[callable] le: `callable` used to evaluate whether
+        one object is less than or equal to another object.
+    :param Optional[callable] gt: `callable` used to evaluate whether
+        one object is greater than another object.
+    :param Optional[callable] ge: `callable` used to evaluate whether
+        one object is greater than or equal to another object.
+
+    :param bool require_same_type: When `True`, equality and ordering methods
+        will return `NotImplemented` if objects are not of the same type.
+
+    :param Optional[str] class_name: Name of class. Defaults to 'Comparable'.
+
+    .. versionadded:: 21.1.0
+    """
+
+    @attrs(slots=True, eq=False, order=False)
+    class Comparable(object):
+        value = attrib()
+        _requirements = []
+
+        def _is_comparable_to(self, other):
+            """
+            Check whether `other` is comparable to `self`.
+            """
+            for func in self._requirements:
+                if not func(self, other):
+                    return False
+            return True
+
+    if class_name is None:
+        Comparable.__qualname__ = Comparable.__name__
+    else:
+        Comparable.__name__ = class_name
+        Comparable.__qualname__ = class_name
+
+    # Add same type requirement.
+    if require_same_type:
+        Comparable._requirements.append(_check_same_type)
+
+    # Add operations.
+    num_order_fucntions = 0
+    has_eq_function = False
+
+    if eq is not None:
+        has_eq_function = True
+        Comparable.__eq__ = _make_operator("eq", eq)
+        Comparable.__ne__ = _make_ne()
+
+    if lt is not None:
+        num_order_fucntions += 1
+        Comparable.__lt__ = _make_operator("lt", lt)
+
+    if le is not None:
+        num_order_fucntions += 1
+        Comparable.__le__ = _make_operator("le", le)
+
+    if gt is not None:
+        num_order_fucntions += 1
+        Comparable.__gt__ = _make_operator("gt", gt)
+
+    if ge is not None:
+        num_order_fucntions += 1
+        Comparable.__ge__ = _make_operator("ge", ge)
+
+    # Add total ordering if at least one operation was defined.
+    if 0 < num_order_fucntions < 4:
+        if not has_eq_function:
+            # functools.total_ordering requires __eq__ to be defined,
+            # so raise early error here to keep a nice stach.
+            raise ValueError(
+                "eq must be define is order to complete ordering from "
+                "lt, le, gt, ge."
+            )
+        Comparable = functools.total_ordering(Comparable)
+
+    # Fix dunders to add nice qualified names, etc.
+    for name in ["__eq__", "__ne__", "__lt__", "__le__", "__gt__", "__ge__"]:
+        method = getattr(Comparable, name, None)
+        if method is not None:
+            setattr(Comparable, name, _add_method_dunders(Comparable, method))
+
+    return Comparable
+
+
+def _add_method_dunders(cls, method):
+    """
+    Add __module__ and __qualname__ to a *method* if possible.
+    """
+    try:
+        method.__module__ = cls.__module__
+    except AttributeError:
+        pass
+
+    try:
+        method.__qualname__ = ".".join((cls.__qualname__, method.__name__))
+    except AttributeError:
+        pass
+
+    return method
+
+
+def _make_operator(name, func):
+    """
+    Create operator method.
+    """
+
+    def method(self, other):
+        """
+        Evaluate operator and either return the result or NotImplemented.
+        """
+        if not self._is_comparable_to(other):
+            return NotImplemented
+
+        result = func(self.value, other.value)
+        if result is NotImplemented:
+            return NotImplemented
+
+        return result
+
+    method.__name__ = "__%s__" % (name,)
+    method.__doc__ = "Return a %s b.  Computed by attrs." % (
+        _operation_names[name],
+    )
+
+    return method
+
+
+def _check_same_type(self, other):
+    """
+    Return True if *self* and *other* are of the same type, False otherwise.
+    """
+    return other.value.__class__ is self.value.__class__

--- a/src/attr/_cmp.py
+++ b/src/attr/_cmp.py
@@ -52,7 +52,7 @@ def cmp_using(
     }
 
     # Add operations.
-    num_order_fucntions = 0
+    num_order_functions = 0
     has_eq_function = False
 
     if eq is not None:
@@ -61,19 +61,19 @@ def cmp_using(
         body["__ne__"] = _make_ne()
 
     if lt is not None:
-        num_order_fucntions += 1
+        num_order_functions += 1
         body["__lt__"] = _make_operator("lt", lt)
 
     if le is not None:
-        num_order_fucntions += 1
+        num_order_functions += 1
         body["__le__"] = _make_operator("le", le)
 
     if gt is not None:
-        num_order_fucntions += 1
+        num_order_functions += 1
         body["__gt__"] = _make_operator("gt", gt)
 
     if ge is not None:
-        num_order_fucntions += 1
+        num_order_functions += 1
         body["__ge__"] = _make_operator("ge", ge)
 
     type_ = new_class(class_name, (object,), {}, lambda ns: ns.update(body))
@@ -83,7 +83,7 @@ def cmp_using(
         type_._requirements.append(_check_same_type)
 
     # Add total ordering if at least one operation was defined.
-    if 0 < num_order_fucntions < 4:
+    if 0 < num_order_functions < 4:
         if not has_eq_function:
             # functools.total_ordering requires __eq__ to be defined,
             # so raise early error here to keep a nice stack.

--- a/src/attr/_cmp.py
+++ b/src/attr/_cmp.py
@@ -16,7 +16,7 @@ def cmp_using(
     gt=None,
     ge=None,
     require_same_type=True,
-    class_name=None,
+    class_name="Comparable",
 ):
     """
     Utility function that creates a class with customized equality and
@@ -76,9 +76,7 @@ def cmp_using(
         num_order_fucntions += 1
         body["__ge__"] = _make_operator("ge", ge)
 
-    type_ = new_class(
-        class_name or "Comparable", (object,), {}, lambda ns: ns.update(body)
-    )
+    type_ = new_class(class_name, (object,), {}, lambda ns: ns.update(body))
 
     # Add same type requirement.
     if require_same_type:

--- a/src/attr/_cmp.pyi
+++ b/src/attr/_cmp.pyi
@@ -1,0 +1,14 @@
+from typing import Type
+
+from . import _CompareWithType
+
+
+def cmp_using(
+    eq: Optional[_CompareWithType],
+    lt: Optional[_CompareWithType],
+    le: Optional[_CompareWithType],
+    gt: Optional[_CompareWithType],
+    ge: Optional[_CompareWithType],
+    require_same_type: bool,
+    class_name: Optional[str],
+) -> Type: ...

--- a/src/attr/_cmp.pyi
+++ b/src/attr/_cmp.pyi
@@ -10,5 +10,5 @@ def cmp_using(
     gt: Optional[_CompareWithType],
     ge: Optional[_CompareWithType],
     require_same_type: bool,
-    class_name: Optional[str],
+    class_name: str,
 ) -> Type: ...

--- a/tests/test_cmp.py
+++ b/tests/test_cmp.py
@@ -126,11 +126,12 @@ class TestEqOrder(object):
         """
         Less-than values of different types are detected appropriately.
         """
-        if requires_same_type and not PY2:
+        if requires_same_type:
             # Unlike __eq__, NotImplemented will cause an exception to be
             # raised from __lt__.
-            with pytest.raises(TypeError):
-                cls(1) < cls(2.0)
+            if not PY2:
+                with pytest.raises(TypeError):
+                    cls(1) < cls(2.0)
         else:
             assert cls(1) < cls(2.0)
             assert not (cls(2) < cls(1.0))
@@ -176,11 +177,12 @@ class TestEqOrder(object):
         """
         Less-than-or-equal values of diff. types are detected appropriately.
         """
-        if requires_same_type and not PY2:
+        if requires_same_type:
             # Unlike __eq__, NotImplemented will cause an exception to be
             # raised from __le__.
-            with pytest.raises(TypeError):
-                cls(1) <= cls(2.0)
+            if not PY2:
+                with pytest.raises(TypeError):
+                    cls(1) <= cls(2.0)
         else:
             assert cls(1) <= cls(2.0)
             assert cls(1) <= cls(1.0)
@@ -225,11 +227,12 @@ class TestEqOrder(object):
         """
         Greater-than values of different types are detected appropriately.
         """
-        if requires_same_type and not PY2:
+        if requires_same_type:
             # Unlike __eq__, NotImplemented will cause an exception to be
             # raised from __gt__.
-            with pytest.raises(TypeError):
-                cls(2) > cls(1.0)
+            if not PY2:
+                with pytest.raises(TypeError):
+                    cls(2) > cls(1.0)
         else:
             assert cls(2) > cls(1.0)
             assert not (cls(1) > cls(2.0))
@@ -275,11 +278,12 @@ class TestEqOrder(object):
         """
         Greater-than-or-equal values of diff. types are detected appropriately.
         """
-        if requires_same_type and not PY2:
+        if requires_same_type:
             # Unlike __eq__, NotImplemented will cause an exception to be
             # raised from __ge__.
-            with pytest.raises(TypeError):
-                cls(2) >= cls(1.0)
+            if not PY2:
+                with pytest.raises(TypeError):
+                    cls(2) >= cls(1.0)
         else:
             assert cls(2) >= cls(2.0)
             assert cls(2) >= cls(1.0)

--- a/tests/test_cmp.py
+++ b/tests/test_cmp.py
@@ -79,7 +79,7 @@ class TestEqOrder(object):
         assert not (cls(1) == cls(2))
 
     @pytest.mark.parametrize("cls, requires_same_type", cmp_data, ids=cmp_ids)
-    def test_equal_different_type(self, cls, requires_same_type: bool):
+    def test_equal_different_type(self, cls, requires_same_type):
         """
         Equal values of different types are detected appropriately.
         """

--- a/tests/test_cmp.py
+++ b/tests/test_cmp.py
@@ -302,7 +302,6 @@ class TestDundersUnnamedClass(object):
         method = self.cls.__eq__
         assert method.__doc__.strip() == "Return a == b.  Computed by attrs."
         assert method.__name__ == "__eq__"
-        assert method.__qualname__ == "Comparable.__eq__"
 
     def test_ne(self):
         """
@@ -314,7 +313,6 @@ class TestDundersUnnamedClass(object):
             "        return the result negated."
         )
         assert method.__name__ == "__ne__"
-        assert method.__qualname__ == "Comparable.__ne__"
 
 
 class TestDundersPartialOrdering(object):
@@ -338,7 +336,6 @@ class TestDundersPartialOrdering(object):
         method = self.cls.__eq__
         assert method.__doc__.strip() == "Return a == b.  Computed by attrs."
         assert method.__name__ == "__eq__"
-        assert method.__qualname__ == "PartialOrderCSameType.__eq__"
 
     def test_ne(self):
         """
@@ -350,7 +347,6 @@ class TestDundersPartialOrdering(object):
             "        return the result negated."
         )
         assert method.__name__ == "__ne__"
-        assert method.__qualname__ == "PartialOrderCSameType.__ne__"
 
     def test_lt(self):
         """
@@ -359,7 +355,6 @@ class TestDundersPartialOrdering(object):
         method = self.cls.__lt__
         assert method.__doc__.strip() == "Return a < b.  Computed by attrs."
         assert method.__name__ == "__lt__"
-        assert method.__qualname__ == "PartialOrderCSameType.__lt__"
 
     def test_le(self):
         """
@@ -370,7 +365,6 @@ class TestDundersPartialOrdering(object):
             "Return a <= b.  Computed by @total_ordering from"
         )
         assert method.__name__ == "__le__"
-        assert method.__qualname__ == "PartialOrderCSameType.__le__"
 
     def test_gt(self):
         """
@@ -381,7 +375,6 @@ class TestDundersPartialOrdering(object):
             "Return a > b.  Computed by @total_ordering from"
         )
         assert method.__name__ == "__gt__"
-        assert method.__qualname__ == "PartialOrderCSameType.__gt__"
 
     def test_ge(self):
         """
@@ -389,10 +382,9 @@ class TestDundersPartialOrdering(object):
         """
         method = self.cls.__ge__
         assert method.__doc__.strip().startswith(
-            "Return a <= b.  Computed by @total_ordering from"
+            "Return a >= b.  Computed by @total_ordering from"
         )
         assert method.__name__ == "__ge__"
-        assert method.__qualname__ == "PartialOrderCSameType.__ge__"
 
 
 class TestDundersFullOrdering(object):
@@ -416,7 +408,6 @@ class TestDundersFullOrdering(object):
         method = self.cls.__eq__
         assert method.__doc__.strip() == "Return a == b.  Computed by attrs."
         assert method.__name__ == "__eq__"
-        assert method.__qualname__ == "FullOrderCSameType.__eq__"
 
     def test_ne(self):
         """
@@ -428,7 +419,6 @@ class TestDundersFullOrdering(object):
             "        return the result negated."
         )
         assert method.__name__ == "__ne__"
-        assert method.__qualname__ == "FullOrderCSameType.__ne__"
 
     def test_lt(self):
         """
@@ -437,7 +427,6 @@ class TestDundersFullOrdering(object):
         method = self.cls.__lt__
         assert method.__doc__.strip() == "Return a < b.  Computed by attrs."
         assert method.__name__ == "__lt__"
-        assert method.__qualname__ == "FullOrderCSameType.__lt__"
 
     def test_le(self):
         """
@@ -446,7 +435,6 @@ class TestDundersFullOrdering(object):
         method = self.cls.__le__
         assert method.__doc__.strip() == "Return a <= b.  Computed by attrs."
         assert method.__name__ == "__le__"
-        assert method.__qualname__ == "FullOrderCSameType.__le__"
 
     def test_gt(self):
         """
@@ -455,7 +443,6 @@ class TestDundersFullOrdering(object):
         method = self.cls.__gt__
         assert method.__doc__.strip() == "Return a > b.  Computed by attrs."
         assert method.__name__ == "__gt__"
-        assert method.__qualname__ == "FullOrderCSameType.__gt__"
 
     def test_ge(self):
         """
@@ -464,4 +451,3 @@ class TestDundersFullOrdering(object):
         method = self.cls.__ge__
         assert method.__doc__.strip() == "Return a >= b.  Computed by attrs."
         assert method.__name__ == "__ge__"
-        assert method.__qualname__ == "FullOrderCSameType.__ge__"

--- a/tests/test_cmp.py
+++ b/tests/test_cmp.py
@@ -302,7 +302,8 @@ class TestDundersUnnamedClass(object):
         Class name and qualified name should be well behaved.
         """
         assert self.cls.__name__ == "Comparable"
-        assert self.cls.__qualname__ == "Comparable"
+        if not PY2:
+            assert self.cls.__qualname__ == "Comparable"
 
     def test_eq(self):
         """
@@ -336,7 +337,8 @@ class TestDundersPartialOrdering(object):
         Class name and qualified name should be well behaved.
         """
         assert self.cls.__name__ == "PartialOrderCSameType"
-        assert self.cls.__qualname__ == "PartialOrderCSameType"
+        if not PY2:
+            assert self.cls.__qualname__ == "PartialOrderCSameType"
 
     def test_eq(self):
         """
@@ -370,9 +372,12 @@ class TestDundersPartialOrdering(object):
         __le__ docstring and qualified name should be well behaved.
         """
         method = self.cls.__le__
-        assert method.__doc__.strip().startswith(
-            "Return a <= b.  Computed by @total_ordering from"
-        )
+        if PY2:
+            assert method.__doc__ == "x.__le__(y) <==> x<=y"
+        else:
+            assert method.__doc__.strip().startswith(
+                "Return a <= b.  Computed by @total_ordering from"
+            )
         assert method.__name__ == "__le__"
 
     def test_gt(self):
@@ -380,9 +385,12 @@ class TestDundersPartialOrdering(object):
         __gt__ docstring and qualified name should be well behaved.
         """
         method = self.cls.__gt__
-        assert method.__doc__.strip().startswith(
-            "Return a > b.  Computed by @total_ordering from"
-        )
+        if PY2:
+            assert method.__doc__ == "x.__gt__(y) <==> x>y"
+        else:
+            assert method.__doc__.strip().startswith(
+                "Return a > b.  Computed by @total_ordering from"
+            )
         assert method.__name__ == "__gt__"
 
     def test_ge(self):
@@ -390,9 +398,12 @@ class TestDundersPartialOrdering(object):
         __ge__ docstring and qualified name should be well behaved.
         """
         method = self.cls.__ge__
-        assert method.__doc__.strip().startswith(
-            "Return a >= b.  Computed by @total_ordering from"
-        )
+        if PY2:
+            assert method.__doc__ == "x.__ge__(y) <==> x>=y"
+        else:
+            assert method.__doc__.strip().startswith(
+                "Return a >= b.  Computed by @total_ordering from"
+            )
         assert method.__name__ == "__ge__"
 
 
@@ -408,7 +419,8 @@ class TestDundersFullOrdering(object):
         Class name and qualified name should be well behaved.
         """
         assert self.cls.__name__ == "FullOrderCSameType"
-        assert self.cls.__qualname__ == "FullOrderCSameType"
+        if not PY2:
+            assert self.cls.__qualname__ == "FullOrderCSameType"
 
     def test_eq(self):
         """

--- a/tests/test_cmp.py
+++ b/tests/test_cmp.py
@@ -1,0 +1,467 @@
+"""
+Tests for methods from `attrib._cmp`.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from attr._cmp import cmp_using
+
+
+# Test parameters.
+EqCSameType = cmp_using(eq=lambda a, b: a == b, class_name="EqCSameType")
+PartialOrderCSameType = cmp_using(
+    eq=lambda a, b: a == b,
+    lt=lambda a, b: a < b,
+    class_name="PartialOrderCSameType",
+)
+FullOrderCSameType = cmp_using(
+    eq=lambda a, b: a == b,
+    lt=lambda a, b: a < b,
+    le=lambda a, b: a <= b,
+    gt=lambda a, b: a > b,
+    ge=lambda a, b: a >= b,
+    class_name="FullOrderCSameType",
+)
+
+EqCAnyType = cmp_using(
+    eq=lambda a, b: a == b, require_same_type=False, class_name="EqCAnyType"
+)
+PartialOrderCAnyType = cmp_using(
+    eq=lambda a, b: a == b,
+    lt=lambda a, b: a < b,
+    require_same_type=False,
+    class_name="PartialOrderCAnyType",
+)
+
+
+eq_data = [
+    (EqCSameType, True),
+    (EqCAnyType, False),
+]
+
+order_data = [
+    (PartialOrderCSameType, True),
+    (PartialOrderCAnyType, False),
+    (FullOrderCSameType, True),
+]
+
+eq_ids = [c[0].__name__ for c in eq_data]
+order_ids = [c[0].__name__ for c in order_data]
+
+cmp_data = eq_data + order_data
+cmp_ids = eq_ids + order_ids
+
+
+class TestEqOrder(object):
+    """
+    Tests for eq and order related methods.
+    """
+
+    #########
+    # eq
+    #########
+    @pytest.mark.parametrize("cls, requires_same_type", cmp_data, ids=cmp_ids)
+    def test_equal_same_type(self, cls, requires_same_type):
+        """
+        Equal objects are detected as equal.
+        """
+        assert cls(1) == cls(1)
+        assert not (cls(1) != cls(1))
+
+    @pytest.mark.parametrize("cls, requires_same_type", cmp_data, ids=cmp_ids)
+    def test_unequal_same_type(self, cls, requires_same_type):
+        """
+        Unequal objects of correct type are detected as unequal.
+        """
+        assert cls(1) != cls(2)
+        assert not (cls(1) == cls(2))
+
+    @pytest.mark.parametrize("cls, requires_same_type", cmp_data, ids=cmp_ids)
+    def test_equal_different_type(self, cls, requires_same_type: bool):
+        """
+        Equal values of different types are detected appropriately.
+        """
+        assert (cls(1) == cls(1.0)) == (not requires_same_type)
+        assert not (cls(1) != cls(1.0)) == (not requires_same_type)
+
+    #########
+    # lt
+    #########
+    @pytest.mark.parametrize("cls, requires_same_type", eq_data, ids=eq_ids)
+    def test_lt_unorderable(self, cls, requires_same_type):
+        """
+        TypeError is raised if class does not implement __lt__.
+        """
+        with pytest.raises(TypeError):
+            cls(1) < cls(2)
+
+    @pytest.mark.parametrize(
+        "cls, requires_same_type", order_data, ids=order_ids
+    )
+    def test_lt_same_type(self, cls, requires_same_type):
+        """
+        Less-than objects are detected appropriately.
+        """
+        assert cls(1) < cls(2)
+        assert not (cls(2) < cls(1))
+
+    @pytest.mark.parametrize(
+        "cls, requires_same_type", order_data, ids=order_ids
+    )
+    def test_not_lt_same_type(self, cls, requires_same_type):
+        """
+        Not less-than objects are detected appropriately.
+        """
+        assert cls(2) >= cls(1)
+        assert not (cls(1) >= cls(2))
+
+    @pytest.mark.parametrize(
+        "cls, requires_same_type", order_data, ids=order_ids
+    )
+    def test_lt_different_type(self, cls, requires_same_type):
+        """
+        Less-than values of different types are detected appropriately.
+        """
+        if requires_same_type:
+            # Unlike __eq__, NotImplemented will cause an exception to be
+            # raised from __lt__.
+            with pytest.raises(TypeError):
+                cls(1) < cls(2.0)
+        else:
+            assert cls(1) < cls(2.0)
+            assert not (cls(2) < cls(1.0))
+
+    #########
+    # le
+    #########
+    @pytest.mark.parametrize("cls, requires_same_type", eq_data, ids=eq_ids)
+    def test_le_unorderable(self, cls, requires_same_type):
+        """
+        TypeError is raised if class does not implement __le__.
+        """
+        with pytest.raises(TypeError):
+            cls(1) <= cls(2)
+
+    @pytest.mark.parametrize(
+        "cls, requires_same_type", order_data, ids=order_ids
+    )
+    def test_le_same_type(self, cls, requires_same_type):
+        """
+        Less-than-or-equal objects are detected appropriately.
+        """
+        assert cls(1) <= cls(1)
+        assert cls(1) <= cls(2)
+        assert not (cls(2) <= cls(1))
+
+    @pytest.mark.parametrize(
+        "cls, requires_same_type", order_data, ids=order_ids
+    )
+    def test_not_le_same_type(self, cls, requires_same_type):
+        """
+        Not less-than-or-equal objects are detected appropriately.
+        """
+        assert cls(2) > cls(1)
+        assert not (cls(1) > cls(1))
+        assert not (cls(1) > cls(2))
+
+    @pytest.mark.parametrize(
+        "cls, requires_same_type", order_data, ids=order_ids
+    )
+    def test_le_different_type(self, cls, requires_same_type):
+        """
+        Less-than-or-equal values of diff. types are detected appropriately.
+        """
+        if requires_same_type:
+            # Unlike __eq__, NotImplemented will cause an exception to be
+            # raised from __le__.
+            with pytest.raises(TypeError):
+                cls(1) <= cls(2.0)
+        else:
+            assert cls(1) <= cls(2.0)
+            assert cls(1) <= cls(1.0)
+            assert not (cls(2) <= cls(1.0))
+
+    #########
+    # gt
+    #########
+    @pytest.mark.parametrize("cls, requires_same_type", eq_data, ids=eq_ids)
+    def test_gt_unorderable(self, cls, requires_same_type):
+        """
+        TypeError is raised if class does not implement __gt__.
+        """
+        with pytest.raises(TypeError):
+            cls(2) > cls(1)
+
+    @pytest.mark.parametrize(
+        "cls, requires_same_type", order_data, ids=order_ids
+    )
+    def test_gt_same_type(self, cls, requires_same_type):
+        """
+        Greater-than objects are detected appropriately.
+        """
+        assert cls(2) > cls(1)
+        assert not (cls(1) > cls(2))
+
+    @pytest.mark.parametrize(
+        "cls, requires_same_type", order_data, ids=order_ids
+    )
+    def test_not_gt_same_type(self, cls, requires_same_type):
+        """
+        Not greater-than objects are detected appropriately.
+        """
+        assert cls(1) <= cls(2)
+        assert not (cls(2) <= cls(1))
+
+    @pytest.mark.parametrize(
+        "cls, requires_same_type", order_data, ids=order_ids
+    )
+    def test_gt_different_type(self, cls, requires_same_type):
+        """
+        Greater-than values of different types are detected appropriately.
+        """
+        if requires_same_type:
+            # Unlike __eq__, NotImplemented will cause an exception to be
+            # raised from __gt__.
+            with pytest.raises(TypeError):
+                cls(2) > cls(1.0)
+        else:
+            assert cls(2) > cls(1.0)
+            assert not (cls(1) > cls(2.0))
+
+    #########
+    # ge
+    #########
+    @pytest.mark.parametrize("cls, requires_same_type", eq_data, ids=eq_ids)
+    def test_ge_unorderable(self, cls, requires_same_type):
+        """
+        TypeError is raised if class does not implement __ge__.
+        """
+        with pytest.raises(TypeError):
+            cls(2) >= cls(1)
+
+    @pytest.mark.parametrize(
+        "cls, requires_same_type", order_data, ids=order_ids
+    )
+    def test_ge_same_type(self, cls, requires_same_type):
+        """
+        Greater-than-or-equal objects are detected appropriately.
+        """
+        assert cls(1) >= cls(1)
+        assert cls(2) >= cls(1)
+        assert not (cls(1) >= cls(2))
+
+    @pytest.mark.parametrize(
+        "cls, requires_same_type", order_data, ids=order_ids
+    )
+    def test_not_ge_same_type(self, cls, requires_same_type):
+        """
+        Not greater-than-or-equal objects are detected appropriately.
+        """
+        assert cls(1) < cls(2)
+        assert not (cls(1) < cls(1))
+        assert not (cls(2) < cls(1))
+
+    @pytest.mark.parametrize(
+        "cls, requires_same_type", order_data, ids=order_ids
+    )
+    def test_ge_different_type(self, cls, requires_same_type):
+        """
+        Greater-than-or-equal values of diff. types are detected appropriately.
+        """
+        if requires_same_type:
+            # Unlike __eq__, NotImplemented will cause an exception to be
+            # raised from __ge__.
+            with pytest.raises(TypeError):
+                cls(2) >= cls(1.0)
+        else:
+            assert cls(2) >= cls(2.0)
+            assert cls(2) >= cls(1.0)
+            assert not (cls(1) >= cls(2.0))
+
+
+class TestDundersUnnamedClass(object):
+    """
+    Tests for dunder attributes of unnamed classes.
+    """
+
+    cls = cmp_using(eq=lambda a, b: a == b)
+
+    def test_class(self):
+        """
+        Class name and qualified name should be well behaved.
+        """
+        assert self.cls.__name__ == "Comparable"
+        assert self.cls.__qualname__ == "Comparable"
+
+    def test_eq(self):
+        """
+        __eq__ docstring and qualified name should be well behaved.
+        """
+        method = self.cls.__eq__
+        assert method.__doc__.strip() == "Return a == b.  Computed by attrs."
+        assert method.__name__ == "__eq__"
+        assert method.__qualname__ == "Comparable.__eq__"
+
+    def test_ne(self):
+        """
+        __ne__ docstring and qualified name should be well behaved.
+        """
+        method = self.cls.__ne__
+        assert method.__doc__.strip() == (
+            "Check equality and either forward a NotImplemented or\n"
+            "        return the result negated."
+        )
+        assert method.__name__ == "__ne__"
+        assert method.__qualname__ == "Comparable.__ne__"
+
+
+class TestDundersPartialOrdering(object):
+    """
+    Tests for dunder attributes of classes with partial ordering.
+    """
+
+    cls = PartialOrderCSameType
+
+    def test_class(self):
+        """
+        Class name and qualified name should be well behaved.
+        """
+        assert self.cls.__name__ == "PartialOrderCSameType"
+        assert self.cls.__qualname__ == "PartialOrderCSameType"
+
+    def test_eq(self):
+        """
+        __eq__ docstring and qualified name should be well behaved.
+        """
+        method = self.cls.__eq__
+        assert method.__doc__.strip() == "Return a == b.  Computed by attrs."
+        assert method.__name__ == "__eq__"
+        assert method.__qualname__ == "PartialOrderCSameType.__eq__"
+
+    def test_ne(self):
+        """
+        __ne__ docstring and qualified name should be well behaved.
+        """
+        method = self.cls.__ne__
+        assert method.__doc__.strip() == (
+            "Check equality and either forward a NotImplemented or\n"
+            "        return the result negated."
+        )
+        assert method.__name__ == "__ne__"
+        assert method.__qualname__ == "PartialOrderCSameType.__ne__"
+
+    def test_lt(self):
+        """
+        __lt__ docstring and qualified name should be well behaved.
+        """
+        method = self.cls.__lt__
+        assert method.__doc__.strip() == "Return a < b.  Computed by attrs."
+        assert method.__name__ == "__lt__"
+        assert method.__qualname__ == "PartialOrderCSameType.__lt__"
+
+    def test_le(self):
+        """
+        __le__ docstring and qualified name should be well behaved.
+        """
+        method = self.cls.__le__
+        assert method.__doc__.strip().startswith(
+            "Return a <= b.  Computed by @total_ordering from"
+        )
+        assert method.__name__ == "__le__"
+        assert method.__qualname__ == "PartialOrderCSameType.__le__"
+
+    def test_gt(self):
+        """
+        __gt__ docstring and qualified name should be well behaved.
+        """
+        method = self.cls.__gt__
+        assert method.__doc__.strip().startswith(
+            "Return a > b.  Computed by @total_ordering from"
+        )
+        assert method.__name__ == "__gt__"
+        assert method.__qualname__ == "PartialOrderCSameType.__gt__"
+
+    def test_ge(self):
+        """
+        __ge__ docstring and qualified name should be well behaved.
+        """
+        method = self.cls.__ge__
+        assert method.__doc__.strip().startswith(
+            "Return a <= b.  Computed by @total_ordering from"
+        )
+        assert method.__name__ == "__ge__"
+        assert method.__qualname__ == "PartialOrderCSameType.__ge__"
+
+
+class TestDundersFullOrdering(object):
+    """
+    Tests for dunder attributes of classes with full ordering.
+    """
+
+    cls = FullOrderCSameType
+
+    def test_class(self):
+        """
+        Class name and qualified name should be well behaved.
+        """
+        assert self.cls.__name__ == "FullOrderCSameType"
+        assert self.cls.__qualname__ == "FullOrderCSameType"
+
+    def test_eq(self):
+        """
+        __eq__ docstring and qualified name should be well behaved.
+        """
+        method = self.cls.__eq__
+        assert method.__doc__.strip() == "Return a == b.  Computed by attrs."
+        assert method.__name__ == "__eq__"
+        assert method.__qualname__ == "FullOrderCSameType.__eq__"
+
+    def test_ne(self):
+        """
+        __ne__ docstring and qualified name should be well behaved.
+        """
+        method = self.cls.__ne__
+        assert method.__doc__.strip() == (
+            "Check equality and either forward a NotImplemented or\n"
+            "        return the result negated."
+        )
+        assert method.__name__ == "__ne__"
+        assert method.__qualname__ == "FullOrderCSameType.__ne__"
+
+    def test_lt(self):
+        """
+        __lt__ docstring and qualified name should be well behaved.
+        """
+        method = self.cls.__lt__
+        assert method.__doc__.strip() == "Return a < b.  Computed by attrs."
+        assert method.__name__ == "__lt__"
+        assert method.__qualname__ == "FullOrderCSameType.__lt__"
+
+    def test_le(self):
+        """
+        __le__ docstring and qualified name should be well behaved.
+        """
+        method = self.cls.__le__
+        assert method.__doc__.strip() == "Return a <= b.  Computed by attrs."
+        assert method.__name__ == "__le__"
+        assert method.__qualname__ == "FullOrderCSameType.__le__"
+
+    def test_gt(self):
+        """
+        __gt__ docstring and qualified name should be well behaved.
+        """
+        method = self.cls.__gt__
+        assert method.__doc__.strip() == "Return a > b.  Computed by attrs."
+        assert method.__name__ == "__gt__"
+        assert method.__qualname__ == "FullOrderCSameType.__gt__"
+
+    def test_ge(self):
+        """
+        __ge__ docstring and qualified name should be well behaved.
+        """
+        method = self.cls.__ge__
+        assert method.__doc__.strip() == "Return a >= b.  Computed by attrs."
+        assert method.__name__ == "__ge__"
+        assert method.__qualname__ == "FullOrderCSameType.__ge__"

--- a/tests/test_cmp.py
+++ b/tests/test_cmp.py
@@ -325,6 +325,40 @@ class TestDundersUnnamedClass(object):
         assert method.__name__ == "__ne__"
 
 
+class TestTotalOrderingException(object):
+    """
+    Test for exceptions related to total ordering.
+    """
+
+    def test_eq_must_specified(self):
+        """
+        `total_ordering` requires `__eq__` to be specified.
+        """
+        with pytest.raises(ValueError) as ei:
+            cmp_using(lt=lambda a, b: a < b)
+
+        assert ei.value.args[0] == (
+            "eq must be define is order to complete ordering from "
+            "lt, le, gt, ge."
+        )
+
+
+class TestNotImplementedIsPropagated(object):
+    """
+    Test related to functions that return NotImplemented.
+    """
+
+    def test_not_implemented_is_propagated(self):
+        """
+        If the comparison function returns NotImplemented,
+        the dunder method should too.
+        """
+        C = cmp_using(eq=lambda a, b: NotImplemented if a == 1 else a == b)
+
+        assert C(2) == C(2)
+        assert C(1) != C(1)
+
+
 class TestDundersPartialOrdering(object):
     """
     Tests for dunder attributes of classes with partial ordering.

--- a/tests/test_cmp.py
+++ b/tests/test_cmp.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function
 import pytest
 
 from attr._cmp import cmp_using
+from attr._compat import PY2
 
 
 # Test parameters.
@@ -89,6 +90,7 @@ class TestEqOrder(object):
     #########
     # lt
     #########
+    @pytest.mark.skipif(PY2, reason="PY2 does not raise TypeError")
     @pytest.mark.parametrize("cls, requires_same_type", eq_data, ids=eq_ids)
     def test_lt_unorderable(self, cls, requires_same_type):
         """
@@ -124,7 +126,7 @@ class TestEqOrder(object):
         """
         Less-than values of different types are detected appropriately.
         """
-        if requires_same_type:
+        if requires_same_type and not PY2:
             # Unlike __eq__, NotImplemented will cause an exception to be
             # raised from __lt__.
             with pytest.raises(TypeError):
@@ -136,6 +138,7 @@ class TestEqOrder(object):
     #########
     # le
     #########
+    @pytest.mark.skipif(PY2, reason="PY2 does not raise TypeError")
     @pytest.mark.parametrize("cls, requires_same_type", eq_data, ids=eq_ids)
     def test_le_unorderable(self, cls, requires_same_type):
         """
@@ -173,7 +176,7 @@ class TestEqOrder(object):
         """
         Less-than-or-equal values of diff. types are detected appropriately.
         """
-        if requires_same_type:
+        if requires_same_type and not PY2:
             # Unlike __eq__, NotImplemented will cause an exception to be
             # raised from __le__.
             with pytest.raises(TypeError):
@@ -186,6 +189,7 @@ class TestEqOrder(object):
     #########
     # gt
     #########
+    @pytest.mark.skipif(PY2, reason="PY2 does not raise TypeError")
     @pytest.mark.parametrize("cls, requires_same_type", eq_data, ids=eq_ids)
     def test_gt_unorderable(self, cls, requires_same_type):
         """
@@ -221,7 +225,7 @@ class TestEqOrder(object):
         """
         Greater-than values of different types are detected appropriately.
         """
-        if requires_same_type:
+        if requires_same_type and not PY2:
             # Unlike __eq__, NotImplemented will cause an exception to be
             # raised from __gt__.
             with pytest.raises(TypeError):
@@ -233,6 +237,7 @@ class TestEqOrder(object):
     #########
     # ge
     #########
+    @pytest.mark.skipif(PY2, reason="PY2 does not raise TypeError")
     @pytest.mark.parametrize("cls, requires_same_type", eq_data, ids=eq_ids)
     def test_ge_unorderable(self, cls, requires_same_type):
         """
@@ -270,7 +275,7 @@ class TestEqOrder(object):
         """
         Greater-than-or-equal values of diff. types are detected appropriately.
         """
-        if requires_same_type:
+        if requires_same_type and not PY2:
             # Unlike __eq__, NotImplemented will cause an exception to be
             # raised from __ge__.
             with pytest.raises(TypeError):


### PR DESCRIPTION
# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.  If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.

- [X] Added **tests** for changed code.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [X] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [?] ...and used in the stub test file `tests/typing_example.py`.
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/main/src/attr/__init__.py) file.
- [ ] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
