### PR TITLE
Call abc.update_abstractmethods on 3.10+

### DIFF
--- a/changelog.d/1001.change.rst
+++ b/changelog.d/1001.change.rst
@@ -1,0 +1,3 @@
+On Python 3.10 and later, call `abc.update_abstractmethods() <https://docs.pytho.
+org/3.10/library/abc.html#abc.update_abstractmethods>`_ on dict classes after creation.
+This improves the detection of abstractness.

--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,15 @@
 # SPDX-License-Identifier: MIT
 
+import pytest
+
 from hypothesis import HealthCheck, settings
 
 from attr._compat import PY310
+
+
+@pytest.fixture(name="slots", params=(True, False))
+def slots(request):
+    return request.param
 
 
 def pytest_configure(config):

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: MIT
 
+import abc
 import copy
 import linecache
 import sys
@@ -717,15 +718,30 @@ class _ClassBuilder:
     def __repr__(self):
         return f"<_ClassBuilder(cls={self._cls.__name__})>"
 
-    def build_class(self):
-        """
-        Finalize class based on the accumulated configuration.
+    if PY310:
 
-        Builder cannot be used after calling this method.
-        """
-        if self._slots is True:
-            return self._create_slots_class()
-        else:
+        def build_class(self):
+            """
+            Finalize class based on the accumulated configuration.
+
+            Builder cannot be used after calling this method.
+            """
+            if self._slots is True:
+                return self._create_slots_class()
+
+            return abc.update_abstractmethods(self._patch_original_class())
+
+    else:
+
+        def build_class(self):
+            """
+            Finalize class based on the accumulated configuration.
+
+            Builder cannot be used after calling this method.
+            """
+            if self._slots is True:
+                return self._create_slots_class()
+
             return self._patch_original_class()
 
     def _patch_original_class(self):

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 
-import abc
 import copy
 import linecache
 import sys
@@ -719,6 +718,7 @@ class _ClassBuilder:
         return f"<_ClassBuilder(cls={self._cls.__name__})>"
 
     if PY310:
+        import abc
 
         def build_class(self):
             """
@@ -729,7 +729,9 @@ class _ClassBuilder:
             if self._slots is True:
                 return self._create_slots_class()
 
-            return abc.update_abstractmethods(self._patch_original_class())
+            return self.abc.update_abstractmethods(
+                self._patch_original_class()
+            )
 
     else:
 

--- a/tests/test_abc.py
+++ b/tests/test_abc.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: MIT
+
+import abc
+import inspect
+
+import pytest
+
+import attrs
+
+from attr._compat import PY310
+
+
+@pytest.mark.skipif(not PY310, reason="abc.update_abstractmethods is 3.10+")
+class TestUpdateAbstractMethods:
+    def test_abc_implementation(self, slots):
+        """
+        If an attrs class implements an abstract method, it stops being
+        abstract.
+        """
+
+        class Ordered(abc.ABC):
+            @abc.abstractmethod
+            def __lt__(self, other):
+                pass
+
+            @abc.abstractmethod
+            def __le__(self, other):
+                pass
+
+        @attrs.define(order=True, slots=slots)
+        class Concrete(Ordered):
+            x: int
+
+        assert not inspect.isabstract(Concrete)
+        assert Concrete(2) > Concrete(1)
+
+    def test_remain_abstract(self, slots):
+        """
+        If an attrs class inherits from an abstract class but doesn't implement
+        abstract methods, it remains abstract.
+        """
+
+        class A(abc.ABC):
+            @abc.abstractmethod
+            def foo(self):
+                pass
+
+        @attrs.define(slots=slots)
+        class StillAbstract(A):
+            pass
+
+        assert inspect.isabstract(StillAbstract)
+        with pytest.raises(
+            TypeError, match="class StillAbstract with abstract method foo"
+        ):
+            StillAbstract()


### PR DESCRIPTION
I've found this feature while researching #1000.

Unfortunately it didn't fix that particular problem, but it still seems useful.