### PR TITLE
Drop Python 3.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-beta - 3.11", "pypy-3.7", "pypy-3.8"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11.0-beta - 3.11", "pypy-3.7", "pypy-3.8"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     rev: v2.37.3
     hooks:
       - id: pyupgrade
-        args: [--py3-plus, --keep-percent-format]
+        args: [--py36-plus, --keep-percent-format]
         exclude: "tests/test_slots.py"
 
   - repo: https://github.com/PyCQA/isort

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,18 +25,21 @@ repos:
         additional_dependencies: [toml]
         files: \.py$
 
+  - repo: https://github.com/asottile/yesqa
+    rev: v1.3.0
+    hooks:
+      - id: yesqa
+
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 5.0.1
     hooks:
       - id: flake8
-        language_version: python3.10
 
   - repo: https://github.com/econchick/interrogate
     rev: 1.5.0
     hooks:
       - id: interrogate
         args: [tests]
-        language_version: python3.10
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0

--- a/README.rst
+++ b/README.rst
@@ -113,7 +113,7 @@ Project Information
 - **Changelog**: https://www.attrs.org/en/stable/changelog.html
 - **Get Help**: please use the ``python-attrs`` tag on `StackOverflow <https://stackoverflow.com/questions/tagged/python-attrs>`_
 - **Third-party Extensions**: https://github.com/python-attrs/attrs/wiki/Extensions-to-attrs
-- **Supported Python Versions**: 3.5 and later (last 2.7-compatible release is `21.4.0 <https://pypi.org/project/attrs/21.4.0/>`_)
+- **Supported Python Versions**: 3.6 and later (last 2.7-compatible release is `21.4.0 <https://pypi.org/project/attrs/21.4.0/>`_)
 
 If you'd like to contribute to ``attrs`` you're most welcome and we've written `a little guide <https://github.com/python-attrs/attrs/blob/main/.github/CONTRIBUTING.md>`_ to get you started!
 

--- a/changelog.d/988.breaking.rst
+++ b/changelog.d/988.breaking.rst
@@ -1,0 +1,1 @@
+Python 3.5 is not supported anymore.

--- a/conftest.py
+++ b/conftest.py
@@ -1,9 +1,8 @@
 # SPDX-License-Identifier: MIT
 
-
 from hypothesis import HealthCheck, settings
 
-from attr._compat import PY36, PY310
+from attr._compat import PY310
 
 
 def pytest_configure(config):
@@ -15,14 +14,5 @@ def pytest_configure(config):
 
 
 collect_ignore = []
-if not PY36:
-    collect_ignore.extend(
-        [
-            "tests/test_annotations.py",
-            "tests/test_hooks.py",
-            "tests/test_init_subclass.py",
-            "tests/test_next_gen.py",
-        ]
-    )
 if not PY310:
     collect_ignore.extend(["tests/test_pattern_matching.py"])

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14,7 +14,6 @@ As of version 21.3.0, ``attrs`` consists of **two** top-level package names:
 - The classic ``attr`` that powered the venerable `attr.s` and `attr.ib`
 - The modern ``attrs`` that only contains most modern APIs and relies on `attrs.define` and `attrs.field` to define your classes.
   Additionally it offers some ``attr`` APIs with nicer defaults (e.g. `attrs.asdict`).
-  Using this namespace requires Python 3.6 or later.
 
 The ``attrs`` namespace is built *on top of* ``attr`` which will *never* go away.
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -473,7 +473,7 @@ If you're the author of a third-party library with ``attrs`` integration, please
 Types
 -----
 
-``attrs`` also allows you to associate a type with an attribute using either the *type* argument to `attr.ib` or -- as of Python 3.6 -- using :pep:`526`-annotations:
+``attrs`` also allows you to associate a type with an attribute using either the *type* argument to `attr.ib` or using :pep:`526`-annotations:
 
 
 .. doctest::

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -124,7 +124,7 @@ Types
 
 ``attrs`` offers two ways of attaching type information to attributes:
 
