### PR TITLE
Fix typo in tox wiki link in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -225,6 +225,6 @@ If you'd like to join, just get a pull request merged and ask to be added in the
 [CI]: https://github.com/python-attrs/attrs/actions?query=workflow%3ACI
 [Hynek Schlawack]: https://hynek.me/about/
 [*pre-commit*]: https://pre-commit.com/
-[*tox*]: https://https://tox.wiki/
+[*tox*]: https://tox.wiki/
 [semantic newlines]: https://rhodesmill.org/brandon/2012/one-sentence-per-line/
 [*reStructuredText*]: https://www.sphinx-doc.org/en/stable/usage/restructuredtext/basics.html


### PR DESCRIPTION
# Summary

Fixes a typo to the Tox Wiki in CONTRIBUTING.md.