### PR TITLE
WIP: Allow evolve() to recursively evolve attrs classes

### DIFF
--- a/changelog.d/861.change.rst
+++ b/changelog.d/861.change.rst
@@ -1,0 +1,1 @@
+``attrs.evolve()`` now works recursively with nested ``attrs`` classes.

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -623,6 +623,27 @@ In Clojure that function is called `assoc <https://clojuredocs.org/clojure.core/
    >>> i1 == i2
    False
 
+This functions also works for nested ``attrs`` classes.
+Pass a (possibly nested) dictionary with changes for an attribute:
+
+.. doctest::
+
+   >>> @attr.s(frozen=True)
+   ... class Child(object):
+   ...     x = attr.ib()
+   ...     y = attr.ib()
+   >>> @attr.s(frozen=True)
+   ... class Parent(object):
+   ...     child = attr.ib(type=Child)  # Type annotations / passing "type" is important!
+   >>> i1 = Parent(Child(1, 2))
+   >>> i1
+   Parent(child=Child(x=1, y=2))
+   >>> i2 = attr.evolve(i1, child={"y": 3})
+   >>> i2
+   Parent(child=Child(x=1, y=3))
+   >>> i1 == i2, i1.child == i2.child
+   (False, False)
+
 
 Other Goodies
 -------------

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -645,3 +645,50 @@ class TestEvolve(object):
         assert Cls1({"foo": 42, "param2": 42}) == attr.evolve(
             obj1a, param1=obj2b
         )
+
+    def test_recursive(self):
+        """
+        evolve() recursively evolves nested attrs classes when a dict is
+        passed for an attribute.
+        """
+
+        @attr.s
+        class N2(object):
+            e = attr.ib(type=int)
+
+        @attr.s
+        class N1(object):
+            c = attr.ib(type=N2)
+            d = attr.ib(type=int)
+
+        @attr.s
+        class C(object):
+            a = attr.ib(type=N1)
+            b = attr.ib(type=int)
+
+        c1 = C(N1(N2(1), 2), 3)
+        c2 = evolve(c1, a={"c": {"e": 23}}, b=42)
+
+        assert c2 == C(N1(N2(23), 2), 42)
+
+    def test_recursive_attrs_classes(self):
+        """
+        evolve() can evolve fields that are instances of attrs classes.
+        """
+
+        @attr.s
+        class Child(object):
+            param2 = attr.ib()
+
+        @attr.s
+        class Parent(object):
+            param1 = attr.ib(type=Child)
+
+        obj2a = Child(param2="a")
+        obj2b = Child(param2="b")
+
+        obj1a = Parent(param1=obj2a)
+
+        assert Parent(param1=Child(param2="b")) == attr.evolve(
+            obj1a, param1=obj2b
+        )


### PR DESCRIPTION
This is a new atempt to fix #634 (#759 failed: #804, #806)

# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.  If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.

- [x] Added **tests** for changed code.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [x] ...and used in the stub test file `tests/typing_example.py`.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/main/src/attr/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!
