### PR TITLE
Make `from attr import *` work again on recent python versions.

### DIFF
--- a/src/attr/__init__.py
+++ b/src/attr/__init__.py
@@ -75,4 +75,4 @@ __all__ = [
 if sys.version_info[:2] >= (3, 6):
     from ._next_gen import define, field, frozen, mutable
 
-    __all__.extend((define, field, frozen, mutable))
+    __all__.extend(("define", "field", "frozen", "mutable"))

--- a/src/attr/__init__.py
+++ b/src/attr/__init__.py
@@ -73,6 +73,6 @@ __all__ = [
 ]
 
 if sys.version_info[:2] >= (3, 6):
-    from ._next_gen import define, field, frozen, mutable
+    from ._next_gen import define, field, frozen, mutable  # noqa: F401
 
     __all__.extend(("define", "field", "frozen", "mutable"))

--- a/tests/attr_import_star.py
+++ b/tests/attr_import_star.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import
+
+# This is imported by test_import::test_import_attr_star; this must
+# be done indirectly because importing * is only allowed on module level,
+# so can't be done inside a test.
+
+from attr import *  # noqa: F403

--- a/tests/attr_import_star.py
+++ b/tests/attr_import_star.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 
+from attr import *  # noqa: F401,F403
+
+
 # This is imported by test_import::test_import_attr_star; this must
 # be done indirectly because importing * is only allowed on module level,
 # so can't be done inside a test.
-
-from attr import *  # noqa: F403

--- a/tests/attr_import_star.py
+++ b/tests/attr_import_star.py
@@ -3,6 +3,6 @@ from __future__ import absolute_import
 from attr import *  # noqa: F401,F403
 
 
-# This is imported by test_import::test_import_attr_star; this must
+# This is imported by test_import::test_from_attr_import_star; this must
 # be done indirectly because importing * is only allowed on module level,
 # so can't be done inside a test.

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,8 @@
+from __future__ import absolute_import
+
+
+# What follows is the actual test;
+# because import * is only allowed on module level, this cannot be run inside a
+# proper test. If the import fails, the test runner will complain loudly.
+
+from attr import *

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,5 +1,8 @@
 class TestImportStar(object):
     def test_from_attr_import_star(self):
+        """
+        import * from attr
+        """
         # attr_import_star contains `from attr import *`, which cannot
         # be done here because *-imports are only allowed on module level.
         from . import attr_import_star  # noqa: F401

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,8 +1,5 @@
-from __future__ import absolute_import
-
-
-# What follows is the actual test;
-# because import * is only allowed on module level, this cannot be run inside a
-# proper test. If the import fails, the test runner will complain loudly.
-
-from attr import *
+class TestImportStar(object):
+    def test_from_attr_import_star(self):
+        # attr_import_star contains `from attr import *`, which cannot
+        # be done here because *-imports are only allowed on module level.
+        from . import attr_import_star  # noqa: F401


### PR DESCRIPTION
I have no idea why one would want to type this, but it is broken right now on Python >= 3.6. This PR should fix that.

# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.  If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.

- [X] Added **tests** for changed code.
- [X] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [X] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [X] ...and used in the stub test file `tests/typing_example.py`.
- [X] Updated **documentation** for changed code.
    - [X] New functions/classes have to be added to `docs/api.rst` by hand.
    - [X] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [X] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/main/src/attr/__init__.py) file.
- [X] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [X] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
