### PR TITLE
Explain use of global thread-local variable in repr.

### DIFF
--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1864,6 +1864,14 @@ def _add_eq(cls, attrs=None):
     return cls
 
 
+# Thread-local global to track attrs instances which are already being repr'd.
+# This is needed because there is no other (thread-safe) way to pass info
+# about the instances that are already being repr'd through the call stack
+# in order to ensure we don't perform infinite recursion.
+#
+# For instance, if an instance contains a dict which contains that instance,
+# we need to know that we're already repr'ing the outside instance from within
+# the dict's repr() call.
 _already_repring = threading.local()
 
 if HAS_F_STRINGS:

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -364,8 +364,10 @@ class TestAddRepr(object):
             cycle = attr.ib(default=None)
 
         cycle = Cycle()
-        cycle.cycle = cycle
-        assert "Cycle(value=7, cycle=...)" == repr(cycle)
+        # Ensure that the reference cycle passes through a non-attrs object.
+        # This demonstrates the need for a thread-local "global" ID tracker.
+        cycle.cycle = [cycle]
+        assert "Cycle(value=7, cycle=[...])" == repr(cycle)
 
     def test_underscores(self):
         """


### PR DESCRIPTION
It's not completely obvious to a reader why we need a thread-local
"global" variable to track reference cycles in `__repr__` calls,
and the test does not currently contain one. This change adds a comment
explaining the need and also adds a non-attrs value in the reference
cycle of `test_infinite_recursion`.

---

This was inspired by [a bug that was opened](https://github.com/python-attrs/attrs/issues/754#issue-800763332) where the reporter couldn't see why the global variable was needed in the `__repr__` process. Initially I couldn't either, so I figured it was a good idea to add an explanation of *why* it is there—turns out it is an excellent solution to a real problem. I will gladly accept input about the nature/phrasing/placement of the commentary.

This is essentially a docs-only change (with a minor test change attached) so I don't think the full checklist applies in this case.