### PR TITLE
use an actual class for Factory hints

### DIFF
--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -65,27 +65,36 @@ NOTHING: object
 # Work around mypy issue #4554 in the common case by using an overload.
 if sys.version_info >= (3, 8):
     from typing import Literal
-    @overload
-    def Factory(factory: Callable[[], _T]) -> _T: ...
-    @overload
-    def Factory(
-        factory: Callable[[Any], _T],
-        takes_self: Literal[True],
-    ) -> _T: ...
-    @overload
-    def Factory(
-        factory: Callable[[], _T],
-        takes_self: Literal[False],
-    ) -> _T: ...
+    class Factory(object):
+        factory: Any
+        takes_self: bool
+        @overload
+        def __init__(self, factory: Callable[[], _T]) -> None: ...
+        @overload
+        def __init__(
+            self,
+            factory: Callable[[Any], _T],
+            takes_self: Literal[True],
+        ) -> None: ...
+        @overload
+        def __init__(
+            self,
+            factory: Callable[[], _T],
+            takes_self: Literal[False],
+        ) -> None: ...
 
 else:
-    @overload
-    def Factory(factory: Callable[[], _T]) -> _T: ...
-    @overload
-    def Factory(
-        factory: Union[Callable[[Any], _T], Callable[[], _T]],
-        takes_self: bool = ...,
-    ) -> _T: ...
+    class Factory(object):
+        factory: Any
+        takes_self: bool
+        @overload
+        def __init__(self, factory: Callable[[], _T]) -> _T: ...
+        @overload
+        def __init__(
+            self,
+            factory: Union[Callable[[Any], _T], Callable[[], _T]],
+            takes_self: bool = ...,
+        ) -> _T: ...
 
 # Static type inference support via __dataclass_transform__ implemented as per:
 # https://github.com/microsoft/pyright/blob/1.1.135/specs/dataclass_transforms.md

--- a/tests/typing_example.py
+++ b/tests/typing_example.py
@@ -1,6 +1,6 @@
 import re
 
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import attr
 
@@ -257,6 +257,10 @@ class FactoryTest:
     a: List[int] = attr.ib(default=attr.Factory(list))
     b: List[Any] = attr.ib(default=attr.Factory(list, False))
     c: List[int] = attr.ib(default=attr.Factory((lambda s: s.a), True))
+
+    d: Optional[attr.Factory] = attr.Factory(list)
+    if isinstance(d, attr.Factory):
+        d.takes_self
 
 
 # Check match_args stub


### PR DESCRIPTION
This change relates to making the following code work with mypy in [desert](https://github.com/python-desert/desert).

https://github.com/python-desert/desert/blob/1fc8466ab0c6d2e1139421cf0d79646c90e1379a/src/desert/_make.py#L330-L333
```python
        if isinstance(field.default, attr.Factory):
            if field.default.takes_self:
                return attr.NOTHING
            return field.default.factory
```

Specifically, mypy gives the following errors (and other unrelated ones) without these changes.  Given that `Factory` is hinted as a function, it makes sense that we can't `isinstance()` against it.

```
src/desert/_make.py:330: error: Argument 2 to "isinstance" has incompatible type overloaded function; expected "Union[type, Tuple[Union[type, Tuple[Any, ...]], ...]]"
src/desert/_make.py:331: error: Item "None" of "Optional[Any]" has no attribute "takes_self"
src/desert/_make.py:333: error: Item "None" of "Optional[Any]" has no attribute "factory"
```

Draft for:
- [ ] Discussion and understanding of why a function was used to hint the `Factory` class to begin with.

# Pull Request Check List

- [x] Added **tests** for changed code.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [x] ...and used in the stub test file `tests/typing_example.py`.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/main/src/attr/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).