-- :pep:`526` annotations on Python 3.6 and later,
+- :pep:`526` annotations,
 - and the *type* argument to `attr.ib`.
 
 This information is available to you:

--- a/docs/names.rst
+++ b/docs/names.rst
@@ -19,7 +19,6 @@ We recommend our modern APIs for new code:
 - and `attrs.field()` to define an attribute.
 
 They have been added in ``attrs`` 20.1.0, they are expressive, and they have modern defaults like slots and type annotation awareness switched on by default.
-They are only available in Python 3.6 and later.
 Sometimes they're referred to as *next-generation* or *NG* APIs.
 As of ``attrs`` 21.3.0 you can also import them from the ``attrs`` package namespace.
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import codecs
 import os
 import platform
 import re
-import sys
 
 from setuptools import find_packages, setup
 
@@ -33,7 +32,6 @@ CLASSIFIERS = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
@@ -57,10 +55,7 @@ EXTRAS_REQUIRE = {
         "pytest>=4.3.0",  # 4.3.0 dropped last use of `convert`
     ],
 }
-if (
-    sys.version_info[:2] >= (3, 6)
-    and platform.python_implementation() != "PyPy"
-):
+if platform.python_implementation() != "PyPy":
     EXTRAS_REQUIRE["tests_no_zope"].extend(
         ["mypy>=0.900,!=0.940", "pytest-mypy-plugins"]
     )
@@ -92,11 +87,11 @@ def find_meta(meta):
     Extract __*meta*__ from META_FILE.
     """
     meta_match = re.search(
-        r"^__{meta}__ = ['\"]([^'\"]*)['\"]".format(meta=meta), META_FILE, re.M
+        rf"^__{meta}__ = ['\"]([^'\"]*)['\"]", META_FILE, re.M
     )
     if meta_match:
         return meta_match.group(1)
-    raise RuntimeError("Unable to find __{meta}__ string.".format(meta=meta))
+    raise RuntimeError(f"Unable to find __{meta}__ string.")
 
 
 LOGO = """
@@ -119,7 +114,7 @@ LONG = (
         re.S,
     ).group(1)
     + "\n\n`Full changelog "
-    + "<{url}en/stable/changelog.html>`_.\n\n".format(url=URL)
+    + f"<{URL}en/stable/changelog.html>`_.\n\n"
     + read("AUTHORS.rst")
 )
 
@@ -141,7 +136,7 @@ if __name__ == "__main__":
         long_description_content_type="text/x-rst",
         packages=PACKAGES,
         package_dir={"": "src"},
