### PR TITLE
Update comparisons to dataclasses

### DIFF
--- a/docs/why.rst
+++ b/docs/why.rst
@@ -5,51 +5,46 @@ Why not…
 If you'd like third party's account why ``attrs`` is great, have a look at Glyph's `The One Python Library Everyone Needs <https://glyph.twistedmatrix.com/2016/08/attrs.html>`_!
 
 
-…tuples?
---------
+…Data Classes?
+--------------
+
+:pep:`557` added Data Classes to `Python 3.7 <https://docs.python.org/3.7/whatsnew/3.7.html#dataclasses>`_ that resemble ``attrs`` in many ways.
+
+They are the result of the Python community's `wish <https://mail.python.org/pipermail/python-ideas/2017-May/045618.html>`_ to have an easier way to write classes in the standard library that doesn't carry the problems of ``namedtuple``\ s.
+To that end, ``attrs`` and its developers were involved in the PEP process and while we may disagree with some minor decisions that have been made, it's a fine library and if it stops you from abusing ``namedtuple``\ s, they are a huge win.
+
+Nevertheless, there are still reasons to prefer ``attrs`` over Data Classes whose relevancy depends on your circumstances:
+
+- ``attrs`` supports all mainstream Python versions, including CPython 2.7 and PyPy.
+- ``attrs`` doesn't force type annotations on you if you don't like them.
+- But since it **also** supports typing, it's the best way to embrace type hints *gradually*, too.
+- While Data Classes are implementing features from ``attrs`` every now and then, their presence is dependent on the Python version, not the package version.
+  For example, support for ``__slots__`` has only been added in Python 3.10.
+  That is especially painful in PyPI packages that support multiple Python versions.
+  This includes possible implementation bugs.
+- Data Classes are *intentionally* less powerful than ``attrs``.
+  There is a long list of features that were sacrificed for the sake of simplicity and while the most obvious ones are validators, converters, field hooks, or equality customization, it permeates throughout all APIs.
+
+  On the other hand, Data Classes currently do not offer any significant feature that ``attrs`` doesn't already have.
+- ``attrs`` can and will move faster.
+  We are not bound to any release schedules and we have a clear deprecation policy.
+
+  One of the `reasons <https://www.python.org/dev/peps/pep-0557/#why-not-just-use-attrs>`_ to not vendor ``attrs`` in the standard library was to not impede ``attrs``'s future development.
+
+One way to think about ``attrs`` vs Data Classes is that ``attrs`` is a fully-fledged toolkit to write powerful classes while Data Classes are an easy way to get a class with some attributes.
+Basically what ``attrs`` was in 2015.
 
 
-Readability
-^^^^^^^^^^^
+…pydantic?
+----------
 
-What makes more sense while debugging::
+*pydantic* is first an foremost a *data validation library*.
+As such, it is a capable complement to class building libraries like ``attrs`` (or Data Classes!) for parsing and validating untrusted data.
 
-   Point(x=1, y=2)
+However as convenient as it is, using it for your business layer `is problematic in many ways <https://threeofwands.com/why-i-use-attrs-instead-of-pydantic/>`_.
+In the parlance of `Form, Command, and Model Validation <https://verraes.net/2015/02/form-command-model-validation/>`_, *pydantic* is the right tools for *Commands*.
 
-or::
-
-   (1, 2)
-
-?
-
-Let's add even more ambiguity::
-
-   Customer(id=42, reseller=23, first_name="Jane", last_name="John")
-
-or::
-
-   (42, 23, "Jane", "John")
-
-?
-
-Why would you want to write ``customer[2]`` instead of ``customer.first_name``?
-
-Don't get me started when you add nesting.
-If you've never run into mysterious tuples you had no idea what the hell they meant while debugging, you're much smarter than yours truly.
-
-Using proper classes with names and types makes program code much more readable and comprehensible_.
-Especially when trying to grok a new piece of software or returning to old code after several months.
-
-.. _comprehensible: https://arxiv.org/pdf/1304.5257.pdf
-
-
-Extendability
-^^^^^^^^^^^^^
-
-Imagine you have a function that takes or returns a tuple.
-Especially if you use tuple unpacking (eg. ``x, y = get_point()``), adding additional data means that you have to change the invocation of that function *everywhere*.
-
-Adding an attribute to a class concerns only those who actually care about that attribute.
+`Separation of concerns <https://en.wikipedia.org/wiki/Separation_of_concerns>`_ feels tedious at times, but it's one of those things that you get to appreciate once you've shot your own foot often enough.
 
 
 …namedtuples?
