### PR TITLE
Add __match_args__ to support match case destructuring in Python 3.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
     rev: 20.8b1
     hooks:
       - id: black
+        exclude: tests/test_pattern_matching.py
         language_version: python3.8
 
   - repo: https://github.com/PyCQA/isort
@@ -22,8 +23,9 @@ repos:
     rev: 1.3.2
     hooks:
       - id: interrogate
+        exclude: tests/test_pattern_matching.py
         args: [tests]
-        language_version: python3.8
+        language_version: python3.10
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
@@ -31,4 +33,5 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: debug-statements
+        language_version: python3.10
       - id: check-toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: 3.8.4
     hooks:
       - id: flake8
-        language_version: python3.8
+        language_version: python3.10
 
   - repo: https://github.com/econchick/interrogate
     rev: 1.3.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,13 +15,6 @@ Changes for the upcoming release can be found in the `"changelog.d" directory <h
 
 .. towncrier release notes start
 
-21.3.0.dev0 (2021-05-14)
-No significant changes.
-
-
-----
-
-
 21.2.0 (2021-05-07)
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,13 @@ Changes for the upcoming release can be found in the `"changelog.d" directory <h
 
 .. towncrier release notes start
 
+21.3.0.dev0 (2021-05-14)
+No significant changes.
+
+
+----
+
+
 21.2.0 (2021-05-07)
 -------------------
 

--- a/changelog.d/815.changes.rst
+++ b/changelog.d/815.changes.rst
@@ -1,2 +1,3 @@
-Add ``__match_args__`` to generated class to support match case destructuring
-in Python 3.10. This can be controlled by ``match_args`` argument to ``@attrib.s``.
+``__match_args__`` are now generated to support Python 3.10's
+`Structural Pattern Matching <https://docs.python.org/3.10/whatsnew/3.10.html#pep-634-structural-pattern-matching>`_.
+This can be controlled by ``match_args`` argument to the class decorators.

--- a/changelog.d/815.changes.rst
+++ b/changelog.d/815.changes.rst
@@ -1,0 +1,2 @@
+Add ``__match_args__`` to generated class to support match case destructuring
+in Python 3.10. This can be controlled by ``match_args`` argument to ``@attrib.s``.

--- a/conftest.py
+++ b/conftest.py
@@ -23,6 +23,12 @@ if sys.version_info[:2] < (3, 6):
             "tests/test_next_gen.py",
         ]
     )
+if sys.version_info[:2] < (3, 10):
+    collect_ignore.extend(
+        [
+            "tests/test_pattern_matching.py"
+        ]
+    )
 if sys.version_info[:2] >= (3, 10):
     collect_ignore.extend(
         [

--- a/conftest.py
+++ b/conftest.py
@@ -24,11 +24,7 @@ if sys.version_info[:2] < (3, 6):
         ]
     )
 if sys.version_info[:2] < (3, 10):