-        python_requires=">=3.5",
+        python_requires=">=3.6",
         zip_safe=False,
         classifiers=CLASSIFIERS,
         install_requires=INSTALL_REQUIRES,

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ LOGO = """
 .. image:: https://www.attrs.org/en/stable/_static/attrs_logo.png
    :alt: attrs logo
    :align: center
-"""  # noqa
+"""
 
 VERSION = find_meta("version")
 URL = find_meta("url")

--- a/src/attr/__init__.py
+++ b/src/attr/__init__.py
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: MIT
 
-
-import sys
-
 from functools import partial
 
 from . import converters, exceptions, filters, setters, validators
@@ -20,6 +17,7 @@ from ._make import (
     make_class,
     validate,
 )
+from ._next_gen import define, field, frozen, mutable
 from ._version_info import VersionInfo
 
 
@@ -56,15 +54,19 @@ __all__ = [
     "attrs",
     "cmp_using",
     "converters",
+    "define",
     "evolve",
     "exceptions",
+    "field",
     "fields",
     "fields_dict",
     "filters",
+    "frozen",
     "get_run_validators",
     "has",
     "ib",
     "make_class",
+    "mutable",
     "resolve_types",
     "s",
     "set_run_validators",
@@ -72,8 +74,3 @@ __all__ = [
     "validate",
     "validators",
 ]
-
-if sys.version_info[:2] >= (3, 6):
-    from ._next_gen import define, field, frozen, mutable  # noqa: F401
-
-    __all__.extend(("define", "field", "frozen", "mutable"))

--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -12,17 +12,7 @@ from collections.abc import Mapping, Sequence  # noqa
 
 
 PYPY = platform.python_implementation() == "PyPy"
-PY36 = sys.version_info[:2] >= (3, 6)
-HAS_F_STRINGS = PY36
 PY310 = sys.version_info[:2] >= (3, 10)
-
-
-if PYPY or PY36:
-    ordered_dict = dict
-else:
-    from collections import OrderedDict
-
-    ordered_dict = OrderedDict
 
 
 def just_warn(*args, **kw):

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -11,14 +11,7 @@ from operator import itemgetter
 # We need to import _compat itself in addition to the _compat members to avoid
 # having the thread-local in the globals here.
 from . import _compat, _config, setters
-from ._compat import (
-    HAS_F_STRINGS,
-    PY310,
-    PYPY,
-    _AnnotationExtractor,
-    ordered_dict,
-    set_closure_cell,
-)
+from ._compat import PY310, PYPY, _AnnotationExtractor, set_closure_cell
 from .exceptions import (
     DefaultAlreadySetError,
     FrozenInstanceError,
@@ -201,9 +194,9 @@ def attrib(
         value is converted before being passed to the validator, if any.
     :param metadata: An arbitrary mapping, to be used by third-party
         components.  See `extending_metadata`.
-    :param type: The type of the attribute.  In Python 3.6 or greater, the
-        preferred method to specify the type is using a variable annotation
-        (see :pep:`526`).
+
+    :param type: The type of the attribute. Nowadays, the preferred method to
+        specify the type is using a variable annotation (see :pep:`526`).
         This argument is provided for backward compatibility.
         Regardless of the approach used, the type will be stored on
         ``Attribute.type``.
@@ -323,7 +316,7 @@ def _make_method(name, script, filename, globs):
         if old_val == linecache_tuple:
             break
         else:
-            filename = "{}-{}>".format(base_filename[:-1], count)
+            filename = f"{base_filename[:-1]}-{count}>"
             count += 1
 
     _compile_and_eval(script, globs, locs, filename)
@@ -341,9 +334,9 @@ def _make_attr_tuple_class(cls_name, attr_names):
         __slots__ = ()
         x = property(itemgetter(0))
     """
-    attr_class_name = "{}Attributes".format(cls_name)
+    attr_class_name = f"{cls_name}Attributes"
     attr_class_template = [
-        "class {}(tuple):".format(attr_class_name),
+        f"class {attr_class_name}(tuple):",
         "    __slots__ = ()",
     ]
     if attr_names:
