### PR TITLE
Remove mutable default arg in function example

### DIFF
--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -171,7 +171,7 @@ Here are some tips for effective use of metadata:
 
   .. doctest::
 
-    >>> from attr import fields, NOTHING
+    >>> from attr import field, NOTHING
     >>> MY_TYPE_METADATA = '__my_type_metadata'
     >>>
     >>> def typed(
@@ -179,7 +179,7 @@ Here are some tips for effective use of metadata:
     ...     eq=True, order=None, hash=None, init=True, metadata=None,
     ...     converter=None
     ... ):
-    ...     metadata = {} if not metadata else metadata
+    ...     metadata = metadata or {}
     ...     metadata[MY_TYPE_METADATA] = cls
     ...     return field(
     ...         default=default, validator=validator, repr=repr,

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -171,7 +171,7 @@ Here are some tips for effective use of metadata:
 
   .. doctest::
 
-    >>> from attr import field, NOTHING
+    >>> from attr import fields, NOTHING
     >>> MY_TYPE_METADATA = '__my_type_metadata'
     >>>
     >>> def typed(

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -176,10 +176,10 @@ Here are some tips for effective use of metadata:
     >>>
     >>> def typed(
     ...     cls, default=NOTHING, validator=None, repr=True,
-    ...     eq=True, order=None, hash=None, init=True, metadata={},
+    ...     eq=True, order=None, hash=None, init=True, metadata=None,
     ...     converter=None
     ... ):
-    ...     metadata = dict() if not metadata else metadata
+    ...     metadata = {} if not metadata else metadata
     ...     metadata[MY_TYPE_METADATA] = cls
     ...     return field(
     ...         default=default, validator=validator, repr=repr,


### PR DESCRIPTION
Removed mutable default arg, replaced with `None`.
https://docs.quantifiedcode.com/python-anti-patterns/correctness/mutable_default_value_as_argument.html

Replaced `dict()` with `{}`.
https://stackoverflow.com/questions/8424942/creating-a-new-dictionary-in-python

# Summary

Documentation changes.