### PR TITLE
Initial implementation of a faster repr

### DIFF
--- a/changelog.d/819.changes.rst
+++ b/changelog.d/819.changes.rst
@@ -1,1 +1,1 @@
-The generated `__repr__` is significantly faster on Pythons with F-strings.
+The generated ``__repr__`` is significantly faster on Pythons with F-strings.

--- a/changelog.d/819.changes.rst
+++ b/changelog.d/819.changes.rst
@@ -1,0 +1,1 @@
+The generated `__repr__` is significantly faster on Pythons with F-strings.

--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -8,6 +8,7 @@ import warnings
 
 PY2 = sys.version_info[0] == 2
 PYPY = platform.python_implementation() == "PyPy"
+HAS_F_STRINGS = sys.version_info[:2] >= (3, 7)
 PY310 = sys.version_info[:2] >= (3, 10)
 
 

--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -8,7 +8,11 @@ import warnings
 
 PY2 = sys.version_info[0] == 2
 PYPY = platform.python_implementation() == "PyPy"
-HAS_F_STRINGS = sys.version_info[:2] >= (3, 7)
+HAS_F_STRINGS = (
+    sys.version_info[:2] >= (3, 7)
+    if not PYPY
+    else sys.version_info[:2] >= (3, 6)
+)
 PY310 = sys.version_info[:2] >= (3, 10)
 
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1905,7 +1905,6 @@ if HAS_F_STRINGS:
                 "%s={%s!r}" % (name, accessor)
                 if r == repr
                 else "%s={%s_repr(%s)}" % (name, name, accessor)
-                )
             )
             attribute_fragments.append(fragment)
         repr_fragment = ", ".join(attribute_fragments)

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1935,8 +1935,10 @@ if HAS_F_STRINGS:
         )
         lines.append("  finally:")
         lines.append("    working_set.remove(id(self))")
-        script = "\n".join(lines)
-        return _make_method("__repr__", script, unique_filename, globs=globs)
+
+        return _make_method(
+            "__repr__", "\n".join(lines), unique_filename, globs=globs
+        )
 
 
 else:

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1886,7 +1886,7 @@ if HAS_F_STRINGS:
             if a.repr is not False
         )
         globs = {
-            f"{name}_repr": r
+            name + "_repr": r
             for name, r, _ in attr_names_with_reprs
             if r != repr
         }
@@ -1896,12 +1896,16 @@ if HAS_F_STRINGS:
         attribute_fragments = []
         for name, r, i in attr_names_with_reprs:
             accessor = (
-                f"self.{name}" if i else f'getattr(self, "{name}", NOTHING)'
+                "self." + name
+                if i
+                else 'getattr(self, "' + name + '", NOTHING)'
             )
             fragment = (
-                f"{name}={{{accessor}!r}}"
+                "{name}={{{accessor}!r}}".format(name=name, accessor=accessor)
                 if r == repr
-                else f"{name}={{{name}_repr({accessor})}}"
+                else "{name}={{{name}_repr({accessor})}}".format(
+                    name=name, accessor=accessor
+                )
             )
             attribute_fragments.append(fragment)
         repr_fragment = ", ".join(attribute_fragments)
@@ -1915,7 +1919,7 @@ if HAS_F_STRINGS:
             else:
                 cls_name_fragment = "{self.__class__.__name__}"
         else:
-            cls_name_fragment = f"{ns}.{{self.__class__.__name__}}"
+            cls_name_fragment = ns + ".{self.__class__.__name__}"
 
         lines = []
         lines.append("def __repr__(self):")
@@ -1930,7 +1934,9 @@ if HAS_F_STRINGS:
         lines.append("    else:")
         lines.append("      working_set.add(id(self))")
         lines.append("  try:")
-        lines.append(f"    return f'{cls_name_fragment}({repr_fragment})'")
+        lines.append(
+            "    return f'{}({})'".format(cls_name_fragment, repr_fragment)
+        )
         lines.append("  finally:")
         lines.append("    working_set.remove(id(self))")
         script = "\n".join(lines)

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1904,8 +1904,7 @@ if HAS_F_STRINGS:
             fragment = (
                 "%s={%s!r}" % (name, accessor)
                 if r == repr
-                else "{name}={{{name}_repr({accessor})}}".format(
-                    name=name, accessor=accessor
+                else "%s={%s_repr(%s)}" % (name, name, accessor)
                 )
             )
             attribute_fragments.append(fragment)

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1879,7 +1879,8 @@ if HAS_F_STRINGS:
     def _make_repr(attrs, ns, cls):
         unique_filename = "repr"
         # Figure out which attributes to include, and which function to use to