@@ -503,7 +496,7 @@ def _transform_attrs(
     if these is not None:
         ca_list = [(name, ca) for name, ca in these.items()]
 
-        if not isinstance(these, ordered_dict):
+        if not isinstance(these, dict):
             ca_list.sort(key=_counter_getter)
     elif auto_attribs is True:
         ca_names = {
@@ -735,7 +728,7 @@ class _ClassBuilder:
             ) = self._make_getstate_setstate()
 
     def __repr__(self):
-        return "<_ClassBuilder(cls={cls})>".format(cls=self._cls.__name__)
+        return f"<_ClassBuilder(cls={self._cls.__name__})>"
 
     def build_class(self):
         """
@@ -1218,10 +1211,7 @@ def attrs(
         If *these* is not ``None``, ``attrs`` will *not* search the class body
         for attributes and will *not* remove any attributes from it.
 
-        If *these* is an ordered dict (`dict` on Python 3.6+,
-        `collections.OrderedDict` otherwise), the order is deduced from
-        the order of the attributes inside *these*.  Otherwise the order
-        of the definition of the attributes is used.
+        The order is deduced from the order of the attributes inside *these*.
 
     :type these: `dict` of `str` to `attr.ib`
 
@@ -1329,7 +1319,7 @@ def attrs(
     :param bool weakref_slot: Make instances weak-referenceable.  This has no
         effect unless ``slots`` is also enabled.
     :param bool auto_attribs: If ``True``, collect :pep:`526`-annotated
-        attributes (Python 3.6 and later only) from the class body.
+        attributes from the class body.
 
         In this case, you **must** annotate every field.  If ``attrs``
         encounters a field that is set to an `attr.ib` but lacks a type
@@ -1833,126 +1823,61 @@ def _add_eq(cls, attrs=None):
     return cls
 
 
-if HAS_F_STRINGS:
-
-    def _make_repr(attrs, ns, cls):
-        unique_filename = _generate_unique_filename(cls, "repr")
-        # Figure out which attributes to include, and which function to use to
-        # format them. The a.repr value can be either bool or a custom
-        # callable.
-        attr_names_with_reprs = tuple(
-            (a.name, (repr if a.repr is True else a.repr), a.init)
-            for a in attrs
-            if a.repr is not False
+def _make_repr(attrs, ns, cls):
+    unique_filename = _generate_unique_filename(cls, "repr")
+    # Figure out which attributes to include, and which function to use to
+    # format them. The a.repr value can be either bool or a custom
+    # callable.
+    attr_names_with_reprs = tuple(
+        (a.name, (repr if a.repr is True else a.repr), a.init)
+        for a in attrs
+        if a.repr is not False
+    )
+    globs = {
+        name + "_repr": r for name, r, _ in attr_names_with_reprs if r != repr
+    }
+    globs["_compat"] = _compat
+    globs["AttributeError"] = AttributeError
+    globs["NOTHING"] = NOTHING
+    attribute_fragments = []
+    for name, r, i in attr_names_with_reprs:
+        accessor = (
+            "self." + name if i else 'getattr(self, "' + name + '", NOTHING)'
         )
-        globs = {
-            name + "_repr": r
-            for name, r, _ in attr_names_with_reprs
-            if r != repr
-        }
-        globs["_compat"] = _compat
-        globs["AttributeError"] = AttributeError
-        globs["NOTHING"] = NOTHING
-        attribute_fragments = []
-        for name, r, i in attr_names_with_reprs:
-            accessor = (
-                "self." + name
-                if i
-                else 'getattr(self, "' + name + '", NOTHING)'
-            )
-            fragment = (
-                "%s={%s!r}" % (name, accessor)
-                if r == repr
-                else "%s={%s_repr(%s)}" % (name, name, accessor)
-            )
-            attribute_fragments.append(fragment)
-        repr_fragment = ", ".join(attribute_fragments)
-
-        if ns is None:
-            cls_name_fragment = (
-                '{self.__class__.__qualname__.rsplit(">.", 1)[-1]}'
-            )
-        else:
-            cls_name_fragment = ns + ".{self.__class__.__name__}"
-
-        lines = [
-            "def __repr__(self):",
-            "  try:",
-            "    already_repring = _compat.repr_context.already_repring",
-            "  except AttributeError:",
-            "    already_repring = {id(self),}",
-            "    _compat.repr_context.already_repring = already_repring",
-            "  else:",
-            "    if id(self) in already_repring:",
-            "      return '...'",
-            "    else:",
-            "      already_repring.add(id(self))",
-            "  try:",
-            "    return f'%s(%s)'" % (cls_name_fragment, repr_fragment),
-            "  finally:",
-            "    already_repring.remove(id(self))",
-        ]
-
-        return _make_method(
-            "__repr__", "\n".join(lines), unique_filename, globs=globs
+        fragment = (
+            "%s={%s!r}" % (name, accessor)
+            if r == repr
+            else "%s={%s_repr(%s)}" % (name, name, accessor)
         )
+        attribute_fragments.append(fragment)
+    repr_fragment = ", ".join(attribute_fragments)
 
-else:
+    if ns is None:
+        cls_name_fragment = '{self.__class__.__qualname__.rsplit(">.", 1)[-1]}'
+    else:
+        cls_name_fragment = ns + ".{self.__class__.__name__}"
 
-    def _make_repr(attrs, ns, _):
-        """
-        Make a repr method that includes relevant *attrs*, adding *ns* to the
-        full name.
-        """
+    lines = [
+        "def __repr__(self):",
+        "  try:",
+        "    already_repring = _compat.repr_context.already_repring",
+        "  except AttributeError:",
+        "    already_repring = {id(self),}",
+        "    _compat.repr_context.already_repring = already_repring",
+        "  else:",
+        "    if id(self) in already_repring:",
+        "      return '...'",
+        "    else:",
+        "      already_repring.add(id(self))",
+        "  try:",
+        "    return f'%s(%s)'" % (cls_name_fragment, repr_fragment),
+        "  finally:",
+        "    already_repring.remove(id(self))",
+    ]
 
-        # Figure out which attributes to include, and which function to use to
-        # format them. The a.repr value can be either bool or a custom
-        # callable.
-        attr_names_with_reprs = tuple(
-            (a.name, repr if a.repr is True else a.repr)
-            for a in attrs
-            if a.repr is not False
-        )
-
-        def __repr__(self):
-            """
-            Automatically created by attrs.
-            """
-            try:
-                already_repring = _compat.repr_context.already_repring
-            except AttributeError:
-                already_repring = set()
-                _compat.repr_context.already_repring = already_repring
-
-            if id(self) in already_repring:
-                return "..."
-            real_cls = self.__class__
-            if ns is None:
-                class_name = real_cls.__qualname__.rsplit(">.", 1)[-1]
-            else:
-                class_name = ns + "." + real_cls.__name__
-
-            # Since 'self' remains on the stack (i.e.: strongly referenced)
-            # for the duration of this call, it's safe to depend on id(...)
-            # stability, and not need to track the instance and therefore
-            # worry about properties like weakref- or hash-ability.
-            already_repring.add(id(self))
-            try:
-                result = [class_name, "("]
-                first = True
-                for name, attr_repr in attr_names_with_reprs:
-                    if first:
-                        first = False
-                    else:
-                        result.append(", ")
-                    result.extend(
-                        (name, "=", attr_repr(getattr(self, name, NOTHING)))
-                    )
-                return "".join(result) + ")"
-            finally:
-                already_repring.remove(id(self))
-
-        return __repr__
+    return _make_method(
+        "__repr__", "\n".join(lines), unique_filename, globs=globs
+    )
 
 
 def _add_repr(cls, ns=None, attrs=None):
@@ -1988,9 +1913,7 @@ def fields(cls):
         raise TypeError("Passed object must be a class.")
     attrs = getattr(cls, "__attrs_attrs__", None)
     if attrs is None:
-        raise NotAnAttrsClassError(
-            "{cls!r} is not an attrs-decorated class.".format(cls=cls)
-        )
+        raise NotAnAttrsClassError(f"{cls!r} is not an attrs-decorated class.")
     return attrs
 
 
@@ -2005,10 +1928,7 @@ def fields_dict(cls):
     :raise attr.exceptions.NotAnAttrsClassError: If *cls* is not an ``attrs``
         class.
 
-    :rtype: an ordered dict where keys are attribute names and values are
-        `attrs.Attribute`\\ s. This will be a `dict` if it's
-        naturally ordered like on Python 3.6+ or an
-        :class:`~collections.OrderedDict` otherwise.
+    :rtype: dict
 
     .. versionadded:: 18.1.0
     """
@@ -2016,10 +1936,8 @@ def fields_dict(cls):
         raise TypeError("Passed object must be a class.")
     attrs = getattr(cls, "__attrs_attrs__", None)
     if attrs is None:
-        raise NotAnAttrsClassError(
-            "{cls!r} is not an attrs-decorated class.".format(cls=cls)
-        )
-    return ordered_dict((a.name, a) for a in attrs)
+        raise NotAnAttrsClassError(f"{cls!r} is not an attrs-decorated class.")
+    return {a.name: a for a in attrs}
 
 
 def validate(inst):
@@ -2579,7 +2497,7 @@ class Attribute:
             type=type,
             cmp=None,
             inherited=False,
-            **inst_dict
+            **inst_dict,
         )
 
     # Don't use attr.evolve since fields(Attribute) doesn't work
