### PR TITLE
Clean up some more Python 2-isms

### DIFF
--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -80,7 +80,7 @@ Glossary
            ...     assert 23 == d.method()
 
       - Slotted classes must implement :meth:`__getstate__ <object.__getstate__>` and :meth:`__setstate__ <object.__setstate__>` to be serializable with `pickle` protocol 0 and 1.
-        Therefore, ``attrs`` creates these methods automatically for ``slots=True`` classes (Python 2 uses protocol 0 by default).
+        Therefore, ``attrs`` creates these methods automatically for ``slots=True`` classes.
 
         .. note::
 

--- a/docs/hashing.rst
+++ b/docs/hashing.rst
@@ -32,7 +32,7 @@ Because according to the definition_ from the official Python docs, the returned
    It follows that the moment you (or ``attrs``) change the way equality is handled by implementing ``__eq__`` which is based on attribute values, this constraint is broken.
    For that reason Python 3 will make a class that has customized equality unhashable.
    Python 2 on the other hand will happily let you shoot your foot off.
-   Unfortunately ``attrs`` currently mimics Python 2's behavior for backward compatibility reasons if you set ``hash=False``.
+   Unfortunately, ``attrs`` still mimics (otherwise unsupported) Python 2's behavior for backward compatibility reasons if you set ``hash=False``.
 
    The *correct way* to achieve hashing by id is to set ``@attr.s(eq=False)``.
    Setting ``@attr.s(hash=False)`` (which implies ``eq=True``) is almost certainly a *bug*.

--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -26,10 +26,6 @@ else:
 
 
 def just_warn(*args, **kw):
-    """
-    We only warn on Python 3 because we are not aware of any concrete
-    consequences of not setting the cell on Python 2.
-    """
     warnings.warn(
         "Running interpreter doesn't sufficiently support code object "
         "introspection.  Some features like bare super() or accessing "

--- a/src/attr/validators.py
+++ b/src/attr/validators.py
@@ -169,11 +169,10 @@ def matches_re(regex, flags=0, func=None):
     :param regex: a regex string or precompiled pattern to match against
     :param int flags: flags that will be passed to the underlying re function
         (default 0)
-    :param callable func: which underlying `re` function to call (options
-        are `re.fullmatch`, `re.search`, `re.match`, default
-        is ``None`` which means either `re.fullmatch` or an emulation of
-        it on Python 2). For performance reasons, they won't be used directly
-        but on a pre-`re.compile`\ ed pattern.
+    :param callable func: which underlying `re` function to call. Valid options
+        are `re.fullmatch`, `re.search`, and `re.match`; the default ``None``
+        means `re.fullmatch`. For performance reasons, the pattern is always
+        precompiled using `re.compile`.
 
     .. versionadded:: 19.2.0
     .. versionchanged:: 21.3.0 *regex* can be a pre-compiled pattern.

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -690,7 +690,7 @@ class TestPickle:
 
 def test_slots_super_property_get():
     """
-    On Python 2/3: the `super(self.__class__, self)` works.
+    Both `super()` and `super(self.__class__, self)` work.
     """
 
     @attr.s(slots=True)
@@ -707,8 +707,16 @@ def test_slots_super_property_get():
         def f(self):
             return super().f ** 2
 
+    @attr.s(slots=True)
+    class C(A):
+        @property
+        def f(self):
+            return super(C, self).f ** 2
+
     assert B(11).f == 121
     assert B(17).f == 289
+    assert C(11).f == 121
+    assert C(17).f == 289
 
 
 def test_slots_super_property_get_shortcut():


### PR DESCRIPTION
- Reword and simplify a few docstrings.
- Add back a test for 2-arg super() in property() definitions that
  was (accidentally?) dropped in #936.
