### PR TITLE
Document the various core names and why they exist

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@
 
 .. teaser-begin
 
-``attrs`` is the Python package that will bring back the **joy** of **writing classes** by relieving you from the drudgery of implementing object protocols (aka `dunder <https://nedbatchelder.com/blog/200605/dunder.html>`_ methods).
+``attrs`` is the Python package that will bring back the **joy** of **writing classes** by relieving you from the drudgery of implementing object protocols (aka `dunder methods <https://www.attrs.org/en/latest/glossary.html#term-dunder-methods>`_).
 `Trusted by NASA <https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-profile/customizing-your-profile/personalizing-your-profile#list-of-qualifying-repositories-for-mars-2020-helicopter-contributor-badge>`_ for Mars missions since 2020!
 
 Its main goal is to help you to write **concise** and **correct** software without slowing down your code.
@@ -86,8 +86,10 @@ Never again violate the `single responsibility principle <https://en.wikipedia.o
 ----
 
 In case you're wondering: this example uses ``attrs``'s `modern APIs <https://www.attrs.org/en/stable/api.html#next-generation-apis>`_ that have been introduced in version 20.1.0.
-The classic APIs (``@attr.s``, ``attr.ib``, ``@attr.attrs``, and ``attr.attrib``) will remain indefinitely.
+The classic APIs (``@attr.s``, ``attr.ib``, ``@attr.attrs``, ``attr.attrib``, ``attr.dataclass``) will remain indefinitely.
 `Type annotations <https://www.attrs.org/en/latest/types.html>`_ will also stay entirely **optional** forever.
+
+Please check out `On The Core API Names <https://www.attrs.org/en/latest/names.html>`_ for a more in-depth explanation.
 
 .. -getting-help-
 

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ Never again violate the `single responsibility principle <https://en.wikipedia.o
 ----
 
 In case you're wondering: this example uses ``attrs``'s `modern APIs <https://www.attrs.org/en/stable/api.html#next-generation-apis>`_ that have been introduced in version 20.1.0.
-The classic APIs (``@attr.s``, ``attr.ib``, ``@attr.attrs``, ``attr.attrib``, ``attr.dataclass``) will remain indefinitely.
+The classic APIs (``@attr.s``, ``attr.ib``, ``@attr.attrs``, ``attr.attrib``, and ``attr.dataclass``) will remain indefinitely.
 `Type annotations <https://www.attrs.org/en/latest/types.html>`_ will also stay entirely **optional** forever.
 
 Please check out `On The Core API Names <https://www.attrs.org/en/latest/names.html>`_ for a more in-depth explanation.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -3,14 +3,11 @@ API Reference
 
 .. currentmodule:: attr
 
-``attrs`` works by decorating a class using `attr.s` and then optionally defining attributes on the class using `attr.ib`.
+``attrs`` works by decorating a class using `attr.define` or `attr.s` and then optionally defining attributes on the class using `attr.field`, `attr.ib`, or a type annotation.
 
-.. note::
-
-   When this documentation speaks about "``attrs`` attributes" it means those attributes that are defined using `attr.ib` in the class body.
+If you're confused by the many names, please check out `names` for clarification.
 
 What follows is the API explanation, if you'd like a more hands-on introduction, have a look at `examples`.
-
 
 
 Core

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -3,6 +3,15 @@ Glossary
 
 .. glossary::
 
+   dunder methods
+      "Dunder" is a contraction of "double underscore".
+
+      It's methods like ``__init__`` or ``__eq__`` that are sometimes also called *magic methods* or it's said that they implement an *object protocol*.
+
+      In spoken form, you'd call ``__init__`` just "dunder init".
+
+      Its first documented use is a `mailing list posting <https://mail.python.org/pipermail/python-list/2002-September/155836.html>`_ by Mark Jackson from 2002.
+
    dict classes
       A regular class whose attributes are stored in the `object.__dict__` attribute of every single instance.
       This is quite wasteful especially for objects with very few data attributes and the space consumption can become significant when creating large numbers of instances.

--- a/docs/how-does-it-work.rst
+++ b/docs/how-does-it-work.rst
@@ -15,9 +15,9 @@ Internally they're a representation of the data passed into ``attr.ib`` along wi
 
 In order to ensure that subclassing works as you'd expect it to work, ``attrs`` also walks the class hierarchy and collects the attributes of all base classes.
 Please note that ``attrs`` does *not* call ``super()`` *ever*.