@@ -2865,10 +2783,9 @@ def make_class(name, attrs, bases=(object,), **attributes_arguments):
     :param attrs: A list of names or a dictionary of mappings of names to
         attributes.
 
-        If *attrs* is a list or an ordered dict (`dict` on Python 3.6+,
-        `collections.OrderedDict` otherwise), the order is deduced from
-        the order of the names or attributes inside *attrs*.  Otherwise the
-        order of the definition of the attributes is used.
+        The order is deduced from the order of the names or attributes inside
+        *attrs*.  Otherwise the order of the definition of the attributes is
+        used.
     :type attrs: `list` or `dict`
 
     :param tuple bases: Classes that the new class will subclass.

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -411,13 +411,6 @@ def _get_annotations(cls):
     return {}
 
 
-def _counter_getter(e):
-    """
-    Key function for sorting to avoid re-creating a lambda for every class.
-    """
-    return e[1].counter
-
-
 def _collect_base_attrs(cls, taken_attr_names):
     """
     Collect attr.ibs from base classes of *cls*, except *taken_attr_names*.
@@ -495,9 +488,6 @@ def _transform_attrs(
 
     if these is not None:
         ca_list = [(name, ca) for name, ca in these.items()]
-
-        if not isinstance(these, dict):
-            ca_list.sort(key=_counter_getter)
     elif auto_attribs is True:
         ca_names = {
             name

--- a/src/attr/_next_gen.py
+++ b/src/attr/_next_gen.py
@@ -1,8 +1,8 @@
 # SPDX-License-Identifier: MIT
 
 """