-    collect_ignore.extend(
-        [
-            "tests/test_pattern_matching.py"
-        ]
-    )
+    collect_ignore.extend(["tests/test_pattern_matching.py"])
 if sys.version_info[:2] >= (3, 10):
     collect_ignore.extend(
         [

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -28,7 +28,7 @@ Core
 
 .. autodata:: attr.NOTHING
 
-.. autofunction:: attr.s(these=None, repr_ns=None, repr=None, cmp=None, hash=None, init=None, slots=False, frozen=False, weakref_slot=True, str=False, auto_attribs=False, kw_only=False, cache_hash=False, auto_exc=False, eq=None, order=None, auto_detect=False, collect_by_mro=False, getstate_setstate=None, on_setattr=None, field_transformer=None)
+.. autofunction:: attr.s(these=None, repr_ns=None, repr=None, cmp=None, hash=None, init=None, slots=False, frozen=False, weakref_slot=True, str=False, auto_attribs=False, kw_only=False, cache_hash=False, auto_exc=False, eq=None, order=None, auto_detect=False, collect_by_mro=False, getstate_setstate=None, on_setattr=None, field_transformer=None, match_args=True)
 
    .. note::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ exclude_lines = [
 
 [tool.black]
 line-length = 79
+extend-exclude = '''
+# Exclude pattern matching test till black gains Python 3.10 support
+.*test_pattern_matching.*
+'''
 
 
 [tool.interrogate]

--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -367,6 +367,7 @@ def define(
     getstate_setstate: Optional[bool] = ...,
     on_setattr: Optional[_OnSetAttrArgType] = ...,
     field_transformer: Optional[_FieldTransformer] = ...,
+    match_args: bool = ...,
 ) -> _C: ...
 @overload
 @__dataclass_transform__(field_descriptors=(attrib, field))
@@ -391,6 +392,7 @@ def define(
     getstate_setstate: Optional[bool] = ...,
     on_setattr: Optional[_OnSetAttrArgType] = ...,
     field_transformer: Optional[_FieldTransformer] = ...,
+    match_args: bool = ...,
 ) -> Callable[[_C], _C]: ...
 
 mutable = define

--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -315,6 +315,7 @@ def attrs(
     getstate_setstate: Optional[bool] = ...,
     on_setattr: Optional[_OnSetAttrArgType] = ...,
     field_transformer: Optional[_FieldTransformer] = ...,
+    match_args: bool = ...,
 ) -> _C: ...
 @overload
 @__dataclass_transform__(order_default=True, field_descriptors=(attrib, field))
@@ -341,6 +342,7 @@ def attrs(
     getstate_setstate: Optional[bool] = ...,
     on_setattr: Optional[_OnSetAttrArgType] = ...,
     field_transformer: Optional[_FieldTransformer] = ...,
+    match_args: bool = ...,
 ) -> Callable[[_C], _C]: ...
 @overload
 @__dataclass_transform__(field_descriptors=(attrib, field))

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1369,7 +1369,7 @@ def attrs(
     :param bool collect_by_mro: Setting this to `True` fixes the way ``attrs``
        collects attributes from base classes.  The default behavior is
        incorrect in certain cases of multiple inheritance.  It should be on by
-       default but is kept off for backward-compatability.
+       default but is kept off for backward-compatibility.
 
        See issue `#428 <https://github.com/python-attrs/attrs/issues/428>`_ for
        more details.

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -966,6 +966,13 @@ class _ClassBuilder(object):
 
         return self
 
+    def add_match_args(self):
+        self._cls_dict["__match_args__"] = tuple(
+            field.name
+            for field in self._attrs
+            if field.init and not field.kw_only
+        )
+
     def add_attrs_init(self):
         self._cls_dict["__attrs_init__"] = self._add_method_dunders(
             _make_init(
@@ -1192,6 +1199,7 @@ def attrs(
     getstate_setstate=None,
     on_setattr=None,
     field_transformer=None,
+    match_args=True,
 ):
     r"""
     A class decorator that adds `dunder
@@ -1407,6 +1415,10 @@ def attrs(
         this, e.g., to automatically add converters or validators to
         fields based on their types.  See `transform-fields` for more details.
 
+    :param bool match_args:
+        If `True` it sets __match_args__ in the class to support PEP 634. It is a
+        tuple of __init__ parameter names that are only positional arguments.
+
     .. versionadded:: 16.0.0 *slots*
     .. versionadded:: 16.1.0 *frozen*
     .. versionadded:: 16.3.0 *str*
@@ -1555,6 +1567,9 @@ def attrs(
                     "Invalid value for cache_hash.  To use hash caching,"
                     " init must be True."
                 )
+
+        if match_args and "__match_args__" not in cls.__dict__:
+            builder.add_match_args()
 
         return builder.build_class()
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1570,7 +1570,7 @@ def attrs(
                     " init must be True."
                 )
 
-        if match_args and "__match_args__" not in cls.__dict__:
+        if match_args and not _has_own_attribute(cls, "__match_args__"):
             builder.add_match_args()
 
         return builder.build_class()

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1416,8 +1416,9 @@ def attrs(
         fields based on their types.  See `transform-fields` for more details.
 
     :param bool match_args:
-        If `True` it sets __match_args__ in the class to support PEP 634. It is a
-        tuple of __init__ parameter names that are only positional arguments.
+        If `True` it sets __match_args__ in the class to support PEP 634. It 
+        is a tuple of __init__ parameter names that are only positional 
+        arguments.
 
     .. versionadded:: 16.0.0 *slots*
     .. versionadded:: 16.1.0 *frozen*

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1416,8 +1416,8 @@ def attrs(
         fields based on their types.  See `transform-fields` for more details.
 
     :param bool match_args:
-        If `True` it sets __match_args__ in the class to support PEP 634. It 
-        is a tuple of __init__ parameter names that are only positional 
+        If `True` it sets __match_args__ in the class to support PEP 634. It
+        is a tuple of __init__ parameter names that are only positional
         arguments.
 
     .. versionadded:: 16.0.0 *slots*

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1416,9 +1416,10 @@ def attrs(
         fields based on their types.  See `transform-fields` for more details.
 
     :param bool match_args:
-        If `True` it sets __match_args__ in the class to support PEP 634. It
-        is a tuple of __init__ parameter names that are only positional
-        arguments.
+        If `True`, set ``__match_args__`` on the class to support `PEP 634
+        <https://www.python.org/dev/peps/pep-0634/>`_ (Structural Pattern
+        Matching). It is a tuple of all positional-only ``__init__`` parameter
+        names.
 
     .. versionadded:: 16.0.0 *slots*
     .. versionadded:: 16.1.0 *frozen*

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1452,6 +1452,7 @@ def attrs(
        ``init=False`` injects ``__attrs_init__``
     .. versionchanged:: 21.1.0 Support for ``__attrs_pre_init__``
     .. versionchanged:: 21.1.0 *cmp* undeprecated
+    .. versionadded:: 21.3.0 *match_args*
     """
     if auto_detect and PY2:
         raise PythonTooOldError(

--- a/src/attr/_next_gen.py
+++ b/src/attr/_next_gen.py
@@ -32,6 +32,7 @@ def define(
     getstate_setstate=None,
     on_setattr=None,
     field_transformer=None,
+    match_args=True,
 ):
     r"""
     The only behavioral differences are the handling of the *auto_attribs*
@@ -72,6 +73,7 @@ def define(
             getstate_setstate=getstate_setstate,
             on_setattr=on_setattr,
             field_transformer=field_transformer,
+            match_args=match_args,
         )
 
     def wrap(cls):

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -2329,8 +2329,16 @@ class TestAutoDetect:
         assert None is getattr(C(), "__getstate__", None)
 
 
-class TestMatchArgs:
+class TestMatchArgs(object):
+    """
+    Tests for match_args and __match_args__ generation.
+    """
+
     def test_match_args(self):
+        """
+        Test __match_args__ generation
+        """
+
         @attr.s()
         class C(object):
             a = attr.ib()
@@ -2338,6 +2346,10 @@ class TestMatchArgs:
         assert C.__match_args__ == ("a",)
 
     def test_explicit_match_args(self):
+        """
+        Test __match_args__ manually set is not overriden.
+        """
+
         ma = ()
 
         @attr.s()
@@ -2349,6 +2361,10 @@ class TestMatchArgs:
 
     @pytest.mark.parametrize("match_args", [True, False])
     def test_match_args_attr_set(self, match_args):
+        """
+        Test __match_args__ being set depending on match_args.
+        """
+
         @attr.s(match_args=match_args)
         class C(object):
             a = attr.ib()
@@ -2359,6 +2375,11 @@ class TestMatchArgs:
             assert not hasattr(C, "__match_args__")
 
     def test_match_args_kw_only(self):
+        """
+        Test kw_only being set doesn't generate __match_args__
+        Test kw_only field is not included in __match_args__
+        """
+
         @attr.s()
         class C(object):
             a = attr.ib(kw_only=True)
@@ -2374,6 +2395,10 @@ class TestMatchArgs:
         assert C.__match_args__ == ()
 
     def test_match_args_argument(self):
+        """
+        Test match_args being False with inheritance.
+        """
+
         @attr.s(match_args=False)
         class X(object):
             a = attr.ib()
@@ -2405,6 +2430,10 @@ class TestMatchArgs:
         assert B.__match_args__ == ("a", "z")
 
     def test_make_class(self):
+        """
+        Test match_args generation with make_class.
+        """
+
         C1 = make_class("C1", ["a", "b"])
         assert C1.__match_args__ == ("a", "b")
 

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -2336,7 +2336,7 @@ class TestMatchArgs(object):
 
     def test_match_args(self):
         """
-        Test __match_args__ generation
+        __match_args__ generation
         """
 
         @attr.s()
@@ -2347,7 +2347,7 @@ class TestMatchArgs(object):
 
     def test_explicit_match_args(self):
         """
-        Test __match_args__ manually set is not overriden.
+        __match_args__ manually set is not overriden.
         """
 
         ma = ()
@@ -2362,7 +2362,7 @@ class TestMatchArgs(object):
     @pytest.mark.parametrize("match_args", [True, False])
     def test_match_args_attr_set(self, match_args):
         """
-        Test __match_args__ being set depending on match_args.
+        __match_args__ being set depending on match_args.
         """
 
         @attr.s(match_args=match_args)
@@ -2376,8 +2376,8 @@ class TestMatchArgs(object):
 
     def test_match_args_kw_only(self):
         """
-        Test kw_only being set doesn't generate __match_args__
-        Test kw_only field is not included in __match_args__
+        kw_only being set doesn't generate __match_args__
+        kw_only field is not included in __match_args__
         """
 
         @attr.s()
@@ -2396,7 +2396,7 @@ class TestMatchArgs(object):
 
     def test_match_args_argument(self):
         """
-        Test match_args being False with inheritance.
+        match_args being False with inheritance.
         """
 
         @attr.s(match_args=False)
@@ -2431,7 +2431,7 @@ class TestMatchArgs(object):
 
     def test_make_class(self):
         """
-        Test match_args generation with make_class.
+        match_args generation with make_class.
         """
 
         C1 = make_class("C1", ["a", "b"])

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -2332,7 +2332,7 @@ class TestAutoDetect:
 class TestMatchArgs:
     def test_match_args(self):
         @attr.s()
-        class C:
+        class C(object):
             a = attr.ib()
 
         assert C.__match_args__ == ("a",)
@@ -2341,7 +2341,7 @@ class TestMatchArgs:
         ma = ()
 
         @attr.s()
-        class C:
+        class C(object):
             a = attr.ib()
             __match_args__ = ma
 
@@ -2350,7 +2350,7 @@ class TestMatchArgs:
     @pytest.mark.parametrize("match_args", [True, False])
     def test_match_args_attr_set(self, match_args):
         @attr.s(match_args=match_args)
-        class C:
+        class C(object):
             a = attr.ib()
 
         if match_args:
@@ -2360,14 +2360,14 @@ class TestMatchArgs:
 
     def test_match_args_kw_only(self):
         @attr.s()
-        class C:
+        class C(object):
             a = attr.ib(kw_only=True)
             b = attr.ib()
 
         assert C.__match_args__ == ("b",)
 
         @attr.s(match_args=True, kw_only=True)
-        class C:
+        class C(object):
             a = attr.ib()
             b = attr.ib()
 
@@ -2375,13 +2375,13 @@ class TestMatchArgs:
 
     def test_match_args_argument(self):
         @attr.s(match_args=False)
-        class X:
+        class X(object):
             a = attr.ib()
 
         assert "__match_args__" not in X.__dict__
 
         @attr.s(match_args=False)
-        class Y:
+        class Y(object):
             a = attr.ib()
             __match_args__ = ("b",)
 
@@ -2394,7 +2394,7 @@ class TestMatchArgs:
         assert Z.__match_args__ == ("b",)
 
         @attr.s()
-        class A:
+        class A(object):
             a = attr.ib()
             z = attr.ib()
 

--- a/tests/test_pattern_matching.py
+++ b/tests/test_pattern_matching.py
@@ -3,6 +3,7 @@
 import pytest
 
 import attr
+
 from attr._make import make_class
 
 

--- a/tests/test_pattern_matching.py
+++ b/tests/test_pattern_matching.py
@@ -1,0 +1,97 @@
+# flake8: noqa
+# Python 3.10 issue in flake8 : https://github.com/PyCQA/pyflakes/issues/634
+import pytest
+
+import attr
+from attr._make import make_class
+
+
+class TestPatternMatching(object):
+    """
+    Pattern matching syntax test cases.
+    """
+
+    def test_simple_match_case(self):
+        """
+        Simple match case statement
+        """
+
+        @attr.s()
+        class C(object):
+            a = attr.ib()
+
+        assert C.__match_args__ == ("a",)
+
+        matched = False
+        c = C(a=1)
+        match c:
+            case C(a):
+                matched = True
+
+        assert matched
+
+    def test_explicit_match_args(self):
+        """
+        Manually set empty __match_args__ will not match.
+        """
+
+        ma = ()
+
+        @attr.s()
+        class C(object):
+            a = attr.ib()
+            __match_args__ = ma
+
+        c = C(a=1)
+
+        msg = r"C\(\) accepts 0 positional sub-patterns \(1 given\)"
+        with pytest.raises(TypeError, match=msg):
+            match c:
+                case C(a):
+                    pass
+
+    def test_match_args_kw_only(self):
+        """
+        kw_only being set doesn't generate __match_args__
+        kw_only field is not included in __match_args__
+        """
+
+        @attr.s()
+        class C(object):
+            a = attr.ib(kw_only=True)
+            b = attr.ib()
+
+        assert C.__match_args__ == ("b",)
+
+        c = C(a=1, b=1)
+        msg = r"C\(\) accepts 1 positional sub-pattern \(2 given\)"
+        with pytest.raises(TypeError, match=msg):
+            match c:
+                case C(a, b):
+                    pass
+
+        found = False
+        match c:
+            case C(b, a=a):
+                found = True
+
+        assert found
+
+        @attr.s(match_args=True, kw_only=True)
+        class C(object):
+            a = attr.ib()
+            b = attr.ib()
+
+        c = C(a=1, b=1)
+        msg = r"C\(\) accepts 0 positional sub-patterns \(2 given\)"
+        with pytest.raises(TypeError, match=msg):
+            match c:
+                case C(a, b):
+                    pass
+
+        found = False
+        match c:
+            case C(a=a, b=b):
+                found = True
+
+        assert found

--- a/tests/typing_example.py
+++ b/tests/typing_example.py
@@ -257,3 +257,10 @@ class FactoryTest:
     a: List[int] = attr.ib(default=attr.Factory(list))
     b: List[Any] = attr.ib(default=attr.Factory(list, False))
     c: List[int] = attr.ib(default=attr.Factory((lambda s: s.a), True))
+
+
+# Check match_args stub
+@attr.s(match_args=False)
+class MatchArgs:
+    a: int = attr.ib()
+    b: int = attr.ib()

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ commands =
 
 
 [testenv:lint]
-basepython = python3.8
+basepython = python3.10
 skip_install = true
 deps =
     pre-commit

--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,9 @@ python =
     3.5: py35
     3.6: py36
     3.7: py37, docs
-    3.8: py38, lint, manifest, typing, changelog
+    3.8: py38, manifest, typing, changelog
     3.9: py39, pyright
-    3.10: py310
+    3.10: py310, lint
     pypy2: pypy2
     pypy3: pypy3
 


### PR DESCRIPTION
# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.  If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.

- [x] Added **tests** for changed code.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [x] ...and used in the stub test file `tests/typing_example.py`.
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/main/src/attr/__init__.py) file.
- [ ] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
