### PR TITLE
Replace omnipresent pytest.mark.parametrize("(slots|frozen)" w/ fixture

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,20 @@
 # SPDX-License-Identifier: MIT
 
+import pytest
+
 from hypothesis import HealthCheck, settings
 
 from attr._compat import PY310
+
+
+@pytest.fixture(name="slots", params=(True, False))
+def _slots(request):
+    return request.param
+
+
+@pytest.fixture(name="frozen", params=(True, False))
+def _frozen(request):
+    return request.param
 
 
 def pytest_configure(config):

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -96,7 +96,6 @@ class TestAnnotations:
         sys.version_info[:2] < (3, 11),
         reason="Incompatible behavior on older Pythons",
     )
-    @pytest.mark.parametrize("slots", [True, False])
     def test_auto_attribs(self, slots):
         """
         If *auto_attribs* is True, bare annotations are collected too.
@@ -154,7 +153,6 @@ class TestAnnotations:
             foo=typing.Any,
         )
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_auto_attribs_unannotated(self, slots):
         """
         Unannotated `attr.ib`s raise an error.
@@ -172,7 +170,6 @@ class TestAnnotations:
             "The following `attr.ib`s lack a type annotation: v, y.",
         ) == e.value.args
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_auto_attribs_subclassing(self, slots):
         """
         Attributes from base classes are inherited, it doesn't matter if the
@@ -390,7 +387,6 @@ class TestAnnotations:
         sys.version_info[:2] < (3, 11),
         reason="Incompatible behavior on older Pythons",
     )
-    @pytest.mark.parametrize("slots", [True, False])
     def test_annotations_strings(self, slots):
         """
         String annotations are passed into __init__ as is.
@@ -423,7 +419,6 @@ class TestAnnotations:
             foo=typing.Any,
         )
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_typing_extensions_classvar(self, slots):
         """
         If ClassVar is coming from typing_extensions, it is recognized too.
@@ -521,7 +516,6 @@ class TestAnnotations:
         assert str is attr.fields(C).y.type
         assert None is attr.fields(C).z.type
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_resolve_types_auto_attrib(self, slots):
         """
         Types can be resolved even when strings are involved.
@@ -541,7 +535,6 @@ class TestAnnotations:
         assert typing.List[int] == attr.fields(A).b.type
         assert typing.List[int] == attr.fields(A).c.type
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_resolve_types_decorator(self, slots):
         """
         Types can be resolved using it as a decorator.
@@ -558,7 +551,6 @@ class TestAnnotations:
         assert typing.List[int] == attr.fields(A).b.type
         assert typing.List[int] == attr.fields(A).c.type
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_self_reference(self, slots):
         """
         References to self class using quotes can be resolved.
@@ -574,7 +566,6 @@ class TestAnnotations:
         assert A == attr.fields(A).a.type
         assert typing.Optional[A] == attr.fields(A).b.type
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_forward_reference(self, slots):
         """
         Forward references can be resolved.

--- a/tests/test_dunders.py
+++ b/tests/test_dunders.py
@@ -320,7 +320,6 @@ class TestAddRepr:
     Tests for `_add_repr`.
     """
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_repr(self, slots):
         """
         If `repr` is False, ignore that attribute.
@@ -646,8 +645,6 @@ class TestAddHash:
         assert 1 == cached_instance.hash_counter.times_hash_called
 
     @pytest.mark.parametrize("cache_hash", [True, False])
-    @pytest.mark.parametrize("frozen", [True, False])
-    @pytest.mark.parametrize("slots", [True, False])
     def test_copy_hash_cleared(self, cache_hash, frozen, slots):
         """
         Test that the default hash is recalculated after a copy operation.
@@ -701,7 +698,6 @@ class TestAddHash:
 
         assert original_hash != hash(obj_rt)
 
-    @pytest.mark.parametrize("frozen", [True, False])
     def test_copy_two_arg_reduce(self, frozen):
         """
         If __getstate__ returns None, the tuple returned by object.__reduce__

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -353,8 +353,6 @@ class TestFunctional:
 
         assert C(1, 2) == C()
 
-    @pytest.mark.parametrize("slots", [True, False])
-    @pytest.mark.parametrize("frozen", [True, False])
     @pytest.mark.parametrize("weakref_slot", [True, False])
     def test_attrib_overwrite(self, slots, frozen, weakref_slot):
         """