@@ -57,7 +52,7 @@ Adding an attribute to a class concerns only those who actually care about that 
 
 `collections.namedtuple`\ s are tuples with names, not classes. [#history]_
 Since writing classes is tiresome in Python, every now and then someone discovers all the typing they could save and gets really excited.
-However that convenience comes at a price.
+However, that convenience comes at a price.
 
 The most obvious difference between ``namedtuple``\ s and ``attrs``-based classes is that the latter are type-sensitive:
 
@@ -133,46 +128,50 @@ With ``attrs`` your users won't notice a difference because it creates regular, 
 .. _behaving like a tuple: https://docs.python.org/3/tutorial/datastructures.html#tuples-and-sequences
 
 
-…Data Classes?
---------------
+…tuples?
+--------
 
-:pep:`557` added Data Classes to `Python 3.7 <https://docs.python.org/3.7/whatsnew/3.7.html#dataclasses>`_ that resemble ``attrs`` in many ways.
+Readability
+^^^^^^^^^^^
 
-They are the result of the Python community's `wish <https://mail.python.org/pipermail/python-ideas/2017-May/045618.html>`_ to have an easier way to write classes in the standard library that doesn't carry the problems of ``namedtuple``\ s.
-To that end, ``attrs`` and its developers were involved in the PEP process and while we may disagree with some minor decisions that have been made, it's a fine library and if it stops you from abusing ``namedtuple``\ s, they are a huge win.
+What makes more sense while debugging::
 
-Nevertheless, there are still reasons to prefer ``attrs`` over Data Classes whose relevancy depends on your circumstances:
+   Point(x=1, y=2)
 
-- ``attrs`` supports all mainstream Python versions, including CPython 2.7 and PyPy.
-- ``attrs`` doesn't force type annotations on you if you don't like them.
-- But since it **also** supports typing, it's the best way to embrace type hints *gradually*, too.
-- While Data Classes are implementing features from ``attrs`` every now and then, their presence is dependent on the Python version, not the package version.
-  For example, support for ``__slots__`` has only been added in Python 3.10.
-  That is especially painful in PyPI packages that support multiple Python versions.
-  This includes possible implementation bugs.
-- Data Classes are *intentionally* less powerful than ``attrs``.
-  There is a long list of features that were sacrificed for the sake of simplicity and while the most obvious ones are validators, converters, field hooks, or equality customization, it permeates throughout all APIs.
+or::
 
-  On the other hand, Data Classes currently do not offer any significant feature that ``attrs`` doesn't already have.
-- ``attrs`` can and will move faster.
-  We are not bound to any release schedules and we have a clear deprecation policy.
+   (1, 2)
 
-  One of the `reasons <https://www.python.org/dev/peps/pep-0557/#why-not-just-use-attrs>`_ to not vendor ``attrs`` in the standard library was to not impede ``attrs``'s future development.
+?
 
-One way to think about ``attrs`` vs Data Classes is that ``attrs`` is a fully-fledged toolkit to write powerful classes while Data Classes are an easy way to get a class with some attributes.
-Basically what ``attrs`` was in 2015.
+Let's add even more ambiguity::
+
+   Customer(id=42, reseller=23, first_name="Jane", last_name="John")
+
+or::
+
+   (42, 23, "Jane", "John")
+
+?
+
+Why would you want to write ``customer[2]`` instead of ``customer.first_name``?
+
+Don't get me started when you add nesting.
+If you've never run into mysterious tuples you had no idea what the hell they meant while debugging, you're much smarter than yours truly.
+
+Using proper classes with names and types makes program code much more readable and comprehensible_.
+Especially when trying to grok a new piece of software or returning to old code after several months.
+
+.. _comprehensible: https://arxiv.org/pdf/1304.5257.pdf
 
 
-…pydantic?
-----------
+Extendability
+^^^^^^^^^^^^^
 
-*pydantic* is first an foremost a *data validation library*.
-As such, it is a capable complement to class building libraries like ``attrs`` (or Data Classes!) for parsing and validating untrusted data.
+Imagine you have a function that takes or returns a tuple.
+Especially if you use tuple unpacking (eg. ``x, y = get_point()``), adding additional data means that you have to change the invocation of that function *everywhere*.
 
-However as convenient as it is, using it for your business layer `is problematic in many ways <https://threeofwands.com/why-i-use-attrs-instead-of-pydantic/>`_.
-In the parlance of `Form, Command, and Model Validation <https://verraes.net/2015/02/form-command-model-validation/>`_, *pydantic* is the right tools for *Commands*.
-
-`Separation of concerns <https://en.wikipedia.org/wiki/Separation_of_concerns>`_ feels tedious at times, but it's one of those things that you get to appreciate once you've shot your own foot often enough.
+Adding an attribute to a class concerns only those who actually care about that attribute.
 
 
 …dicts?

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -144,8 +144,13 @@ To that end, ``attrs`` and its developers were involved in the PEP process and w
 Nevertheless, there are still reasons to prefer ``attrs`` over Data Classes whose relevancy depends on your circumstances:
 
 - ``attrs`` supports all mainstream Python versions, including CPython 2.7 and PyPy.
-- Data Classes are intentionally less powerful than ``attrs``.
-  There is a long list of features that were sacrificed for the sake of simplicity and while the most obvious ones are validators, converters, and ``__slots__``, it permeates throughout all APIs.
+- ``attrs`` doesn't force type annotations on you, if you don't like them.
+- While Data Classes are implementing features from ``attrs`` every now and then, their presence is dependent on the Python version, not the package version.
+  For example, support for ``__slots__`` has only been added in Python 3.10.
+  That is especially painful in PyPI packages that support multiple Python versions.
+  This includes possible implementation bugs.
+- Data Classes are *intentionally* less powerful than ``attrs``.
+  There is a long list of features that were sacrificed for the sake of simplicity and while the most obvious ones are validators, converters, field hooks, or equality customization, it permeates throughout all APIs.
 
   On the other hand, Data Classes currently do not offer any significant feature that ``attrs`` doesn't already have.
 - ``attrs`` can and will move faster.
@@ -153,6 +158,8 @@ Nevertheless, there are still reasons to prefer ``attrs`` over Data Classes whos
 
   One of the `reasons <https://www.python.org/dev/peps/pep-0557/#why-not-just-use-attrs>`_ to not vendor ``attrs`` in the standard library was to not impede ``attrs``'s future development.
 
+One way to think about ``attrs`` vs Data Classes is that ``attrs`` is a fully-fledged toolkit to write powerful classes while Data Classes are an easy way to get a class with some attributes.
+Basically what ``attrs`` was in 2015.
 
 
 …dicts?

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -41,8 +41,8 @@ Basically what ``attrs`` was in 2015.
 *pydantic* is first an foremost a *data validation library*.
 As such, it is a capable complement to class building libraries like ``attrs`` (or Data Classes!) for parsing and validating untrusted data.
 
-However as convenient as it is, using it for your business layer `is problematic in many ways <https://threeofwands.com/why-i-use-attrs-instead-of-pydantic/>`_.
-In the parlance of `Form, Command, and Model Validation <https://verraes.net/2015/02/form-command-model-validation/>`_, *pydantic* is the right tools for *Commands*.
+However, as convenient as it might be, using it for your business or data layer `is problematic in many ways <https://threeofwands.com/why-i-use-attrs-instead-of-pydantic/>`_.
+In the parlance of `Form, Command, and Model Validation <https://verraes.net/2015/02/form-command-model-validation/>`_, *pydantic* is the right tool for *Commands*.
 
 `Separation of concerns <https://en.wikipedia.org/wiki/Separation_of_concerns>`_ feels tedious at times, but it's one of those things that you get to appreciate once you've shot your own foot often enough.
 

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -15,17 +15,17 @@ To that end, ``attrs`` and its developers were involved in the PEP process and w
 
 Nevertheless, there are still reasons to prefer ``attrs`` over Data Classes whose relevancy depends on your circumstances:
 
+- Data Classes are *intentionally* less powerful than ``attrs``.
+  There is a long list of features that were sacrificed for the sake of simplicity and while the most obvious ones are validators, converters, field hooks, or equality customization, it permeates throughout all APIs.
+
+  On the other hand, Data Classes currently do not offer any significant feature that ``attrs`` doesn't already have.
 - ``attrs`` supports all mainstream Python versions, including CPython 2.7 and PyPy.
 - ``attrs`` doesn't force type annotations on you if you don't like them.
 - But since it **also** supports typing, it's the best way to embrace type hints *gradually*, too.
 - While Data Classes are implementing features from ``attrs`` every now and then, their presence is dependent on the Python version, not the package version.
   For example, support for ``__slots__`` has only been added in Python 3.10.
-  That is especially painful in PyPI packages that support multiple Python versions.
+  That is especially painful for PyPI packages that support multiple Python versions.
   This includes possible implementation bugs.
-- Data Classes are *intentionally* less powerful than ``attrs``.
-  There is a long list of features that were sacrificed for the sake of simplicity and while the most obvious ones are validators, converters, field hooks, or equality customization, it permeates throughout all APIs.
-
-  On the other hand, Data Classes currently do not offer any significant feature that ``attrs`` doesn't already have.
 - ``attrs`` can and will move faster.
   We are not bound to any release schedules and we have a clear deprecation policy.
 

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -145,6 +145,7 @@ Nevertheless, there are still reasons to prefer ``attrs`` over Data Classes whos
 
 - ``attrs`` supports all mainstream Python versions, including CPython 2.7 and PyPy.
 - ``attrs`` doesn't force type annotations on you, if you don't like them.
+- But since it **does** support typing, it's the best way to embrace type hints *gradually*, too.
 - While Data Classes are implementing features from ``attrs`` every now and then, their presence is dependent on the Python version, not the package version.
   For example, support for ``__slots__`` has only been added in Python 3.10.
   That is especially painful in PyPI packages that support multiple Python versions.

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -42,7 +42,8 @@ Basically what ``attrs`` was in 2015.
 *pydantic* is first an foremost a *data validation library*.
 As such, it is a capable complement to class building libraries like ``attrs`` (or Data Classes!) for parsing and validating untrusted data.
 
-However, as convenient as it might be, using it for your business or data layer `is problematic in many ways <https://threeofwands.com/why-i-use-attrs-instead-of-pydantic/>`_.
+However, as convenient as it might be, using it for your business or data layer `is problematic in several ways <https://threeofwands.com/why-i-use-attrs-instead-of-pydantic/>`_:
+Is it really necessary to re-validate all your objects while reading them from a trusted database?
 In the parlance of `Form, Command, and Model Validation <https://verraes.net/2015/02/form-command-model-validation/>`_, *pydantic* is the right tool for *Commands*.
 
 `Separation of concerns <https://en.wikipedia.org/wiki/Separation_of_concerns>`_ feels tedious at times, but it's one of those things that you get to appreciate once you've shot your own foot often enough.

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -13,7 +13,8 @@ If you'd like third party's account why ``attrs`` is great, have a look at Glyph
 They are the result of the Python community's `wish <https://mail.python.org/pipermail/python-ideas/2017-May/045618.html>`_ to have an easier way to write classes in the standard library that doesn't carry the problems of ``namedtuple``\ s.
 To that end, ``attrs`` and its developers were involved in the PEP process and while we may disagree with some minor decisions that have been made, it's a fine library and if it stops you from abusing ``namedtuple``\ s, they are a huge win.
 
-Nevertheless, there are still reasons to prefer ``attrs`` over Data Classes whose relevancy depends on your circumstances:
+Nevertheless, there are still reasons to prefer ``attrs`` over Data Classes.
+Whether they're relevant to *you* depends on your circumstances:
 
 - Data Classes are *intentionally* less powerful than ``attrs``.
   There is a long list of features that were sacrificed for the sake of simplicity and while the most obvious ones are validators, converters, :ref:`equality customization <custom-comparison>`, or :doc:`extensibility <extending>` in general, it permeates throughout all APIs.

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -16,7 +16,7 @@ To that end, ``attrs`` and its developers were involved in the PEP process and w
 Nevertheless, there are still reasons to prefer ``attrs`` over Data Classes whose relevancy depends on your circumstances:
 
 - Data Classes are *intentionally* less powerful than ``attrs``.
-  There is a long list of features that were sacrificed for the sake of simplicity and while the most obvious ones are validators, converters, field hooks, or equality customization, it permeates throughout all APIs.
+  There is a long list of features that were sacrificed for the sake of simplicity and while the most obvious ones are validators, converters, :ref:`equality customization <custom-comparison>`, or :doc:`extensibility <extending>` in general, it permeates throughout all APIs.
 
   On the other hand, Data Classes currently do not offer any significant feature that ``attrs`` doesn't already have.
 - ``attrs`` supports all mainstream Python versions, including CPython 2.7 and PyPy.

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -168,8 +168,8 @@ Basically what ``attrs`` was in 2015.
 
 *pydantic* is first an foremost a *data validation library*.
 As such, it is a capable complement to class building libraries like ``attrs`` (or Data Classes!) for parsing and validating untrusted data.
-However as convenient as it is, using it for your business layer `is problematic in many ways <https://threeofwands.com/why-i-use-attrs-instead-of-pydantic/>`_.
 
+However as convenient as it is, using it for your business layer `is problematic in many ways <https://threeofwands.com/why-i-use-attrs-instead-of-pydantic/>`_.
 In the parlance of `Form, Command, and Model Validation <https://verraes.net/2015/02/form-command-model-validation/>`_, *pydantic* is the right tools for *Commands*.
 
 `Separation of concerns <https://en.wikipedia.org/wiki/Separation_of_concerns>`_ feels tedious at times, but it's one of those things that you get to appreciate once you've shot your own foot often enough.

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -163,6 +163,18 @@ One way to think about ``attrs`` vs Data Classes is that ``attrs`` is a fully-fl
 Basically what ``attrs`` was in 2015.
 
 
+…pydantic?
+----------
+
+*pydantic* is first an foremost a *data validation library*.
+As such, it is a capable complement to class building libraries like ``attrs`` (or Data Classes!) for parsing and validating untrusted data.
+However as convenient as it is, using it for your business layer `is problematic in many ways <https://threeofwands.com/why-i-use-attrs-instead-of-pydantic/>`_.
+
+In the parlance of `Form, Command, and Model Validation <https://verraes.net/2015/02/form-command-model-validation/>`_, *pydantic* is the right tools for *Commands*.
+
+`Separation of concerns <https://en.wikipedia.org/wiki/Separation_of_concerns>`_ feels tedious at times, but it's one of those things that you get to appreciate once you've shot your own foot often enough.
+
+
 …dicts?
 -------
 

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -144,8 +144,8 @@ To that end, ``attrs`` and its developers were involved in the PEP process and w
 Nevertheless, there are still reasons to prefer ``attrs`` over Data Classes whose relevancy depends on your circumstances:
 
 - ``attrs`` supports all mainstream Python versions, including CPython 2.7 and PyPy.
-- ``attrs`` doesn't force type annotations on you, if you don't like them.
-- But since it **does** support typing, it's the best way to embrace type hints *gradually*, too.
+- ``attrs`` doesn't force type annotations on you if you don't like them.
+- But since it **also** supports typing, it's the best way to embrace type hints *gradually*, too.
 - While Data Classes are implementing features from ``attrs`` every now and then, their presence is dependent on the Python version, not the package version.
   For example, support for ``__slots__`` has only been added in Python 3.10.
   That is especially painful in PyPI packages that support multiple Python versions.


### PR DESCRIPTION
This is to fix #761

There's a bunch of problems to discuss, so I'm just gonna start _somewhere_.

The big questions to me are:

- do we still have to talk about dicts/tuples at all?
- should we add pydantic? (cf. <https://threeofwands.com/why-i-use-attrs-instead-of-pydantic/>)
- **how** are we going to talk about dataclasses at all, since they're something else in each Python release?
   - [x] which definitely is an upside of attrs that should be mentioned.


# Relevant rendered pages

- https://attrs--872.org.readthedocs.build/en/872/overview.html
- https://attrs--872.org.readthedocs.build/en/872/why.html