### PR TITLE
Enable use of f-strings in Python 3.6.

### DIFF
--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -8,15 +8,12 @@ import warnings
 
 PY2 = sys.version_info[0] == 2
 PYPY = platform.python_implementation() == "PyPy"
-HAS_F_STRINGS = (
-    sys.version_info[:2] >= (3, 7)
-    if not PYPY
-    else sys.version_info[:2] >= (3, 6)
-)
+PY36 = sys.version_info[:2] >= (3, 6)
+HAS_F_STRINGS = PY36
 PY310 = sys.version_info[:2] >= (3, 10)
 
 
-if PYPY or sys.version_info[:2] >= (3, 6):
+if PYPY or PY36:
     ordered_dict = dict
 else:
     from collections import OrderedDict


### PR DESCRIPTION
CPython 3.6 has f-strings:

```
Python 3.6.13 |Anaconda, Inc.| (default, Jun  4 2021, 14:25:59)
[GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> f"hello"
'hello'
```

---

A quick thing I noticed. Feel free to reject if there's an assumption I'm missing (e.g. a feature of f-strings that was introduced after 3.6 that attrs uses).

Checklist: All N/A.