### PR TITLE
No longer explicitly subclass ‘object’

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -71,7 +71,7 @@ Core
 
       >>> import attr
       >>> @attr.s
-      ... class C(object):
+      ... class C:
       ...     x = attr.ib()
       >>> attr.fields(C).x
       Attribute(name='x', default=NOTHING, validator=None, repr=True, eq=True, eq_key=None, order=True, order_key=None, hash=None, init=True, metadata=mappingproxy({}), type=None, converter=None, kw_only=False, inherited=False, on_setattr=None)
@@ -101,7 +101,7 @@ Core
    .. doctest::
 
       >>> @attr.s
-      ... class C(object):
+      ... class C:
       ...     x = attr.ib(default=attr.Factory(list))
       ...     y = attr.ib(default=attr.Factory(
       ...         lambda self: set(self.x),
@@ -132,11 +132,11 @@ Classic
 
       >>> import attr
       >>> @attr.s
-      ... class C(object):
+      ... class C:
       ...     _private = attr.ib()
       >>> C(private=42)
       C(_private=42)
-      >>> class D(object):
+      >>> class D:
       ...     def __init__(self, x):
       ...         self.x = x
       >>> D(1)
@@ -171,7 +171,7 @@ Classic
    .. doctest::
 
       >>> @attr.s
-      ... class C(object):
+      ... class C:
       ...     x = attr.ib()
       ...     y = attr.ib()
       ...     @x.validator
@@ -242,7 +242,7 @@ Helpers
    .. doctest::
 
       >>> @attr.s
-      ... class C(object):
+      ... class C:
       ...     x = attr.ib()
       ...     y = attr.ib()
       >>> attrs.fields(C)
@@ -263,7 +263,7 @@ Helpers
    .. doctest::
 
       >>> @attr.s
-      ... class C(object):
+      ... class C:
       ...     x = attr.ib()
       ...     y = attr.ib()
       >>> attrs.fields_dict(C)
@@ -284,7 +284,7 @@ Helpers
    .. doctest::
 
       >>> @attr.s
-      ... class C(object):
+      ... class C:
       ...     pass
       >>> attr.has(C)
       True
@@ -467,7 +467,7 @@ All objects from ``attrs.validators`` are also available from ``attr.validators`
    .. doctest::
 
       >>> @attrs.define
-      ... class C(object):
+      ... class C:
       ...     x = attrs.field(validator=attr.validators.le(42))
       >>> C(42)
       C(x=42)
@@ -732,7 +732,7 @@ All objects from ``attrs.converters`` are also available from ``attr.converters`
    .. doctest::
 
       >>> @attr.s
-      ... class C(object):
+      ... class C:
       ...     x = attr.ib(converter=attr.converters.optional(int))
       >>> C(None)
       C(x=None)
@@ -747,7 +747,7 @@ All objects from ``attrs.converters`` are also available from ``attr.converters`
    .. doctest::
 
       >>> @attr.s
-      ... class C(object):
+      ... class C:
       ...     x = attr.ib(
       ...         converter=attr.converters.default_if_none("")
       ...     )
@@ -762,7 +762,7 @@ All objects from ``attrs.converters`` are also available from ``attr.converters`
    .. doctest::
 
       >>> @attr.s
-      ... class C(object):
+      ... class C:
       ...     x = attr.ib(
       ...         converter=attr.converters.to_bool
       ...     )
@@ -836,7 +836,7 @@ It behaves similarly to `sys.version_info` and is an instance of `VersionInfo`:
    >>> cmp_off == {"eq":  False}
    True
    >>> @attr.s(**cmp_off)
-   ... class C(object):
+   ... class C:
    ...     pass
 
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -200,7 +200,7 @@ For that, `attrs.asdict` offers a callback that decides whether an attribute sho
 .. doctest::
 
    >>> @define
-   ... class User(object):
+   ... class User:
    ...     email: str
    ...     password: str
 
@@ -486,7 +486,7 @@ Types
 
    >>> import attr
    >>> @attr.s
-   ... class C(object):
+   ... class C:
    ...     x = attr.ib(type=int)
    >>> fields(C).x.type
    <class 'int'>

--- a/docs/init.rst
+++ b/docs/init.rst
@@ -8,7 +8,7 @@ Passing complex objects into ``__init__`` and then using them to derive data for
 
 So assuming you use an ORM and want to extract 2D points from a row object, do not write code like this::
 
-    class Point(object):
+    class Point:
         def __init__(self, database_row):
             self.x = database_row.x
             self.y = database_row.y

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -57,7 +57,7 @@ But overall, ``attrs`` in this shape was a **huge** success -- especially after 
 Being able to just write::
 
    @attr.s
-   class Point(object):
+   class Point:
        x = attr.ib()
        y = attr.ib()
 

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -68,7 +68,7 @@ To mypy, this code is equivalent to the one above:
 .. code-block:: python
 
   @attr.s
-  class SomeClass(object):
+  class SomeClass:
       a_number = attr.ib(default=42)  # type: int
       list_of_numbers = attr.ib(factory=list, type=list[int])
 

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -202,7 +202,7 @@ To bring it into perspective, the equivalent of
 .. doctest::
 
    >>> @attr.s
-   ... class SmartClass(object):
+   ... class SmartClass:
    ...    a = attr.ib()
    ...    b = attr.ib()
    >>> SmartClass(1, 2)
@@ -212,7 +212,7 @@ is roughly
 
 .. doctest::
 
-   >>> class ArtisanalClass(object):
+   >>> class ArtisanalClass:
    ...     def __init__(self, a, b):
    ...         self.a = a
    ...         self.b = b
@@ -272,7 +272,7 @@ You can freely choose which features you want and disable those that you want mo
 .. doctest::
 
    >>> @attr.s(repr=False)
-   ... class SmartClass(object):
+   ... class SmartClass:
    ...    a = attr.ib()
    ...    b = attr.ib()
    ...

--- a/tests/test_mypy.yml
+++ b/tests/test_mypy.yml
@@ -688,7 +688,7 @@
   main: |
     import attr
     @attr.s
-    class C(object):
+    class C:
         x: int = attr.ib(default=1)
         y: int = attr.ib()
         @y.default
@@ -700,7 +700,7 @@
   main: |
     import attr
     @attr.s
-    class C(object):
+    class C:
         x = attr.ib()
         @x.validator
         def check(self, attribute, value):
@@ -944,7 +944,7 @@
   main: |
     import attr
     @attr.s
-    class C(object):
+    class C:
         _x = attr.ib(init=False, default=42)
     C()
     C(_x=42)  # E: Unexpected keyword argument "_x" for "C"
@@ -1228,7 +1228,7 @@
 
     import attr
     @attr.s
-    class C(object):
+    class C:
         x: int = attr.ib(default=1)
         y: int = attr.ib()
         @y.default
@@ -1243,7 +1243,7 @@
 
     import attr
     @attr.s
-    class C(object):
+    class C:
         x = attr.ib()
         @x.validator
         def check(self, attribute, value):


### PR DESCRIPTION
This is no longer relevant in Python 3+. Follow-up to !936.
