### PR TITLE
Pull threading.local out of the generated repr's globals.

### DIFF
--- a/changelog.d/847.change.rst
+++ b/changelog.d/847.change.rst
@@ -1,0 +1,2 @@
+Attrs classes are now fully compatible with cloudpickle.
+`#847 <https://github.com/python-attrs/attrs/issues/847>`_

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,8 @@ INSTALL_REQUIRES = []
 EXTRAS_REQUIRE = {
     "docs": ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"],
     "tests_no_zope": [
+        # For regression test to ensure cloudpickle compat doesn't break.
+        "cloudpickle",
         # 5.0 introduced toml; parallel was broken until 5.0.2
         "coverage[toml]>=5.0.2",
         "hypothesis",

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,0 +1,26 @@
+"""
+Tests for compatibility against other Python modules.
+"""
+
+import cloudpickle
+
+from hypothesis import given
+
+from .strategies import simple_classes
+
+
+class TestCloudpickleCompat(object):
+    """
+    Tests for compatibility with ``cloudpickle``.
+    """
+
+    @given(simple_classes())
+    def test_repr(self, cls):
+        """
+        attrs instances can be pickled and un-pickled with cloudpickle.
+        """
+        inst = cls()
+        # Exact values aren't a concern so long as neither direction
+        # raises an exception.
+        pkl = cloudpickle.dumps(inst)
+        cloudpickle.loads(pkl)

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -367,6 +367,23 @@ class TestAddRepr(object):
         cycle.cycle = cycle
         assert "Cycle(value=7, cycle=...)" == repr(cycle)
 
+    def test_infinite_recursion_long_cycle(self):
+        """
+        A cyclic graph can pass through other non-attrs objects, and repr will
+        still emit an ellipsis and not raise an exception.
+        """
+
+        @attr.s
+        class LongCycle(object):
+            value = attr.ib(default=14)
+            cycle = attr.ib(default=None)
+
+        cycle = LongCycle()
+        # Ensure that the reference cycle passes through a non-attrs object.
+        # This demonstrates the need for a thread-local "global" ID tracker.
+        cycle.cycle = {"cycle": [cycle]}
+        assert "LongCycle(value=14, cycle={'cycle': [...]})" == repr(cycle)
+
     def test_underscores(self):
         """
         repr does not strip underscores.


### PR DESCRIPTION
Generated `__repr__` methods for Pythons with f-strings included
a `threading.local` object in that method's `globals()` dictionary.
Because `cloudpickle` attempts to serialize all globals of this method,
it ends up trying to pickle the `threading.local`, which cannot be
pickled.

Instead, we now pull use of the thread-local out into its own function,
which `cloudpickle` will happily serialize. As an added benefit, this
eliminates some duplicated code between f-string and non–f-string
`__repr__`s.

Should fix:

- https://github.com/python-attrs/attrs/issues/458
- https://github.com/cloudpipe/cloudpickle/issues/320

# Pull Request Check List

- [x] Added **tests** for changed code.
    I'm not sure what the best direction to go on this is. I run this locally and see that when I cloudpickle an attrs class, it works fine. It would be pretty simple to add a test dep on cloudpickle and then create and pickle an attrs class in a new test case. But would that be too much of a special-case test case for this specific library? That said, it is more likely that changes here would cause problems in cloudpickling, rather than changes in cloudpickle causing problems here, and it would be nice to catch them faster.
- (N/A) New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- (N/A) Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
- (N/A) Updated **documentation** for changed code.
- [X] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [X] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).

Another implementation idea I had would be to simply pull the `threading.local` out into another module, because that would make the global a module (which would be pickled by reference) rather than a local (which would be pickled by value). That, however, would leave essentially a two-line `import threading; repr_context = threading.local()` module, which, ehhhhhhhh