-These are Python 3.6+-only and keyword-only APIs that call `attr.s` and
-`attr.ib` with different default values.
+These are keyword-only APIs that call `attr.s` and `attr.ib` with different
+default values.
 """
 
 

--- a/src/attr/converters.py
+++ b/src/attr/converters.py
@@ -141,4 +141,4 @@ def to_bool(val):
     except TypeError:
         # Raised when "val" is not hashable (e.g., lists)
         pass
-    raise ValueError("Cannot convert value to bool: {}".format(val))
+    raise ValueError(f"Cannot convert value to bool: {val}")

--- a/src/attr/validators.py
+++ b/src/attr/validators.py
@@ -391,7 +391,7 @@ class _DeepIterable:
         iterable_identifier = (
             ""
             if self.iterable_validator is None
-            else " {iterable!r}".format(iterable=self.iterable_validator)
+            else f" {self.iterable_validator!r}"
         )
         return (
             "<deep_iterable validator for{iterable_identifier}"
@@ -548,7 +548,7 @@ class _MaxLengthValidator:
             )
 
     def __repr__(self):
-        return "<max_len validator for {max}>".format(max=self.max_length)
+        return f"<max_len validator for {self.max_length}>"
 
 
 def max_len(length):
@@ -579,7 +579,7 @@ class _MinLengthValidator:
             )
 
     def __repr__(self):
-        return "<min_len validator for {min}>".format(min=self.min_length)
+        return f"<min_len validator for {self.min_length}>"
 
 
 def min_len(length):

--- a/tests/attr_import_star.py
+++ b/tests/attr_import_star.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 
-from attr import *  # noqa: F401,F403
+from attr import *  # noqa: F401, F403
 
 
 # This is imported by test_import::test_from_attr_import_star; this must

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -2,8 +2,6 @@
 
 """
 Tests for PEP-526 type annotations.
-
-Python 3.6+ only.
 """
 
 import sys
@@ -397,7 +395,7 @@ class TestAnnotations:
         """
         String annotations are passed into __init__ as is.
 