@@ -423,7 +421,6 @@ class TestFunctional:
         class D(C):
             pass
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_hash_false_eq_false(self, slots):
         """
         hash=False and eq=False make a class hashable by ID.
@@ -435,7 +432,6 @@ class TestFunctional:
 
         assert hash(C()) != hash(C())
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_eq_false(self, slots):
         """
         eq=False makes a class hashable by ID.
@@ -543,8 +539,6 @@ class TestFunctional:
         assert "itemgetter" == attr.fields(C).itemgetter.name
         assert "x" == attr.fields(C).x.name
 
-    @pytest.mark.parametrize("slots", [True, False])
-    @pytest.mark.parametrize("frozen", [True, False])
     def test_auto_exc(self, slots, frozen):
         """
         Classes with auto_exc=True have a Exception-style __str__, compare and
@@ -599,8 +593,6 @@ class TestFunctional:
                 deepcopy(e1)
                 deepcopy(e2)
 
-    @pytest.mark.parametrize("slots", [True, False])
-    @pytest.mark.parametrize("frozen", [True, False])
     def test_auto_exc_one_attrib(self, slots, frozen):
         """
         Having one attribute works with auto_exc=True.
@@ -614,8 +606,6 @@ class TestFunctional:
 
         FooError(1)
 
-    @pytest.mark.parametrize("slots", [True, False])
-    @pytest.mark.parametrize("frozen", [True, False])
     def test_eq_only(self, slots, frozen):
         """
         Classes with order=False cannot be ordered.
@@ -639,7 +629,6 @@ class TestFunctional:
 
         assert ei.value.args[0] in possible_errors
 
-    @pytest.mark.parametrize("slots", [True, False])
     @pytest.mark.parametrize("cmp", [True, False])
     def test_attrib_cmp_shortcut(self, slots, cmp):
         """
@@ -653,7 +642,6 @@ class TestFunctional:
         assert cmp is attr.fields(C).x.eq
         assert cmp is attr.fields(C).x.order
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_no_setattr_if_validate_without_validators(self, slots):
         """
         If a class has on_setattr=attr.setters.validate (former default in NG
@@ -663,11 +651,11 @@ class TestFunctional:
         Regression test for #816.
         """
 
-        @attr.s(on_setattr=attr.setters.validate)
+        @attr.s(on_setattr=attr.setters.validate, slots=slots)
         class C:
             x = attr.ib()
 
-        @attr.s(on_setattr=attr.setters.validate)
+        @attr.s(on_setattr=attr.setters.validate, slots=slots)
         class D(C):
             y = attr.ib()
 
@@ -678,18 +666,17 @@ class TestFunctional:
         assert "self.y = y" in src
         assert object.__setattr__ == D.__setattr__
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_no_setattr_if_convert_without_converters(self, slots):
         """
         If a class has on_setattr=attr.setters.convert but sets no validators,
         don't use the (slower) setattr in __init__.
         """
 
-        @attr.s(on_setattr=attr.setters.convert)
+        @attr.s(on_setattr=attr.setters.convert, slots=slots)
         class C:
             x = attr.ib()
 
-        @attr.s(on_setattr=attr.setters.convert)
+        @attr.s(on_setattr=attr.setters.convert, slots=slots)
         class D(C):
             y = attr.ib()
 
@@ -700,7 +687,6 @@ class TestFunctional:
         assert "self.y = y" in src
         assert object.__setattr__ == D.__setattr__
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_no_setattr_with_ng_defaults(self, slots):
         """
         If a class has the NG default on_setattr=[convert, validate] but sets
@@ -708,7 +694,7 @@ class TestFunctional:
         __init__.
         """
 
-        @attr.define
+        @attr.define(slots=slots)
         class C:
             x = attr.ib()
 
@@ -718,7 +704,7 @@ class TestFunctional:
         assert "self.x = x" in src
         assert object.__setattr__ == C.__setattr__
 
-        @attr.define
+        @attr.define(slots=slots)
         class D(C):
             y = attr.ib()
 