-It will write dunder methods to work on *all* of those attributes which also has performance benefits due to fewer function calls.
+It will write :term:`dunder methods`` to work on *all* of those attributes which also has performance benefits due to fewer function calls.
 
-Once ``attrs`` knows what attributes it has to work on, it writes the requested dunder methods and -- depending on whether you wish to have a :term:`dict <dict classes>` or :term:`slotted <slotted classes>` class -- creates a new class for you (``slots=True``) or attaches them to the original class (``slots=False``).
+Once ``attrs`` knows what attributes it has to work on, it writes the requested :term:`dunder methods` and -- depending on whether you wish to have a :term:`dict <dict classes>` or :term:`slotted <slotted classes>` class -- creates a new class for you (``slots=True``) or attaches them to the original class (``slots=False``).
 While creating new classes is more elegant, we've run into several edge cases surrounding metaclasses that make it impossible to go this route unconditionally.
 
 To be very clear: if you define a class with a single attribute without a default value, the generated ``__init__`` will look *exactly* how you'd expect:

--- a/docs/how-does-it-work.rst
+++ b/docs/how-does-it-work.rst
@@ -15,7 +15,7 @@ Internally they're a representation of the data passed into ``attr.ib`` along wi
 
 In order to ensure that subclassing works as you'd expect it to work, ``attrs`` also walks the class hierarchy and collects the attributes of all base classes.
 Please note that ``attrs`` does *not* call ``super()`` *ever*.
-It will write :term:`dunder methods`` to work on *all* of those attributes which also has performance benefits due to fewer function calls.
+It will write :term:`dunder methods` to work on *all* of those attributes which also has performance benefits due to fewer function calls.
 
 Once ``attrs`` knows what attributes it has to work on, it writes the requested :term:`dunder methods` and -- depending on whether you wish to have a :term:`dict <dict classes>` or :term:`slotted <slotted classes>` class -- creates a new class for you (``slots=True``) or attaches them to the original class (``slots=False``).
 While creating new classes is more elegant, we've run into several edge cases surrounding metaclasses that make it impossible to go this route unconditionally.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,9 +25,10 @@ The recommended installation method is `pip <https://pip.pypa.io/en/stable/>`_-i
 The next three steps should bring you up and running in no time:
 
 - `overview` will show you a simple example of ``attrs`` in action and introduce you to its philosophy.
-  Afterwards, you can start writing your own classes, understand what drives ``attrs``'s design, and know what ``@attr.s`` and ``attr.ib()`` stand for.
+  Afterwards, you can start writing your own classes and understand what drives ``attrs``'s design.
 - `examples` will give you a comprehensive tour of ``attrs``'s features.
   After reading, you will know about our advanced features and how to use them.
+- If you're confused by all the ``attr.s``, ``attr.ib``, ``attrs``, ``attrib``, ``define``, ``frozen``, and ``field``, head over to `names` for a very brief history lesson.
 - Finally `why` gives you a rundown of potential alternatives and why we think ``attrs`` is superior.
   Yes, we've heard about ``namedtuple``\ s and Data Classes!
 - If at any point you get confused by some terminology, please check out our `glossary`.
@@ -77,6 +78,7 @@ Full Table of Contents
    api
    extending
    how-does-it-work
+   names
    glossary
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ The next three steps should bring you up and running in no time:
   Afterwards, you can start writing your own classes and understand what drives ``attrs``'s design.
 - `examples` will give you a comprehensive tour of ``attrs``'s features.
   After reading, you will know about our advanced features and how to use them.
-- If you're confused by all the ``attr.s``, ``attr.ib``, ``attrs``, ``attrib``, ``define``, ``frozen``, and ``field``, head over to `names` for a very brief history lesson.
+- If you're confused by all the ``attr.s``, ``attr.ib``, ``attrs``, ``attrib``, ``define``, ``frozen``, and ``field``, head over to `names` for a very short explanation, and optionally a quick history lesson.
 - Finally `why` gives you a rundown of potential alternatives and why we think ``attrs`` is superior.
   Yes, we've heard about ``namedtuple``\ s and Data Classes!
 - If at any point you get confused by some terminology, please check out our `glossary`.

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -43,7 +43,7 @@ At this point the plan was not to make ``attrs`` what it is now -- a flexible cl
 All we wanted was an ergonomic little library to succinctly define classes with attributes.
 
 Under the impression of of the unwieldy ``characteristic`` name, we went to the other side and decided to make the package name part of the API, and keep the API functions very short.