-        It fails on 3.6 due to a bug in Python.
+        The strings keep changing between releases.
         """
         import typing as t
 

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -15,7 +15,7 @@ from hypothesis import strategies as st
 import attr
 
 from attr import asdict, assoc, astuple, evolve, fields, has
-from attr._compat import Mapping, Sequence, ordered_dict
+from attr._compat import Mapping, Sequence
 from attr.exceptions import AttrsAttributeNotFoundError
 from attr.validators import instance_of
 
@@ -196,7 +196,7 @@ class TestAsDict:
         Field order should be preserved when dumping to an ordered_dict.
         """
         instance = cls()
-        dict_instance = asdict(instance, dict_factory=ordered_dict)
+        dict_instance = asdict(instance, dict_factory=dict)
 
         assert [a.name for a in fields(cls)] == list(dict_instance.keys())
 
@@ -483,9 +483,7 @@ class TestAssoc:
         ) as e, pytest.deprecated_call():
             assoc(C(), aaaa=2)
 
-        assert (
-            "aaaa is not an attrs attribute on {cls!r}.".format(cls=C),
-        ) == e.value.args
+        assert (f"aaaa is not an attrs attribute on {C!r}.",) == e.value.args
 
     def test_frozen(self):
         """

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -17,7 +17,6 @@ from hypothesis.strategies import booleans
 
 import attr
 
-from attr._compat import PY36
 from attr._make import NOTHING, Attribute
 from attr.exceptions import FrozenInstanceError
 
@@ -224,9 +223,9 @@ class TestFunctional:
         assert i.x is i.meth() is obj
         assert i.y == 2
         if cls is Sub:
-            assert "Sub(x={obj}, y=2)".format(obj=obj) == repr(i)
+            assert f"Sub(x={obj}, y=2)" == repr(i)
         else:
-            assert "SubSlots(x={obj}, y=2)".format(obj=obj) == repr(i)
+            assert f"SubSlots(x={obj}, y=2)" == repr(i)
 
     @pytest.mark.parametrize("base", [Base, BaseSlots])
     def test_subclass_without_extra_attrs(self, base):
@@ -241,7 +240,7 @@ class TestFunctional:
         obj = object()
         i = Sub2(x=obj)
         assert i.x is i.meth() is obj
-        assert "Sub2(x={obj})".format(obj=obj) == repr(i)
+        assert f"Sub2(x={obj})" == repr(i)
 
     @pytest.mark.parametrize(
         "frozen_class",
@@ -701,7 +700,6 @@ class TestFunctional:
         assert "self.y = y" in src
         assert object.__setattr__ == D.__setattr__
 
-    @pytest.mark.skipif(not PY36, reason="NG APIs are 3.6+")
     @pytest.mark.parametrize("slots", [True, False])
     def test_no_setattr_with_ng_defaults(self, slots):
         """

--- a/tests/test_init_subclass.py
+++ b/tests/test_init_subclass.py
@@ -2,8 +2,6 @@
 
 """
 Tests for `__init_subclass__` related tests.
-
-Python 3.6+ only.
 """
 
 import pytest

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -22,7 +22,7 @@ from hypothesis.strategies import booleans, integers, lists, sampled_from, text
 import attr
 
 from attr import _config