--- a/tests/test_init_subclass.py
+++ b/tests/test_init_subclass.py
@@ -4,12 +4,9 @@
 Tests for `__init_subclass__` related tests.
 """
 
-import pytest
-
 import attr
 
 
-@pytest.mark.parametrize("slots", [True, False])
 def test_init_subclass_vanilla(slots):
     """
     `super().__init_subclass__` can be used if the subclass is not an attrs

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -683,7 +683,6 @@ class TestAttributes:
         assert str is fields(C).y.type
         assert None is fields(C).z.type
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_clean_class(self, slots):
         """
         Attribute definitions do not appear on the class body after @attr.s.
@@ -1043,7 +1042,6 @@ class TestMakeClass:
         assert D in cls.__mro__
         assert isinstance(cls(), D)
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_clean_class(self, slots):
         """
         Attribute definitions do not appear on the class body.
@@ -1941,8 +1939,6 @@ class TestAutoDetect:
             C, None, True, ("__le__", "__lt__", "__ge__", "__gt__")
         )
 
-    @pytest.mark.parametrize("slots", [True, False])
-    @pytest.mark.parametrize("frozen", [True, False])
     def test_make_all_by_default(self, slots, frozen):
         """
         If nothing is there to be detected, imply init=True, repr=True,
@@ -1965,8 +1961,6 @@ class TestAutoDetect:
         assert i.__ge__ is not o.__ge__
         assert i.__gt__ is not o.__gt__
 
-    @pytest.mark.parametrize("slots", [True, False])
-    @pytest.mark.parametrize("frozen", [True, False])
     def test_detect_auto_init(self, slots, frozen):
         """
         If auto_detect=True and an __init__ exists, don't write one.
@@ -1981,8 +1975,6 @@ class TestAutoDetect:
 
         assert 42 == CI().x
 
-    @pytest.mark.parametrize("slots", [True, False])
-    @pytest.mark.parametrize("frozen", [True, False])
     def test_detect_auto_repr(self, slots, frozen):
         """
         If auto_detect=True and an __repr__ exists, don't write one.
@@ -1997,8 +1989,6 @@ class TestAutoDetect:
 
         assert "hi" == repr(C(42))
 
-    @pytest.mark.parametrize("slots", [True, False])
-    @pytest.mark.parametrize("frozen", [True, False])
     def test_hash_uses_eq(self, slots, frozen):
         """
         If eq is passed in, then __hash__ should use the eq callable
@@ -2018,8 +2008,6 @@ class TestAutoDetect:
         assert hash(C("1")) == hash(C(1))
         assert hash(D("1")) != hash(D(1))
 
-    @pytest.mark.parametrize("slots", [True, False])
-    @pytest.mark.parametrize("frozen", [True, False])
     def test_detect_auto_hash(self, slots, frozen):
         """
         If auto_detect=True and an __hash__ exists, don't write one.
@@ -2034,8 +2022,6 @@ class TestAutoDetect:
 
         assert 0xC0FFEE == hash(C(42))
 
-    @pytest.mark.parametrize("slots", [True, False])
-    @pytest.mark.parametrize("frozen", [True, False])
     def test_detect_auto_eq(self, slots, frozen):
         """
         If auto_detect=True and an __eq__ or an __ne__, exist, don't write one.
@@ -2061,8 +2047,6 @@ class TestAutoDetect:
         with pytest.raises(ValueError, match="worked"):
             D(1) != D(1)
 
-    @pytest.mark.parametrize("slots", [True, False])
-    @pytest.mark.parametrize("frozen", [True, False])
     def test_detect_auto_order(self, slots, frozen):
         """
         If auto_detect=True and an __ge__, __gt__, __le__, or and __lt__ exist,
@@ -2108,8 +2092,6 @@ class TestAutoDetect:
         assert_none_set(GE, "__ge__")
         assert_none_set(GT, "__gt__")
 
-    @pytest.mark.parametrize("slots", [True, False])
-    @pytest.mark.parametrize("frozen", [True, False])
     def test_override_init(self, slots, frozen):
         """
         If init=True is passed, ignore __init__.
@@ -2124,8 +2106,6 @@ class TestAutoDetect:
 
         assert C(1) == C(1)
 