-This led to the infamous `attr.s` and `attr.ib` which some found confusing and pronounced it as "attr dot s" or used a singular `@s` as the decorator.
+This led to the infamous `attr.s` and `attr.ib` which some found confusing and pronounced it as "attr dot s" or used a singular ``@s`` as the decorator.
 But it was really just a way to say ``attrs`` and ``attrib``\ [#attr]_.
 
 Some people hated this cutey API from day one, which is why we added aliases for them that we called *serious business*: ``@attr.attrs`` and ``attr.attrib()``.

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -71,7 +71,7 @@ A big change happened in May 2017 when Hynek sat down with `Guido van Rossum <ht
 Type annotations for class attributes have `just landed <https://www.python.org/dev/peps/pep-0526/>`_ in Python 3.6 and Guido felt like it would be a good mechanic to introduce something similar to ``attrs`` to the Python standard library.
 The result, of course, was `PEP 557 <https://www.python.org/dev/peps/pep-0557/>`_\ [#stdlib]_ which eventually became the `dataclasses` module in Python 3.7.
 
-``attrs`` at this point was lucky to have several people on board who were also very excited about type annotations and helped implementing it, including a `Mypy plugin <https://github.com/python/mypy/blob/master/mypy/plugins/attrs.py>`_.
+``attrs`` at this point was lucky to have several people on board who were also very excited about type annotations and helped implementing it; including a `Mypy plugin <https://github.com/python/mypy/blob/master/mypy/plugins/attrs.py>`_.
 And so it happened that ``attrs`` `shipped <https://www.attrs.org/en/17.3.0.post2/changelog.html>`_ the new method of defining classes more than half a year before Python 3.7 -- and thus `dataclasses` -- were released.
 
 -----

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -11,7 +11,7 @@ And what even is ``attr.dataclass`` that's not documented but commonly used!?
 TL;DR
 -----
 
-We recommend using our modern APIs for new code:
+We recommend our modern APIs for new code:
 
 - `define()` to define a new class,
 - `mutable()` is an alias for `define()`,

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -43,7 +43,7 @@ At this point the plan was not to make ``attrs`` what it is now -- a flexible cl
 All we wanted was an ergonomic little library to succinctly define classes with attributes.
 
 Under the impression of of the unwieldy ``characteristic`` name, we went to the other side and decided to make the package name part of the API, and keep the API functions very short.
-This led to the infamous `attr.s` and `attr.ib` which some found confusing and even pronounced it as "attr dot s".
+This led to the infamous `attr.s` and `attr.ib` which some found confusing and pronounced it as "attr dot s" or used a singular `@s` as the decorator.
 But it was really just a way to say ``attrs`` and ``attrib``\ [#attr]_.
 
 Some people hated this cutey API from day one, which is why we added aliases for them that we called *serious business*: ``@attr.attrs`` and ``attr.attrib()``.

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -103,7 +103,7 @@ These APIs proved to be vastly popular, so we've finally changed the documentati
 All of this took way too long, of course.
 One reason is the COVID-19 pandemic, but also our fear to fumble this historic chance to fix our APIs.
 
-We hope you like them::
+We hope you like the result::
 
    @define
    class Point:

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -80,7 +80,7 @@ Due to backward-compatibility concerns, this feature is off by default in the `a
 As a little easter egg and to save ourselves some typing, we've also `added <https://github.com/python-attrs/attrs/commit/88aa1c897dfe2ee4aa987e4a56f2ba1344a17238#diff-4fc63db1f2fcb7c6e464ee9a77c3c74e90dd191d1c9ffc3bdd1234d3a6663dc0R48>`_ an alias called ``attr.dataclasses`` that just set ``auto_attribs=True``.
 It was never documented, but people found it and used it and loved it.
 
-Over the next years it became clear that type annotations are the main new way to define classes and their attributes.
+Over the next months and years it became clear that type annotations have become the popular way to define classes and their attributes.
 However, it has also become clear that some people viscerally hate type annotations.
 We're determined to serve both.
 

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -87,10 +87,10 @@ We're determined to serve both.
 ``attrs`` TNG
 ^^^^^^^^^^^^^
 
-Over its existance, ``attrs`` never stood still.
+Over its existence, ``attrs`` never stood still.
 But since we also greatly care about backward compatibility and not breaking our users's code, many features and niceties have to be manually activated.
 
-That is not only annoying, it also leads to the problem that many of ``attrs``'s users don't even know what it can.
+That is not only annoying, it also leads to the problem that many of ``attrs``'s users don't even know what it can do for them.
 We've spent years alone explaining that defining attributes using type annotations is in no way unique to `dataclasses`.
 
 Finally we've decided to take the `Go route <https://go.dev/blog/module-compatibility>`_:

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -1,0 +1,111 @@
+On The Core API Names
+=====================
+
+You may be surprised seeing ``attrs`` classes being created using `attr.define` and with type annotated fields, instead of `attr.s` and `attr.ib()`.
+
+Or, you wonder why the web and talks are full of this weird `attr.s` and `attr.ib` -- including people having strong opinions about it and using ``attr.attrs`` and ``attr.attrib`` instead.
+
+And what even is ``attr.dataclass`` that's not documented but commonly used!?
+
+
+TL;DR
+-----
+
+We recommend using our modern APIs for new code:
+
+- `define()` to define a new class,
+- `mutable()` is an alias for `define()`,
+- :func:`~attr.frozen` is an alias for ``define(frozen=True)``
+- and `field()` to define an attribute.
+
+They have been added in ``attrs`` 20.1.0, they are expressive, and they have modern defaults like slots and type annotation awareness.
+They are only available in Python 3.6 and later.
+Sometimes they're referred to as *next-generation* or *NG* APIs.
+
+The traditional APIs `attr.s` / `attr.ib`, their serious business aliases ``attr.attrs`` / ``attr.attrib``, and the never-documented, but popular ``attr.dataclass`` easter egg will stay **forever**.
+
+``attrs`` will **never** force you to use type annotations.
+
+
+A Short History Lesson
+----------------------
+
+At this point, ``attrs`` is an old project.
+It had its first release in April 2015 -- back when most Python code was on Python 2.7 and Python 3.4 was the first Python 3 release that showed promise.
+``attrs`` was always Python 3-first, but `type annotations <https://www.python.org/dev/peps/pep-0484/>`_ came only into Python 3.5 that was released in September 2015.
+
+At this time, if you didn't want to implement all the :term:`dunder methods`, the most common way to create a class with some attributes on it was to subclass a `collections.namedtuple`, or one of the many hacks that allowed you to access dictionary keys using attribute lookup.
+
+But ``attrs`` history goes even a bit further back, to the now-forgotten `characteristic <https://github.com/hynek/characteristic>`_ that came out in May 2014 and already used a class decorator, but was overall too unergonomic.
+
+In the wake of all of that, `glyph <https://twitter.com/glyph>`_ and `Hynek <https://twitter.com/hynek>`_ came together on IRC and brainstormed how to take the good ideas of ``characteristic``, but make them easier to use and read.
+At this point the plan was not to make ``attrs`` what it is now -- a flexible class building kit.
+All we wanted was an ergonomic little library to succintly define classes with attributes.
+
+Under the impression of of the unwieldy ``characteristic`` name, we went to the other side and decided to make the package name part of the API, and keep the API functions very short.
+This led to the infamous `attr.s` and `attr.ib` which some found confusing and even pronounced it as "attr dot s".
+But it was really just a way to say ``attrs`` and ``attrib``\ [#attr]_.
+
+Some people hated this cutey API from day one, which is why we added aliases for them that we called *serious business*: ``@attr.attrs`` and ``attr.attrib()``.
+Fans of them usually imported the names and didn't use the package name in the first place.
+Unfortunately, the ``attr`` package name also started creaking the moment we added `attr.Factory`.
+
+But overall, ``attrs`` in this shape was a **huge** success -- especially after glyph's blog post `The One Python Library Everyone Needs <https://glyph.twistedmatrix.com/2016/08/attrs.html>`_ in August 2016 and `pytest <https://docs.pytest.org/>`_ adopting it.
+
+Being able to just write::
+
+   @attr.s
+   class Point:
+       x = attr.ib()
+       y = attr.ib()
+
+was a big step for those who wanted to write small, focused classes.
+
+
+Dataclasses Enter The Arena
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A big change happened in May 2017 when Hynek sat down with `Guido van Rossum <https://en.wikipedia.org/wiki/Guido_van_Rossum>`_ and `Eric V. Smith <https://github.com/ericvsmith>`_ at PyCon US 2017.
+
+Type annotations for class attributes have just landed in Python 3.6 and Guido felt like it would be a good mechanic to introduce something similar like ``attrs`` to the Python standard library.
+The result, of course, was `PEP 557 <https://www.python.org/dev/peps/pep-0557/>`_\ [#stdlib]_ which eventually became the `dataclasses` module in Python 3.7.
+
+``attrs`` at this point was lucky to have several people on board who were also very excited about type annotations and helped implementing it, including a `Mypy plugin <https://github.com/python/mypy/blob/master/mypy/plugins/attrs.py>`_.
+And so it happened that ``attrs`` `shipped <https://www.attrs.org/en/17.3.0.post2/changelog.html>`_ the new method of defining classes more than half a year before Python 3.7 -- and thus `dataclasses` -- were released.
+
+-----
+
+Due to backward-compatibility concerns, this feature is off by default in the `attr.s` decorator and has to be activated using ``@attr.s(auto_attribs=True)``, though.
+As a little easter egg and to save ourselves some typing, we've also `added <https://github.com/python-attrs/attrs/commit/88aa1c897dfe2ee4aa987e4a56f2ba1344a17238#diff-4fc63db1f2fcb7c6e464ee9a77c3c74e90dd191d1c9ffc3bdd1234d3a6663dc0R48>`_ an alias called ``attr.dataclasses`` that just set ``auto_attribs=True``.
+It was never documented, but people found it and used it and loved it.
+
+Over the next years it became clear that type annotations are the main new way to define classes and their attributes.
+However, it has also become clear that some people viscerally hate type annotations.
+We're determined to serve both.
+
+
+``attrs`` TNG
+^^^^^^^^^^^^^
+
+Over its existance, ``attrs`` never stood still.
+But since we also greatly care about backward compatibility and not breaking our users's code, many features and niceties have to be manually activated.
+
+That is not only annoying, it also leads to the problem that many of ``attrs``'s users don't even know what it can.
+We've spent years alone explaining that defining attributes using type annotations is in no way unique to `dataclasses`.
+
+Finally we've decided to take the `Go route <https://go.dev/blog/module-compatibility>`_:
+instead of fiddling with the old APIs -- whose names felt anachronistic anyway -- we'd define new ones, with better defaults.
+So in July 2018, we `looked for better names <https://github.com/python-attrs/attrs/issues/408>`_ and came up with `define`, `field`, and friends.
+Then in January 2019, we `started looking for inconvenient defaults <https://github.com/python-attrs/attrs/issues/487>`_ that we now could fix without any repercussions.
+
+These APIs proved to be vastly popular, so we've finally changed the documentation to them in November of 2021.
+
+All of this took way too long, of course.
+One reason is the COVID-19 pandemic, but also our fear to fumble this historic chance to fix our APIs.
+
+We hope you'll like them.
+
+
+.. [#attr] We considered calling the package just ``attr`` too, but it was already taken byt a `ostensibly inactive package on PyPI <https://pypi.org/project/attr/#history>`_.
+.. [#stdlib] The highly readable PEP also explains why ``attrs`` wasn't just added to the standard library.
+   Don't believe the myths and rumors.

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -18,7 +18,7 @@ We recommend our modern APIs for new code:
 - :func:`~attr.frozen` is an alias for ``define(frozen=True)``
 - and `field()` to define an attribute.
 
-They have been added in ``attrs`` 20.1.0, they are expressive, and they have modern defaults like slots and type annotation awareness.
+They have been added in ``attrs`` 20.1.0, they are expressive, and they have modern defaults like slots and type annotation awareness switched on by default.
 They are only available in Python 3.6 and later.
 Sometimes they're referred to as *next-generation* or *NG* APIs.
 
@@ -32,7 +32,7 @@ A Short History Lesson
 
 At this point, ``attrs`` is an old project.
 It had its first release in April 2015 -- back when most Python code was on Python 2.7 and Python 3.4 was the first Python 3 release that showed promise.
-``attrs`` was always Python 3-first, but `type annotations <https://www.python.org/dev/peps/pep-0484/>`_ came only into Python 3.5 that was released in September 2015.
+``attrs`` was always Python 3-first, but `type annotations <https://www.python.org/dev/peps/pep-0484/>`_ came only into Python 3.5 that was released in September 2015 and were largely ignored until years later.
 
 At this time, if you didn't want to implement all the :term:`dunder methods`, the most common way to create a class with some attributes on it was to subclass a `collections.namedtuple`, or one of the many hacks that allowed you to access dictionary keys using attribute lookup.
 

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -48,7 +48,8 @@ But it was really just a way to say ``attrs`` and ``attrib``\ [#attr]_.
 
 Some people hated this cutey API from day one, which is why we added aliases for them that we called *serious business*: ``@attr.attrs`` and ``attr.attrib()``.
 Fans of them usually imported the names and didn't use the package name in the first place.
-Unfortunately, the ``attr`` package name also started creaking the moment we added `attr.Factory`.
+Unfortunately, the ``attr`` package name started creaking the moment we added `attr.Factory`, since it couldn’t be morphed into something meaningful in any way.
+A problem that grew worse over time, as more APIs and even modules were added.
 
 But overall, ``attrs`` in this shape was a **huge** success -- especially after glyph's blog post `The One Python Library Everyone Needs <https://glyph.twistedmatrix.com/2016/08/attrs.html>`_ in August 2016 and `pytest <https://docs.pytest.org/>`_ adopting it.
 

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -40,7 +40,7 @@ But ``attrs`` history goes even a bit further back, to the now-forgotten `charac
 
 In the wake of all of that, `glyph <https://twitter.com/glyph>`_ and `Hynek <https://twitter.com/hynek>`_ came together on IRC and brainstormed how to take the good ideas of ``characteristic``, but make them easier to use and read.
 At this point the plan was not to make ``attrs`` what it is now -- a flexible class building kit.
-All we wanted was an ergonomic little library to succintly define classes with attributes.
+All we wanted was an ergonomic little library to succinctly define classes with attributes.
 
 Under the impression of of the unwieldy ``characteristic`` name, we went to the other side and decided to make the package name part of the API, and keep the API functions very short.
 This led to the infamous `attr.s` and `attr.ib` which some found confusing and even pronounced it as "attr dot s".

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -55,7 +55,7 @@ But overall, ``attrs`` in this shape was a **huge** success -- especially after 
 Being able to just write::
 
    @attr.s
-   class Point:
+   class Point(object):
        x = attr.ib()
        y = attr.ib()
 
@@ -103,7 +103,12 @@ These APIs proved to be vastly popular, so we've finally changed the documentati
 All of this took way too long, of course.
 One reason is the COVID-19 pandemic, but also our fear to fumble this historic chance to fix our APIs.
 
-We hope you'll like them.
+We hope you'll like them::
+
+   @define
+   class Point:
+       x: int
+       y: int
 
 
 .. [#attr] We considered calling the package just ``attr`` too, but it was already taken byt a `ostensibly inactive package on PyPI <https://pypi.org/project/attr/#history>`_.

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -103,7 +103,7 @@ These APIs proved to be vastly popular, so we've finally changed the documentati
 All of this took way too long, of course.
 One reason is the COVID-19 pandemic, but also our fear to fumble this historic chance to fix our APIs.
 
-We hope you'll like them::
+We hope you like them::
 
    @define
    class Point:

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -68,7 +68,7 @@ Dataclasses Enter The Arena
 
 A big change happened in May 2017 when Hynek sat down with `Guido van Rossum <https://en.wikipedia.org/wiki/Guido_van_Rossum>`_ and `Eric V. Smith <https://github.com/ericvsmith>`_ at PyCon US 2017.
 
-Type annotations for class attributes have `just landed <https://www.python.org/dev/peps/pep-0526/>`_ in Python 3.6 and Guido felt like it would be a good mechanic to introduce something similar like ``attrs`` to the Python standard library.
+Type annotations for class attributes have `just landed <https://www.python.org/dev/peps/pep-0526/>`_ in Python 3.6 and Guido felt like it would be a good mechanic to introduce something similar to ``attrs`` to the Python standard library.
 The result, of course, was `PEP 557 <https://www.python.org/dev/peps/pep-0557/>`_\ [#stdlib]_ which eventually became the `dataclasses` module in Python 3.7.
 
 ``attrs`` at this point was lucky to have several people on board who were also very excited about type annotations and helped implementing it, including a `Mypy plugin <https://github.com/python/mypy/blob/master/mypy/plugins/attrs.py>`_.

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -111,6 +111,6 @@ We hope you like them::
        y: int
 
 
-.. [#attr] We considered calling the package just ``attr`` too, but it was already taken byt a `ostensibly inactive package on PyPI <https://pypi.org/project/attr/#history>`_.
+.. [#attr] We considered calling the PyPI package just ``attr`` too, but the name was already taken by an *ostensibly* inactive `package on PyPI <https://pypi.org/project/attr/#history>`_.
 .. [#stdlib] The highly readable PEP also explains why ``attrs`` wasn't just added to the standard library.
    Don't believe the myths and rumors.

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -67,7 +67,7 @@ Dataclasses Enter The Arena
 
 A big change happened in May 2017 when Hynek sat down with `Guido van Rossum <https://en.wikipedia.org/wiki/Guido_van_Rossum>`_ and `Eric V. Smith <https://github.com/ericvsmith>`_ at PyCon US 2017.
 
-Type annotations for class attributes have just landed in Python 3.6 and Guido felt like it would be a good mechanic to introduce something similar like ``attrs`` to the Python standard library.
+Type annotations for class attributes have `just landed <https://www.python.org/dev/peps/pep-0526/>`_ in Python 3.6 and Guido felt like it would be a good mechanic to introduce something similar like ``attrs`` to the Python standard library.
 The result, of course, was `PEP 557 <https://www.python.org/dev/peps/pep-0557/>`_\ [#stdlib]_ which eventually became the `dataclasses` module in Python 3.7.
 
 ``attrs`` at this point was lucky to have several people on board who were also very excited about type annotations and helped implementing it, including a `Mypy plugin <https://github.com/python/mypy/blob/master/mypy/plugins/attrs.py>`_.

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -26,7 +26,7 @@ Philosophy
    An ``attrs`` class in runtime is indistinguishable from a regular class: because it *is* a regular class with a few boilerplate-y methods attached.
 
 **Be light on API impact.**
-   As convenient as it seems at first, ``attrs`` will *not* tack on any methods to your classes save the dunder ones.
+   As convenient as it seems at first, ``attrs`` will *not* tack on any methods to your classes except for the :term:`dunder ones <dunder methods>`.
    Hence all the useful `tools <helpers>` that come with ``attrs`` live in functions that operate on top of instances.
    Since they take an ``attrs`` instance as their first argument, you can attach them to your classes with one line of code.
 
@@ -50,38 +50,9 @@ What ``attrs`` Is Not
 All ``attrs`` does is:
 
 1. take your declaration,
-2. write dunder methods based on that information,
+2. write :term:`dunder methods` based on that information,
 3. and attach them to your class.
 
 It does *nothing* dynamic at runtime, hence zero runtime overhead.
 It's still *your* class.
 Do with it as you please.
-
-
-On the ``attr.s`` and ``attr.ib`` Names
-=======================================
-
-The ``attr.s`` decorator and the ``attr.ib`` function aren't any obscure abbreviations.
-They are a *concise* and highly *readable* way to write ``attrs`` and ``attrib`` with an *explicit namespace*.
-
-At first, some people have a negative gut reaction to that; resembling the reactions to Python's significant whitespace.
-And as with that, once one gets used to it, the readability and explicitness of that API prevails and delights.
-
-For those who can't swallow that API at all, ``attrs`` comes with serious business aliases: ``attr.attrs`` and ``attr.attrib``.
-
-Therefore, the following class definition is identical to the previous one:
-
-.. doctest::
-
-   >>> from attr import attrs, attrib, Factory
-   >>> @attrs
-   ... class SomeClass(object):
-   ...     a_number = attrib(default=42)
-   ...     list_of_numbers = attrib(default=Factory(list))
-   ...
-   ...     def hard_math(self, another_number):
-   ...         return self.a_number + sum(self.list_of_numbers) * another_number
-   >>> SomeClass(1, [1, 2, 3])
-   SomeClass(a_number=1, list_of_numbers=[1, 2, 3])
-
-Use whichever variant fits your taste better.


### PR DESCRIPTION
This is an addendum to #863 and fixes #726.

N.B. that you can read the rendered docs at https://attrs--871.org.readthedocs.build/en/871/names.html