### PR TITLE
Title case for to_bool strings

### DIFF
--- a/src/attr/converters.py
+++ b/src/attr/converters.py
@@ -118,18 +118,18 @@ def to_bool(val):
     Values mapping to :code:`True`:
 
     - :code:`True`
-    - :code:`"true"` / :code:`"t"`
-    - :code:`"yes"` / :code:`"y"`
-    - :code:`"on"`
+    - :code:`"true"` / :code:`"t"` / :code:`"True"` / :code:`"T"`
+    - :code:`"yes"` / :code:`"y"` / :code:`"Yes"` / :code:`"T"`
+    - :code:`"on"` / :code:`"On"`
     - :code:`"1"`
     - :code:`1`
 
     Values mapping to :code:`False`:
 
     - :code:`False`
-    - :code:`"false"` / :code:`"f"`
-    - :code:`"no"` / :code:`"n"`
-    - :code:`"off"`
+    - :code:`"false"` / :code:`"f"` / :code:`"False"` / :code:`"F"`
+    - :code:`"no"` / :code:`"n"` / :code:`"No"` / :code:`"N"`
+    - :code:`"off"` / :code:`"Off"`
     - :code:`"0"`
     - :code:`0`
 
@@ -139,8 +139,8 @@ def to_bool(val):
     """
     if isinstance(val, str):
         val = val.lower()
-    truthy = {True, "true", "t", "yes", "y", "on", "1", 1}
-    falsy = {False, "false", "f", "no", "n", "off", "0", 0}
+    truthy = {True, "true", "True", "t", "T", "yes", "Yes", "y", "Y", "on", "On", "1", 1}
+    falsy = {False, "false", "False", "f", "F", "no", "No", "n", "N", "off", "Off", "0", 0}
     try:
         if val in truthy:
             return True

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -148,14 +148,24 @@ class TestToBool(object):
         """
         Fails if truthy values are incorrectly converted.
         """
+        assert to_bool("true")
+        assert to_bool("True")
         assert to_bool("t")
+        assert to_bool("T")
         assert to_bool("yes")
+        assert to_bool("Yes")
         assert to_bool("on")
+        assert to_bool("On")
 
     def test_falsy(self):
         """
         Fails if falsy values are incorrectly converted.
         """
+        assert not to_bool("false")
+        assert not to_bool("False")
         assert not to_bool("f")
+        assert not to_bool("F")
         assert not to_bool("no")
+        assert not to_bool("No")
         assert not to_bool("off")
+        assert not to_bool("Off")


### PR DESCRIPTION
I really like the new `to_bool` converter.  I was thinking it would be good to support some "title case" variations on strings... especially since Python folks might try to use the strings `True` and `False`.  

I did think about modifying the code to do include additional `if` checks inside the `try` block to force `str.lower()` if `isinstance(val, str)` so that we end up handling things like `TRUE`, `TrUe`, etc.... but for now I thought I would proposed the "Keep It Simple" approach since I think "True" is going to be more common than "TRUE" (and things like "TrUe" should be very rare).

I don't think this requires updates to the `versionchanged` info because 21.3.0 hasn't be released yet, but let me know if I have that wrong.

Regards,
HKC


# Pull Request Check List

This is just a friendly reminder about the most common mistakes.  Please make sure that you tick all boxes.  But please read our [contribution guide](https://www.attrs.org/en/latest/contributing.html) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.  If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.

- [x] Added **tests** for changed code.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [x] ...and used in the stub test file `tests/typing_example.py`.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).  Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/main/src/attr/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).

If you have *any* questions to *any* of the points above, just **submit and ask**!  This checklist is here to *help* you, not to deter you from contributing!

