### PR TITLE
docs: fix very minor typo

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -24,7 +24,7 @@ Core
 
 .. note::
 
-  Please not that the ``attrs`` namespace has been added in version 21.3.0.
+  Please note that the ``attrs`` namespace has been added in version 21.3.0.
   Most of the objects are simply re-imported from ``attr``.
   Therefore if a class, method, or function claims that it has been added in an older version, it is only available in the ``attr`` namespace.
 


### PR DESCRIPTION
# Summary

Very minor typo in docs (and a few other questions/points).

Thank you for the great release with 21.3.0... I have already updated a big project I'm working on to use it. :-)

I found this minor typo in the docs.

Also, a couple of other points questions if you don't mind -- I normally wouldn't bring these up in a PR, but since I'm not sure of another place to discuss this, I thought this was better than nothing:

## 1)

This is really minor, but the phrase "vastly popular" in `docs/names.rst` feels a bit awkward to me.  I would expect to see "vastly more popular" if the intent is "people are abandoning the previous way in droves" or "very popular" if the intent is "people seem to really like the new way".  I wasn't sure the intended meaning, so I didn't include this in the PR and just wanted to submit it for consideration.

## 2)

This point is probably very controversial (and probably discussed somewhere else I'm not aware of), but I wanted to ask anyway. :-)  Hopefully that's OK. :-)   I was recently reviewing some code that used `@define` and it caused me to pause and think "what?!?" and then I remembered the "next gen" attrs stuff and it made sense.  But to people not familiar with attrs and the modern API, it might leave them scratching their head for a bit.  Yeah, I know at the top you would have `from attrs import define` and that should clue them in.  But wouldn't it be more explicit and clear to do this?

```
import attrs

@attrs.define
class Coordinates2X:
    x: int
    y: int = attrs.field(
        default=attrs.Factory(
            takes_self=True,
            factory=lambda self: self.x * 2
        )
    )
```

I know people are free to do it either way and that changing the "recommended way" that's shown in the examples probably isn't something you guys want to change at this point, but I wanted to throw it out there since I think it would make it a bit more accessible for people new to attrs.


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/python-attrs/attrs/blob/main/.github/CONTRIBUTING.md) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.
-->

- [x] Added **tests** for changed code.
  Our CI fails if coverage is not 100%.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [x] ...and used in the stub test file `tests/typing_example.py`.
    - [x] If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/main/src/attr/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).