-    @pytest.mark.parametrize("slots", [True, False])
-    @pytest.mark.parametrize("frozen", [True, False])
     def test_override_repr(self, slots, frozen):
         """
         If repr=True is passed, ignore __repr__.
@@ -2140,8 +2120,6 @@ class TestAutoDetect:
 
         assert "C(x=1)" == repr(C(1))
 
-    @pytest.mark.parametrize("slots", [True, False])
-    @pytest.mark.parametrize("frozen", [True, False])
     def test_override_hash(self, slots, frozen):
         """
         If hash=True is passed, ignore __hash__.
@@ -2156,8 +2134,6 @@ class TestAutoDetect:
 
         assert hash(C(1))
 
-    @pytest.mark.parametrize("slots", [True, False])
-    @pytest.mark.parametrize("frozen", [True, False])
     def test_override_eq(self, slots, frozen):
         """
         If eq=True is passed, ignore __eq__ and __ne__.
@@ -2175,8 +2151,6 @@ class TestAutoDetect:
 
         assert C(1) == C(1)
 
-    @pytest.mark.parametrize("slots", [True, False])
-    @pytest.mark.parametrize("frozen", [True, False])
     @pytest.mark.parametrize(
         "eq,order,cmp",
         [
@@ -2213,7 +2187,6 @@ class TestAutoDetect:
         assert C(2) > C(1)
         assert C(2) >= C(1)
 
-    @pytest.mark.parametrize("slots", [True, False])
     @pytest.mark.parametrize("first", [True, False])
     def test_total_ordering(self, slots, first):
         """
@@ -2262,7 +2235,6 @@ class TestAutoDetect:
 
         assert c1.own_eq_called
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_detects_setstate_getstate(self, slots):
         """
         __getstate__ and __setstate__ are not overwritten if either is present.

--- a/tests/test_setattr.py
+++ b/tests/test_setattr.py
@@ -203,7 +203,6 @@ class TestSetAttr:
 
         assert "Frozen classes can't use on_setattr." == ei.value.args[0]
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_setattr_reset_if_no_custom_setattr(self, slots):
         """
         If a class with an active setattr is subclassed and no new setattr
@@ -229,7 +228,6 @@ class TestSetAttr:
         assert not NoHook.__attrs_own_setattr__
         assert WithOnSetAttrHook.__attrs_own_setattr__
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_setattr_inherited_do_not_reset(self, slots):
         """
         If we inherit a __setattr__ that has been written by the user, we must
@@ -257,7 +255,6 @@ class TestSetAttr:
 
         assert C.__setattr__ == A.__setattr__
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_pickling_retains_attrs_own(self, slots):
         """
         Pickling/Unpickling does not lose ownership information about
@@ -314,7 +311,6 @@ class TestSetAttr:
 
         C(1).x = 2
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_setattr_auto_detect_if_no_custom_setattr(self, slots):
         """
         It's possible to remove the on_setattr hook from an attribute and
@@ -334,7 +330,6 @@ class TestSetAttr:
         assert not RemoveNeedForOurSetAttr.__attrs_own_setattr__
         assert 2 == i.x
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_setattr_restore_respects_auto_detect(self, slots):
         """
         If __setattr__ should be restored but the user supplied its own and
@@ -348,7 +343,6 @@ class TestSetAttr:
 
         assert CustomSetAttr.__setattr__ != object.__setattr__
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_setattr_auto_detect_frozen(self, slots):
         """
         frozen=True together with a detected custom __setattr__ are rejected.
@@ -362,7 +356,6 @@ class TestSetAttr:
                 def __setattr__(self, _, __):
                     pass
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_setattr_auto_detect_on_setattr(self, slots):
         """
         on_setattr attributes together with a detected custom __setattr__ are

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -452,7 +452,6 @@ class TestClosureCellRewriting:
         assert non_slot_instance.my_subclass() is C2
         assert slot_instance.my_subclass() is C2Slots
 
-    @pytest.mark.parametrize("slots", [True, False])
     def test_cls_static(self, slots):
         """
         Slotted classes support proper closure cell rewriting for class- and


### PR DESCRIPTION
Actually use it a few times while at it.