### PR TITLE
Remove incorrect statement in documentation

### DIFF
--- a/src/attr/_next_gen.py
+++ b/src/attr/_next_gen.py
@@ -58,7 +58,6 @@ def define(
     - *auto_exc=True*
     - *auto_detect=True*
     - *order=False*
-    - *match_args=True*
     - Some options that were only relevant on Python 2 or were kept around for
       backwards-compatibility have been removed.
 


### PR DESCRIPTION
# Summary

Both `attr.define` and `attr.s` have `match_args=True` by default.