### PR TITLE
Drop the deprecated Attribute.cmp

### DIFF
--- a/changelog.d/939.breaking.rst
+++ b/changelog.d/939.breaking.rst
@@ -1,2 +1,2 @@
 The deprecated ``cmp`` attribute of ``attrs.Attribute`` has been removed.
-This does not affect the *cmp* argument to ``attr.s``/``define`` which can be used as a shortcut to set *eq* and *order* at the same time.
+This does not affect the *cmp* argument to ``attr.s`` that can be used as a shortcut to set *eq* and *order* at the same time.

--- a/changelog.d/939.breaking.rst
+++ b/changelog.d/939.breaking.rst
@@ -1,0 +1,2 @@
+The deprecated ``cmp`` attribute of ``attrs.Attribute`` has been removed.
+This does not affect the *cmp* argument to ``attr.s``/``define`` which can be used as a shortcut to set *eq* and *order* at the same time.

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1,11 +1,9 @@
 # SPDX-License-Identifier: MIT
 
-
 import copy
 import linecache
 import sys
 import typing
-import warnings
 
 from operator import itemgetter
 
@@ -1091,12 +1089,6 @@ class _ClassBuilder:
             pass
 
         return method
-
-
-_CMP_DEPRECATION = (
-    "The usage of `cmp` is deprecated and will be removed on or after "
-    "2021-06-01.  Please use `eq` and `order` instead."
-)
 
 
 def _determine_attrs_eq_order(cmp, eq, order, default_eq):
@@ -2593,15 +2585,6 @@ class Attribute:
             inherited=False,
             **inst_dict
         )
-
-    @property
-    def cmp(self):
-        """
-        Simulate the presence of a cmp attribute and warn.
-        """
-        warnings.warn(_CMP_DEPRECATION, DeprecationWarning, stacklevel=2)
-
-        return self.eq and self.order
 
     # Don't use attr.evolve since fields(Attribute) doesn't work
     def evolve(self, **changes):

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -642,6 +642,20 @@ class TestFunctional:
         assert ei.value.args[0] in possible_errors
 
     @pytest.mark.parametrize("slots", [True, False])
+    @pytest.mark.parametrize("cmp", [True, False])
+    def test_attrib_cmp_shortcut(self, slots, cmp):
+        """
+        Setting cmp on `attr.ib`s sets both eq and order.
+        """
+
+        @attr.s(slots=slots)
+        class C:
+            x = attr.ib(cmp=cmp)
+
+        assert cmp is attr.fields(C).x.eq
+        assert cmp is attr.fields(C).x.order
+
+    @pytest.mark.parametrize("slots", [True, False])
     def test_no_setattr_if_validate_without_validators(self, slots):
         """
         If a class has on_setattr=attr.setters.validate (former default in NG

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -12,7 +12,7 @@ from copy import deepcopy
 
 import pytest
 
-from hypothesis import assume, given
+from hypothesis import given
 from hypothesis.strategies import booleans
 
 import attr
@@ -20,8 +20,6 @@ import attr
 from attr._compat import PY36, TYPE
 from attr._make import NOTHING, Attribute
 from attr.exceptions import FrozenInstanceError
-
-from .strategies import optional_bool
 
 
 @attr.s
@@ -642,45 +640,6 @@ class TestFunctional:
             C(5) < C(6)
 
         assert ei.value.args[0] in possible_errors
-
-    @given(cmp=optional_bool, eq=optional_bool, order=optional_bool)
-    def test_cmp_deprecated_attribute(self, cmp, eq, order):
-        """
-        Accessing Attribute.cmp raises a deprecation warning but returns True
-        if cmp is True, or eq and order are *both* effectively True.
-        """
-        # These cases are invalid and raise a ValueError.
-        assume(cmp is None or (eq is None and order is None))
-        assume(not (eq is False and order is True))
-
-        if cmp is not None:
-            rv = cmp
-        elif eq is True or eq is None:
-            rv = order is None or order is True
-        elif cmp is None and eq is None and order is None:
-            rv = True
-        elif cmp is None or eq is None:
-            rv = False
-        else:
-            pytest.fail(
-                "Unexpected state: cmp=%r eq=%r order=%r" % (cmp, eq, order)
-            )
-
-        with pytest.deprecated_call() as dc:
-
-            @attr.s
-            class C:
-                x = attr.ib(cmp=cmp, eq=eq, order=order)
-
-            assert rv == attr.fields(C).x.cmp
-
-        (w,) = dc.list
-
-        assert (
-            "The usage of `cmp` is deprecated and will be removed on or after "
-            "2021-06-01.  Please use `eq` and `order` instead."
-            == w.message.args[0]
-        )
 
     @pytest.mark.parametrize("slots", [True, False])
     def test_no_setattr_if_validate_without_validators(self, slots):


### PR DESCRIPTION
This has nothing to do with the cmp argument to attr.s/define which have been
undeprecated.