### PR TITLE
Do not require cloudpickle for PyPy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "pypy-2.7", "pypy-3.7"]
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "pypy-2.7", "pypy-3.7", "pypy-3.8"]
 
     steps:
       - uses: actions/checkout@v2

--- a/changelog.d/892.change.rst
+++ b/changelog.d/892.change.rst
@@ -1,0 +1,1 @@
+Fixed the test suite on PyPy3.8 where cloudpickle does not work.

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ EXTRAS_REQUIRE = {
     "docs": ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"],
     "tests_no_zope": [
         # For regression test to ensure cloudpickle compat doesn't break.
-        "cloudpickle",
+        'cloudpickle; python_implementation == "CPython"',
         # 5.0 introduced toml; parallel was broken until 5.0.2
         "coverage[toml]>=5.0.2",
         "hypothesis",

--- a/tests/test_3rd_party.py
+++ b/tests/test_3rd_party.py
@@ -4,11 +4,14 @@
 Tests for compatibility against other Python modules.
 """
 
-import cloudpickle
+import pytest
 
 from hypothesis import given
 
 from .strategies import simple_classes
+
+
+cloudpickle = pytest.importorskip("cloudpickle")
 
 
 class TestCloudpickleCompat(object):


### PR DESCRIPTION
The cloudpickle package relies on CPython implementation details,
and does not even import on PyPy:

```
ImportError while importing test module '/tmp/attrs/tests/test_3rd_party.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/pypy3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_3rd_party.py:7: in <module>
    import cloudpickle
.tox/pypy3/lib/pypy3.8/site-packages/cloudpickle/__init__.py:4: in <module>
    from cloudpickle.cloudpickle import *  # noqa
.tox/pypy3/lib/pypy3.8/site-packages/cloudpickle/cloudpickle.py:57: in <module>
    from .compat import pickle
.tox/pypy3/lib/pypy3.8/site-packages/cloudpickle/compat.py:13: in <module>
    from _pickle import Pickler  # noqa: F401
E   ModuleNotFoundError: No module named '_pickle'
```

Disable the dependency for PyPy and make the test handle missing
cloudpickle gracefully.

# Summary

<!-- Please tell us what your pull request is about here. -->


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/python-attrs/attrs/blob/main/.github/CONTRIBUTING.md) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.
-->

- [ ] Added **tests** for changed code.
  Our CI fails if coverage is not 100%.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [ ] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [ ] ...and used in the stub test file `tests/typing_example.py`.
    - [ ] If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/main/src/attr/__init__.py) file.
- [ ] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