-        # format them. The a.repr value can be either bool or a custom callable.
+        # format them. The a.repr value can be either bool or a custom
+        # callable.
         attr_names_with_reprs = tuple(
             (a.name, repr if a.repr is True else a.repr, a.init)
             for a in attrs
@@ -1947,12 +1948,13 @@ else:
 
     def _make_repr(attrs, ns, _):
         """
-        Make a repr method that includes relevant *attrs*, adding *ns* to the full
-        name.
+        Make a repr method that includes relevant *attrs*, adding *ns* to the
+        full name.
         """
 
         # Figure out which attributes to include, and which function to use to
-        # format them. The a.repr value can be either bool or a custom callable.
+        # format them. The a.repr value can be either bool or a custom
+        # callable.
         attr_names_with_reprs = tuple(
             (a.name, repr if a.repr is True else a.repr)
             for a in attrs
@@ -1981,10 +1983,10 @@ else:
             else:
                 class_name = ns + "." + real_cls.__name__
 
-            # Since 'self' remains on the stack (i.e.: strongly referenced) for the
-            # duration of this call, it's safe to depend on id(...) stability, and
-            # not need to track the instance and therefore worry about properties
-            # like weakref- or hash-ability.
+            # Since 'self' remains on the stack (i.e.: strongly referenced)
+            # for the duration of this call, it's safe to depend on id(...)
+            # stability, and not need to track the instance and therefore
+            # worry about properties like weakref- or hash-ability.
             working_set.add(id(self))
             try:
                 result = [class_name, "("]

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1931,7 +1931,7 @@ if HAS_F_STRINGS:
         lines.append("      working_set.add(id(self))")
         lines.append("  try:")
         lines.append(
-            "    return f'{}({})'".format(cls_name_fragment, repr_fragment)
+            "    return f'%s(%s)'" % (cls_name_fragment, repr_fragment)
         )
         lines.append("  finally:")
         lines.append("    working_set.remove(id(self))")

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -12,6 +12,7 @@ from operator import itemgetter
 
 from . import _config, setters
 from ._compat import (
+    HAS_F_STRINGS,
     PY2,
     PY310,
     PYPY,
@@ -888,7 +889,7 @@ class _ClassBuilder(object):
 
     def add_repr(self, ns):
         self._cls_dict["__repr__"] = self._add_method_dunders(
-            _make_repr(self._attrs, ns=ns)
+            _make_repr(self._attrs, ns=ns, cls=self._cls)
         )
         return self
 
@@ -1873,64 +1874,128 @@ def _add_eq(cls, attrs=None):
 
 _already_repring = threading.local()
 
+if HAS_F_STRINGS:
 
-def _make_repr(attrs, ns):
-    """
-    Make a repr method that includes relevant *attrs*, adding *ns* to the full
-    name.
-    """
+    def _make_repr(attrs, ns, cls):
+        unique_filename = "repr"
+        # Figure out which attributes to include, and which function to use to
+        # format them. The a.repr value can be either bool or a custom callable.
+        attr_names_with_reprs = tuple(
+            (a.name, repr if a.repr is True else a.repr, a.init)
+            for a in attrs
+            if a.repr is not False
+        )
+        globs = {
+            f"{name}_repr": r
+            for name, r, _ in attr_names_with_reprs
+            if r != repr
+        }
+        globs["_already_repring"] = _already_repring
+        globs["AttributeError"] = AttributeError
+        globs["NOTHING"] = NOTHING
+        attribute_fragments = []
+        for name, r, i in attr_names_with_reprs:
+            accessor = (
+                f"self.{name}" if i else f'getattr(self, "{name}", NOTHING)'
+            )
+            fragment = (
+                f"{name}={{{accessor}!r}}"
+                if r == repr
+                else f"{name}={{{name}_repr({accessor})}}"
+            )
+            attribute_fragments.append(fragment)
+        repr_fragment = ", ".join(attribute_fragments)
 
-    # Figure out which attributes to include, and which function to use to
-    # format them. The a.repr value can be either bool or a custom callable.
-    attr_names_with_reprs = tuple(
-        (a.name, repr if a.repr is True else a.repr)
-        for a in attrs
-        if a.repr is not False
-    )
-
-    def __repr__(self):
-        """
-        Automatically created by attrs.
-        """
-        try:
-            working_set = _already_repring.working_set
-        except AttributeError:
-            working_set = set()
-            _already_repring.working_set = working_set
-
-        if id(self) in working_set:
-            return "..."
-        real_cls = self.__class__
         if ns is None:
-            qualname = getattr(real_cls, "__qualname__", None)
+            qualname = getattr(cls, "__qualname__", None)
             if qualname is not None:
-                class_name = qualname.rsplit(">.", 1)[-1]
-            else:
-                class_name = real_cls.__name__
-        else:
-            class_name = ns + "." + real_cls.__name__
-
-        # Since 'self' remains on the stack (i.e.: strongly referenced) for the
-        # duration of this call, it's safe to depend on id(...) stability, and
-        # not need to track the instance and therefore worry about properties
-        # like weakref- or hash-ability.
-        working_set.add(id(self))
-        try:
-            result = [class_name, "("]
-            first = True
-            for name, attr_repr in attr_names_with_reprs:
-                if first:
-                    first = False
-                else:
-                    result.append(", ")
-                result.extend(
-                    (name, "=", attr_repr(getattr(self, name, NOTHING)))
+                cls_name_fragment = (
+                    '{self.__class__.__qualname__.rsplit(">.", 1)[-1]}'
                 )
-            return "".join(result) + ")"
-        finally:
-            working_set.remove(id(self))
+            else:
+                cls_name_fragment = "{self.__class__.__name__}"
+        else:
+            cls_name_fragment = f"{ns}.{{self.__class__.__name__}}"
 
-    return __repr__
+        lines = []
+        lines.append("def __repr__(self):")
+        lines.append("  try:")
+        lines.append("    working_set = _already_repring.working_set")
+        lines.append("  except AttributeError:")
+        lines.append("    working_set = {id(self),}")
+        lines.append("    _already_repring.working_set = working_set")
+        lines.append("  else:")
+        lines.append("    if id(self) in working_set:")
+        lines.append("      return '...'")
+        lines.append("    else:")
+        lines.append("      working_set.add(id(self))")
+        lines.append("  try:")
+        lines.append(f"    return f'{cls_name_fragment}({repr_fragment})'")
+        lines.append("  finally:")
+        lines.append("    working_set.remove(id(self))")
+        script = "\n".join(lines)
+        return _make_method("__repr__", script, unique_filename, globs=globs)
+
+
+else:
+
+    def _make_repr(attrs, ns, _):
+        """
+        Make a repr method that includes relevant *attrs*, adding *ns* to the full
+        name.
+        """
+
+        # Figure out which attributes to include, and which function to use to
+        # format them. The a.repr value can be either bool or a custom callable.
+        attr_names_with_reprs = tuple(
+            (a.name, repr if a.repr is True else a.repr)
+            for a in attrs
+            if a.repr is not False
+        )
+
+        def __repr__(self):
+            """
+            Automatically created by attrs.
+            """
+            try:
+                working_set = _already_repring.working_set
+            except AttributeError:
+                working_set = set()
+                _already_repring.working_set = working_set
+
+            if id(self) in working_set:
+                return "..."
+            real_cls = self.__class__
+            if ns is None:
+                qualname = getattr(real_cls, "__qualname__", None)
+                if qualname is not None:
+                    class_name = qualname.rsplit(">.", 1)[-1]
+                else:
+                    class_name = real_cls.__name__
+            else:
+                class_name = ns + "." + real_cls.__name__
+
+            # Since 'self' remains on the stack (i.e.: strongly referenced) for the
+            # duration of this call, it's safe to depend on id(...) stability, and
+            # not need to track the instance and therefore worry about properties
+            # like weakref- or hash-ability.
+            working_set.add(id(self))
+            try:
+                result = [class_name, "("]
+                first = True
+                for name, attr_repr in attr_names_with_reprs:
+                    if first:
+                        first = False
+                    else:
+                        result.append(", ")
+                    result.extend(
+                        (name, "=", attr_repr(getattr(self, name, NOTHING)))
+                    )
+                return "".join(result) + ")"
+            finally:
+                working_set.remove(id(self))
+
+        return __repr__
 
 
 def _add_repr(cls, ns=None, attrs=None):
@@ -1940,7 +2005,7 @@ def _add_repr(cls, ns=None, attrs=None):
     if attrs is None:
         attrs = cls.__attrs_attrs__
 
-    cls.__repr__ = _make_repr(attrs, ns)
+    cls.__repr__ = _make_repr(attrs, ns, cls)
     return cls
 
 
@@ -2634,7 +2699,7 @@ class Attribute(object):
             type=type,
             cmp=None,
             inherited=False,
-            **inst_dict
+            **inst_dict,
         )
 
     @property

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1912,13 +1912,9 @@ if HAS_F_STRINGS:
         repr_fragment = ", ".join(attribute_fragments)
 
         if ns is None:
-            qualname = getattr(cls, "__qualname__", None)
-            if qualname is not None:
-                cls_name_fragment = (
-                    '{self.__class__.__qualname__.rsplit(">.", 1)[-1]}'
-                )
-            else:
-                cls_name_fragment = "{self.__class__.__name__}"
+            cls_name_fragment = (
+                '{self.__class__.__qualname__.rsplit(">.", 1)[-1]}'
+            )
         else:
             cls_name_fragment = ns + ".{self.__class__.__name__}"
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1971,7 +1971,11 @@ else:
                 return "..."
             real_cls = self.__class__
             if ns is None:
-                class_name = real_cls.__name__
+                qualname = getattr(real_cls, "__qualname__", None)
+                if qualname is not None:
+                    class_name = qualname.rsplit(">.", 1)[-1]
+                else:
+                    class_name = real_cls.__name__
             else:
                 class_name = ns + "." + real_cls.__name__
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -889,7 +889,7 @@ class _ClassBuilder(object):
 
     def add_repr(self, ns):
         self._cls_dict["__repr__"] = self._add_method_dunders(
-            _make_repr(self._attrs, ns=ns, cls=self._cls)
+            _make_repr(self._attrs, ns, self._cls)
         )
         return self
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1972,7 +1972,11 @@ else:
             real_cls = self.__class__
             if ns is None:
                 qualname = getattr(real_cls, "__qualname__", None)
-                if qualname is not None:
+                if qualname is not None:  # pragma: no cover
+                    # This case only happens on Python 3.5 and 3.6. We exclude
+                    # it from coverage, because we don't want to slow down our
+                    # test suite by running them under coverage too for this
+                    # one line.
                     class_name = qualname.rsplit(">.", 1)[-1]
                 else:
                     class_name = real_cls.__name__

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1882,7 +1882,7 @@ if HAS_F_STRINGS:
         # format them. The a.repr value can be either bool or a custom
         # callable.
         attr_names_with_reprs = tuple(
-            (a.name, repr if a.repr is True else a.repr, a.init)
+            (a.name, (repr if a.repr is True else a.repr), a.init)
             for a in attrs
             if a.repr is not False
         )

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1902,7 +1902,7 @@ if HAS_F_STRINGS:
                 else 'getattr(self, "' + name + '", NOTHING)'
             )
             fragment = (
-                "{name}={{{accessor}!r}}".format(name=name, accessor=accessor)
+                "%s={%s!r}" % (name, accessor)
                 if r == repr
                 else "{name}={{{name}_repr({accessor})}}".format(
                     name=name, accessor=accessor

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -2705,7 +2705,7 @@ class Attribute(object):
             type=type,
             cmp=None,
             inherited=False,
-            **inst_dict,
+            **inst_dict
         )
 
     @property

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1971,11 +1971,7 @@ else:
                 return "..."
             real_cls = self.__class__
             if ns is None:
-                qualname = getattr(real_cls, "__qualname__", None)
-                if qualname is not None:
-                    class_name = qualname.rsplit(">.", 1)[-1]
-                else:
-                    class_name = real_cls.__name__
+                class_name = real_cls.__name__
             else:
                 class_name = ns + "." + real_cls.__name__
 


### PR DESCRIPTION
Initial implementation, CHANGELOG to follow.

Benchmark used:
```
pyperf timeit -g -s "from attr import make_class, attrib; A = make_class('A', ['a', 'b', 'c', 'd', 'e']); a = A(1, 2, 3, 4, 5)" "repr(a)"
```

Old code:
```
Mean +- std dev: 2.09 us +- 0.07 us
```

New code:
```
Mean +- std dev: 957 ns +- 27 ns
```