### PR TITLE
Speedup uses of `object.__setattr__`

### DIFF
--- a/changelog.d/898.change.rst
+++ b/changelog.d/898.change.rst
@@ -1,0 +1,1 @@
+Speedup instantiation of frozen slotted classes.

--- a/docs/how-does-it-work.rst
+++ b/docs/how-does-it-work.rst
@@ -87,16 +87,16 @@ This is (still) slower than a plain assignment:
   $ pyperf timeit --rigorous \
         -s "import attr; C = attr.make_class('C', ['x', 'y', 'z'], slots=True)" \
         "C(1, 2, 3)"
-  ........................................
-  Median +- std dev: 378 ns +- 12 ns
+  .........................................
+  Mean +- std dev: 228 ns +- 18 ns
 
   $ pyperf timeit --rigorous \
         -s "import attr; C = attr.make_class('C', ['x', 'y', 'z'], slots=True, frozen=True)" \
         "C(1, 2, 3)"
-  ........................................
-  Median +- std dev: 676 ns +- 16 ns
+  .........................................
+  Mean +- std dev: 450 ns +- 26 ns
 
-So on a laptop computer the difference is about 300 nanoseconds (1 second is 1,000,000,000 nanoseconds).
+So on a laptop computer the difference is about 230 nanoseconds (1 second is 1,000,000,000 nanoseconds).
 It's certainly something you'll feel in a hot loop but shouldn't matter in normal code.
 Pick what's more important to you.
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -784,7 +784,6 @@ class TestFunctional(object):
 
         src = inspect.getsource(D.__init__)
 
-        assert "_setattr = _cached_setattr" in src
-        assert "_setattr('x', x)" in src
-        assert "_setattr('y', y)" in src
+        assert "_setattr(self, 'x', x)" in src
+        assert "_setattr(self, 'y', y)" in src
         assert object.__setattr__ != D.__setattr__


### PR DESCRIPTION
# Summary

I was playing around seeing if I could speedup the creation of frozen slot classes for a project of mine since we instantiate a lot of attr classes. Ideally they would be frozen, but we didnt go with it because of the speed implications it had.

To try and speed it up I tried different things:
- Make use of `objects.__setattr__` during the whole of the init and then place the frozen one at the end
  - The idea behind this is to use the default `__setattr__` during the whole `__init__` function and then setting it to the frozen one after, which I thought would bring speedups as well as improve the UX, since they can could set attributes normally in the init. This unfortunately didnt work nicely with slots and slowed it down even further when attempting a workaround
- Playing around a bit with python internals and trying to figure out the ideal way to implement this
  - This is the change this PR adds does

Overall I wasn't really successful, but I did find this small performance gain of "1.1x", which isnt much, but I think it might be worth having.

Bellow you can see the pypref benchmarks on my laptop (to simulate the ones that were in the documentation)

### Before (attrs == 21.4.0)

```bash
$ pyperf timeit --rigorous -s "import attr; C = attr.make_class('C', ['x', 'y', 'z'], slots=True, frozen=True)" "C(1, 2, 3)"
.........................................
Mean +- std dev: 499 ns +- 26 ns
```

### After
```bash
$ pyperf timeit --rigorous -s "import attr; C = attr.make_class('C', ['x', 'y', 'z'], slots=True, frozen=True)" "C(1, 2, 3)"
.........................................
Mean +- std dev: 450 ns +- 17 ns
```


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/python-attrs/attrs/blob/main/.github/CONTRIBUTING.md) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.
-->

- [x] Added **tests** for changed code.
  Our CI fails if coverage is not 100%.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [x] ...and used in the stub test file `tests/typing_example.py`.
    - [x] If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/main/src/attr/__init__.py) file.
- [x] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).

