### PR TITLE
docs: fix simple typo, coverter -> converter

### DIFF
--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -255,7 +255,7 @@ class TestAnnotations:
 
     def test_nullary_converter(self):
         """
-        A coverter with no arguments doesn't cause a crash.
+        A converter with no arguments doesn't cause a crash.
         """
 
         def noop():


### PR DESCRIPTION
There is a small typo in tests/test_annotations.py.

Should read `converter` rather than `coverter`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md