### PR TITLE
Improve docs of `attr.s(match_args=True)`

### DIFF
--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1458,7 +1458,7 @@ def attrs(
     :param bool match_args:
         If `True` (default), set ``__match_args__`` on the class to support
         `PEP 634 <https://www.python.org/dev/peps/pep-0634/>`_ (Structural
-        Pattern Matching). It is a tuple of all positional-only ``__init__``
+        Pattern Matching). It is a tuple of all positional ``__init__``
         parameter names on Python 3.10 and later. Ignored on older Python
         versions.
 

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1458,7 +1458,7 @@ def attrs(
     :param bool match_args:
         If `True` (default), set ``__match_args__`` on the class to support
         `PEP 634 <https://www.python.org/dev/peps/pep-0634/>`_ (Structural
-        Pattern Matching). It is a tuple of all positional ``__init__``
+        Pattern Matching). It is a tuple of all non-keyword-only ``__init__``
         parameter names on Python 3.10 and later. Ignored on older Python
         versions.
 


### PR DESCRIPTION
# Summary

Hi!

I am implementing `match_args` support in Mypy and while reading your docs I was confused: how can `attr.s` work with *positional-only* arguments to `__init__`?

By *positional-only* many python devs mean this: `def some(x, y, /): ...`
But, this is not the case for `attr.s`, proof:

```python
import attr

@attr.s(match_args=True, auto_attribs=True)
class ToMatch:
    x: int
    y: int
    z: int = attr.field(kw_only=True)

print(ToMatch(1, 2, z=3).__match_args__)  # ('x', 'y')
print(ToMatch(x=1, y=2, z=3).__match_args__)  # ('x', 'y')
```

As you see, here both `x` and `y` are regular arguments, they can be passed by position or by name.

So, I hope that the proposed wording will be cleaner! 👍 