-from attr._compat import PY310, ordered_dict
+from attr._compat import PY310
 from attr._make import (
     Attribute,
     Factory,
@@ -297,7 +297,7 @@ class TestTransformAttrs:
         b = attr.ib(default=2)
         a = attr.ib(default=1)
 
-        @attr.s(these=ordered_dict([("a", a), ("b", b)]))
+        @attr.s(these=dict([("a", a), ("b", b)]))
         class C:
             pass
 
@@ -1071,7 +1071,7 @@ class TestMakeClass:
         b = attr.ib(default=2)
         a = attr.ib(default=1)
 
-        C = attr.make_class("C", ordered_dict([("a", a), ("b", b)]))
+        C = attr.make_class("C", dict([("a", a), ("b", b)]))
 
         assert "C(a=1, b=2)" == repr(C())
 
@@ -1114,7 +1114,7 @@ class TestFields:
             fields(object)
 
         assert (
-            "{o!r} is not an attrs-decorated class.".format(o=object)
+            f"{object!r} is not an attrs-decorated class."
         ) == e.value.args[0]
 
     @given(simple_classes())
@@ -1156,7 +1156,7 @@ class TestFieldsDict:
             fields_dict(object)
 
         assert (
-            "{o!r} is not an attrs-decorated class.".format(o=object)
+            f"{object!r} is not an attrs-decorated class."
         ) == e.value.args[0]
 
     @given(simple_classes())
@@ -1166,7 +1166,7 @@ class TestFieldsDict:
         """
         d = fields_dict(C)
 
-        assert isinstance(d, ordered_dict)
+        assert isinstance(d, dict)
         assert list(fields(C)) == list(d.values())
         assert [a.name for a in fields(C)] == [field_name for field_name in d]
 
@@ -1214,7 +1214,7 @@ class TestConverter:
         """
         C = make_class(
             "C",
-            ordered_dict(
+            dict(
                 [
                     ("y", attr.ib()),
                     (

--- a/tests/test_next_gen.py
+++ b/tests/test_next_gen.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 """
-Python 3-only integration tests for provisional next-generation APIs.
+Integration tests for next-generation APIs.
 """
 
 import re

--- a/tests/test_pyright.py
+++ b/tests/test_pyright.py
@@ -4,17 +4,13 @@ import json
 import os.path
 import shutil
 import subprocess
-import sys
 
 import pytest
 
 import attr
 
 
-if sys.version_info < (3, 6):
-    _found_pyright = False
-else:
-    _found_pyright = shutil.which("pyright")
+_found_pyright = shutil.which("pyright")
 
 
 @attr.s(frozen=True)

--- a/tox.ini
+++ b/tox.ini
@@ -44,11 +44,6 @@ extras = tests
 commands = coverage run -m pytest {posargs}
 
 
-[testenv:py37]
-extras = tests
-commands = coverage run -m pytest {posargs}
-
-
 [testenv:py310]
 # Python 3.6+ has a number of compile-time warnings on invalid string escapes.
 # PYTHONWARNINGS=d and --no-compile below make them visible during the Tox run.
@@ -62,7 +57,7 @@ commands = coverage run -m pytest {posargs}
 
 [testenv:coverage-report]
 basepython = python3.10
-depends = py37,py310
+depends = py36,py310
 skip_install = true
 deps = coverage[toml]>=5.4
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ filterwarnings =
 # Keep docs in sync with docs env and .readthedocs.yml.
 [gh-actions]
 python =
-    3.5: py35
     3.6: py36
     3.7: py37
     3.8: py38, changelog
@@ -21,7 +20,7 @@ python =
 
 
 [tox]
-envlist = typing,pre-commit,py35,py36,py37,py38,py39,py310,py311,pypy3,pyright,manifest,docs,pypi-description,changelog,coverage-report
+envlist = typing,pre-commit,py36,py37,py38,py39,py310,py311,pypy3,pyright,manifest,docs,pypi-description,changelog,coverage-report
 isolated_build = True
 
 
@@ -38,11 +37,6 @@ commands =
 [testenv]
 extras = tests
 commands = python -m pytest {posargs}
-
-
-[testenv:py35]
-extras = tests
-commands = coverage run -m pytest {posargs}
 
 
 [testenv:py37]
@@ -63,7 +57,7 @@ commands = coverage run -m pytest {posargs}
 
 [testenv:coverage-report]
 basepython = python3.10
-depends = py35,py37,py310
+depends = py37,py310
 skip_install = true
 deps = coverage[toml]>=5.4
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,11 @@ extras = tests
 commands = python -m pytest {posargs}
 
 
+[testenv:py36]
+extras = tests
+commands = coverage run -m pytest {posargs}
+
+
 [testenv:py37]
 extras = tests
 commands = coverage run -m pytest {posargs}


### PR DESCRIPTION
Less than 0.5% of our downloads are 3.5 and it allows us to simplify A LOT of code. Just look at all the beautiful (and fast) f-strings (they're courtesy of pyupgrade).

Fixes #965
