### PR TITLE
Update docs/examples.rst: add missing import statement for @frozen

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -583,7 +583,7 @@ Immutability is especially popular in functional programming and is generally a 
 If you'd like to enforce it, ``attrs`` will try to help:
 
 .. doctest::
-   >>> from attr import frozen
+   >>> from attrs import frozen
 
    >>> @frozen
    ... class C:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -583,6 +583,7 @@ Immutability is especially popular in functional programming and is generally a 
 If you'd like to enforce it, ``attrs`` will try to help:
 
 .. doctest::
+   >>> from attr import frozen
 
    >>> @frozen
    ... class C:
@@ -603,7 +604,7 @@ In Clojure that function is called `assoc <https://clojuredocs.org/clojure.core/
 
 .. doctest::
 
-   >>> from attrs import evolve
+   >>> from attrs import evolve, frozen
 
    >>> @frozen
    ... class C:

--- a/docs/init.rst
+++ b/docs/init.rst
@@ -467,9 +467,9 @@ The second one is using a decorator-based default::
        token: str
        client: WebClient = field()  # needed! attr.ib works too
 
-        @client.default
-        def _client_factory(self):
-            return WebClient(self.token)
+       @client.default
+       def _client_factory(self):
+           return WebClient(self.token)
 
 That said, and as pointed out in the beginning of the chapter, a better approach would be to have a factory class method::
 


### PR DESCRIPTION
# Summary

this PR adds the import statement for `@frozen` decorator to maintain consistency; also fix an indention error in `init.rst`.


# Pull Request Check List

Only documentation changes is included, remove check list.