### PR TITLE
Remove warning if eq is customized & order is not

### DIFF
--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1073,11 +1073,6 @@ _CMP_DEPRECATION = (
     "2021-06-01.  Please use `eq` and `order` instead."
 )
 
-_EQ_ORDER_CUSTOMIZATION = (
-    "You have customized the behavior of `eq` but not of `order`.  "
-    "This is probably a bug."
-)
-
 
 def _determine_attrs_eq_order(cmp, eq, order, default_eq):
     """
@@ -1136,9 +1131,6 @@ def _determine_attrib_eq_order(cmp, eq, order, default_eq):
         eq, eq_key = decide_callable_or_boolean(eq)
 
     if order is None:
-        if eq_key is not None:
-            warnings.warn(_EQ_ORDER_CUSTOMIZATION, SyntaxWarning, stacklevel=3)
-
         order, order_key = eq, eq_key
     else:
         order, order_key = decide_callable_or_boolean(order)

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -1908,27 +1908,6 @@ class TestDetermineAttribEqOrder(object):
             None, eq, None, True
         )
 
-    def test_order_missing_and_custom_eq(self):
-        """
-        If eq is customized and order is missing, order mirrors eq
-        but a warning is raised.
-        """
-        with pytest.warns(None) as wr:
-
-            assert (
-                True,
-                str.lower,
-                True,
-                str.lower,
-            ) == _determine_attrib_eq_order(None, str.lower, None, True)
-
-        (w,) = wr.list
-
-        assert (
-            "You have customized the behavior of `eq` but not of `order`.  "
-            "This is probably a bug." == w.message.args[0]
-        )
-
     def test_order_without_eq(self):
         """
         eq=False, order=True raises a meaningful ValueError.


### PR DESCRIPTION
Since this warning is raised from the attr.ib/attr.field call, we cannot verify
whether order is on at all for the whole class. Fixing this would require to
check _after_ the class is assembled which is both additional complexity as
well as performance overhead. Unless we get inundated by bug reports, this
doesn't seem worth it.

@botant @Julian 