### PR TITLE
Add missing attrs.converters/filters, fortify type tests

### DIFF
--- a/src/attrs/__init__.pyi
+++ b/src/attrs/__init__.pyi
@@ -23,13 +23,15 @@ from attr import __version_info__ as __version_info__
 from attr import _FilterType
 from attr import assoc as assoc
 from attr import Attribute as Attribute
+from attr import converters as converters
 from attr import define as define
 from attr import evolve as evolve
-from attr import Factory as Factory
 from attr import exceptions as exceptions
+from attr import Factory as Factory
 from attr import field as field
 from attr import fields as fields
 from attr import fields_dict as fields_dict
+from attr import filters as filters
 from attr import frozen as frozen
 from attr import has as has
 from attr import make_class as make_class

--- a/tests/typing_example.py
+++ b/tests/typing_example.py
@@ -394,27 +394,23 @@ attrs.asdict(MatchArgs2(1, 2))
 attrs.astuple(MatchArgs2(1, 2))
 
 
-def importing_from_attr() -> None:
+def accessing_from_attr() -> None:
     """
     Use a function to keep the ns clean.
     """
-    from attr.converters import optional
-    from attr.exceptions import FrozenError
-    from attr.filters import include
-    from attr.setters import frozen
-    from attr.validators import and_
-
-    assert optional and FrozenError and include and frozen and and_
+    attr.converters.optional
+    attr.exceptions.FrozenError
+    attr.filters.include
+    attr.setters.frozen
+    attr.validators.and_
 
 
-def importing_from_attrs() -> None:
+def accessing_from_attrs() -> None:
     """
     Use a function to keep the ns clean.
     """
-    from attrs.converters import optional
-    from attrs.exceptions import FrozenError
-    from attrs.filters import include
-    from attrs.setters import frozen
-    from attrs.validators import and_
-
-    assert optional and FrozenError and include and frozen and and_
+    attrs.converters.optional
+    attrs.exceptions.FrozenError
+    attrs.filters.include
+    attrs.setters.frozen
+    attrs.validators.and_


### PR DESCRIPTION
Basically we forgot to export converters and filters and the import checks didn't catch that.

Fixes #930 