### PR TITLE
Fix type errors in Pyright

### DIFF
--- a/changelog.d/999.change.rst
+++ b/changelog.d/999.change.rst
@@ -1,0 +1,2 @@
+Made ``attrs.AttrsInstance`` stub available at runtime and fixed type errors
+related to the usage of ``attrs.AttrsInstance`` in Pyright.

--- a/src/attr/__init__.py
+++ b/src/attr/__init__.py
@@ -52,8 +52,14 @@ s = attributes = attrs
 ib = attr = attrib
 dataclass = partial(attrs, auto_attribs=True)  # happy Easter ;)
 
+
+class AttrsInstance:
+    pass
+
+
 __all__ = [
     "Attribute",
+    "AttrsInstance",
     "Factory",
     "NOTHING",
     "asdict",

--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -24,8 +24,8 @@ from . import filters as filters
 from . import setters as setters
 from . import validators as validators
 from ._cmp import cmp_using as cmp_using
-from ._version_info import VersionInfo
 from ._typing_compat import AttrsInstance_
+from ._version_info import VersionInfo
 
 if sys.version_info >= (3, 10):
     from typing import TypeGuard

--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -3,13 +3,11 @@ import sys
 from typing import (
     Any,
     Callable,
-    ClassVar,
     Dict,
     Generic,
     List,
     Mapping,
     Optional,
-    Protocol,
     Sequence,
     Tuple,
     Type,
@@ -26,6 +24,7 @@ from . import setters as setters
 from . import validators as validators
 from ._cmp import cmp_using as cmp_using
 from ._version_info import VersionInfo
+from ._typing_compat import AttrsInstance_ as AttrsInstance
 
 __version__: str
 __version_info__: VersionInfo
@@ -58,10 +57,6 @@ _FieldTransformer = Callable[
 # or tuple, but those are invariant and so would prevent subtypes of
 # _ValidatorType from working when passed in a list or tuple.
 _ValidatorArgType = Union[_ValidatorType[_T], Sequence[_ValidatorType[_T]]]
-
-# A protocol to be able to statically accept an attrs class.
-class AttrsInstance(Protocol):
-    __attrs_attrs__: ClassVar[Any]
 
 # _make --
 

--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -8,6 +8,7 @@ from typing import (
     List,
     Mapping,
     Optional,
+    Protocol,
     Sequence,
     Tuple,
     Type,
@@ -25,8 +26,6 @@ from . import validators as validators
 from ._cmp import cmp_using as cmp_using
 from ._version_info import VersionInfo
 from ._typing_compat import AttrsInstance_
-
-AttrsInstance = AttrsInstance_
 
 if sys.version_info >= (3, 10):
     from typing import TypeGuard
@@ -64,6 +63,10 @@ _FieldTransformer = Callable[
 # or tuple, but those are invariant and so would prevent subtypes of
 # _ValidatorType from working when passed in a list or tuple.
 _ValidatorArgType = Union[_ValidatorType[_T], Sequence[_ValidatorType[_T]]]
+
+# We subclass this here to keep the protocol's qualified name clean.
+class AttrsInstance(AttrsInstance_, Protocol):
+    pass
 
 # _make --
 

--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -24,7 +24,9 @@ from . import setters as setters
 from . import validators as validators
 from ._cmp import cmp_using as cmp_using
 from ._version_info import VersionInfo
-from ._typing_compat import AttrsInstance_ as AttrsInstance
+from ._typing_compat import AttrsInstance_
+
+AttrsInstance = AttrsInstance_
 
 __version__: str
 __version_info__: VersionInfo

--- a/src/attr/_typing_compat.pyi
+++ b/src/attr/_typing_compat.pyi
@@ -1,0 +1,12 @@
+from typing import Any, ClassVar, Protocol
+
+MYPY = False
+
+# A protocol to be able to statically accept an attrs class.
+class AttrsInstance(Protocol):
+    __attrs_attrs__: ClassVar[Any]
+
+if MYPY:
+    AttrsInstance_ = AttrsInstance
+else:
+    AttrsInstance_ = Any

--- a/src/attr/_typing_compat.pyi
+++ b/src/attr/_typing_compat.pyi
@@ -1,5 +1,6 @@
 from typing import Any, ClassVar, Protocol
 
+# MYPY is a special constant in mypy which works the same way as `TYPE_CHECKING`.
 MYPY = False
 
 if MYPY:
@@ -8,5 +9,7 @@ if MYPY:
         __attrs_attrs__: ClassVar[Any]
 
 else:
+    # For type checkers without plug-in support use an empty protocol that
+    # will (hopefully) be combined into a union.
     class AttrsInstance_(Protocol):
         pass

--- a/src/attr/_typing_compat.pyi
+++ b/src/attr/_typing_compat.pyi
@@ -2,11 +2,11 @@ from typing import Any, ClassVar, Protocol
 
 MYPY = False
 
-# A protocol to be able to statically accept an attrs class.
-class AttrsInstance(Protocol):
-    __attrs_attrs__: ClassVar[Any]
-
 if MYPY:
-    AttrsInstance_ = AttrsInstance
+    # A protocol to be able to statically accept an attrs class.
+    class AttrsInstance_(Protocol):
+        __attrs_attrs__: ClassVar[Any]
+
 else:
-    AttrsInstance_ = Any
+    class AttrsInstance_(Protocol):
+        pass

--- a/src/attrs/__init__.py
+++ b/src/attrs/__init__.py
@@ -3,6 +3,7 @@
 from attr import (
     NOTHING,
     Attribute,
+    AttrsInstance,
     Factory,
     __author__,
     __copyright__,

--- a/src/attrs/__init__.py
+++ b/src/attrs/__init__.py
@@ -49,6 +49,7 @@ __all__ = [
     "assoc",
     "astuple",
     "Attribute",
+    "AttrsInstance",
     "cmp_using",
     "converters",
     "define",

--- a/tests/test_pyright.py
+++ b/tests/test_pyright.py
@@ -91,6 +91,7 @@ def test_pyright_attrsinstance_is_any(tmp_path):
         """\
 import attrs
 
+foo: attrs.AttrsInstance = object()  # We can assign any old object to `AttrsInstance`.
 reveal_type(attrs.AttrsInstance)
 """
     )
@@ -99,7 +100,7 @@ reveal_type(attrs.AttrsInstance)
     expected_diagnostics = {
         PyrightDiagnostic(
             severity="information",
-            message='Type of "attrs.AttrsInstance" is "Any"',
+            message='Type of "attrs.AttrsInstance" is "Type[AttrsInstance]"',
         ),
     }
     assert diagnostics == expected_diagnostics

--- a/tests/test_pyright.py
+++ b/tests/test_pyright.py
@@ -91,7 +91,9 @@ def test_pyright_attrsinstance_compat(tmp_path):
         """\
 import attrs
 
-foo: attrs.AttrsInstance = object()  # We can assign any old object to `AttrsInstance`.
+# We can assign any old object to `AttrsInstance`.
+foo: attrs.AttrsInstance = object()
+
 reveal_type(attrs.AttrsInstance)
 """
     )

--- a/tests/test_pyright.py
+++ b/tests/test_pyright.py
@@ -80,14 +80,14 @@ def test_pyright_baseline():
     assert diagnostics == expected_diagnostics
 
 
-def test_pyright_attrsinstance_is_any(tmp_path):
+def test_pyright_attrsinstance_compat(tmp_path):
     """
-    Test that `AttrsInstance` is `Any` under Pyright.
+    Test that `AttrsInstance` is compatible with Pyright.
     """
-    test_pyright_attrsinstance_is_any_path = (
-        tmp_path / "test_pyright_attrsinstance_is_any.py"
+    test_pyright_attrsinstance_compat_path = (
+        tmp_path / "test_pyright_attrsinstance_compat.py"
     )
-    test_pyright_attrsinstance_is_any_path.write_text(
+    test_pyright_attrsinstance_compat_path.write_text(
         """\
 import attrs
 
@@ -96,7 +96,7 @@ reveal_type(attrs.AttrsInstance)
 """
     )
 
-    diagnostics = parse_pyright_output(test_pyright_attrsinstance_is_any_path)
+    diagnostics = parse_pyright_output(test_pyright_attrsinstance_compat_path)
     expected_diagnostics = {
         PyrightDiagnostic(
             severity="information",

--- a/tox.ini
+++ b/tox.ini
@@ -93,7 +93,7 @@ commands = towncrier build --version UNRELEASED --draft
 basepython = python3.10
 deps = mypy>=0.902
 commands =
-    mypy src/attrs/__init__.pyi src/attr/__init__.pyi src/attr/_version_info.pyi src/attr/converters.pyi src/attr/exceptions.pyi src/attr/filters.pyi src/attr/setters.pyi src/attr/validators.pyi
+    mypy src/attrs/__init__.pyi src/attr/__init__.pyi src/attr/_typing_compat.pyi src/attr/_version_info.pyi src/attr/converters.pyi src/attr/exceptions.pyi src/attr/filters.pyi src/attr/setters.pyi src/attr/validators.pyi
     mypy tests/typing_example.py
 
 


### PR DESCRIPTION
# Summary

<!-- Please tell us what your pull request is about here. -->
MyPy treats the user-declared `MYPY` constant equivalently
to `typing.TYPE_CHECKING` (see https://mypy.readthedocs.io/en/stable/more_types.html#conditional-overloads).
This can be used to trick other type checkers into ignoring
MyPy-specific types.

`AttrsInstance` needs to be declared in a separate stub file so as to
not export `MYPY`.

# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/python-attrs/attrs/blob/main/.github/CONTRIBUTING.md) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.
-->

- [x] Added **tests** for changed code.
  Our CI fails if coverage is not 100%.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [ ] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [ ] ...and used in the stub test file `tests/typing_example.py`.
    - [ ] If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          Find the appropriate next version in our [``__init__.py``](https://github.com/python-attrs/attrs/blob/main/src/attr/__init__.py) file.
- [ ] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
