### PR TITLE
Declare Python 3.4 as incompatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ if __name__ == "__main__":
         long_description_content_type="text/x-rst",
         packages=PACKAGES,
         package_dir={"": "src"},
-        python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+        python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
         zip_safe=False,
         classifiers=CLASSIFIERS,
         install_requires=INSTALL_REQUIRES,


### PR DESCRIPTION
Python 3.4 testing has been dropped in #608, but it was not declared as incompatible in setup.py because the code base was expected to still work with Python 3.4 for a while. This compatibility finally broke with the 21.1.0 release. At least one of the problematic commits is e09b1d642339d7d94ba58d7855da40e65ed1a88f introducing an import of the typing module not available in Python 3.4.

Trying to import attr with Python 3.4 gives the following exception:
```
>>> import attr
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/gosmannj/Documents/projects/attrs/.venv/lib/python3.4/site-packages/attr/__init__.py", line 7, in <module>
    from . import converters, exceptions, filters, setters, validators
  File "/Users/gosmannj/Documents/projects/attrs/.venv/lib/python3.4/site-packages/attr/converters.py", line 8, in <module>
    from ._make import NOTHING, Factory, pipe
  File "/Users/gosmannj/Documents/projects/attrs/.venv/lib/python3.4/site-packages/attr/_make.py", line 34, in <module>
    import typing
ImportError: No module named 'typing'
```

Alternatively, it might be a possibility to add the [typing backport](https://pypi.org/project/typing/) as dependency for Python 3.4 installs. But I suppose this is not desired as official Python 3.4 support has been dropped.
