### PR TITLE
Use pytest-xdist in tox / CI

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -72,7 +72,10 @@ At this point,
 $ python -m pytest
 ```
 
-should work and pass, as should:
+should work and pass.
+You can *significantly* speed up the test suite by passing `-n auto` to *pytest* which activates [*pytest-xdist*](https://github.com/pytest-dev/pytest-xdist) and takes advantage of all your CPU cores.
+
+Documentation should also build:
 
 ```console
 $ cd docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Make coverage unique if it exists.
         run: |
           if [ -f .coverage ]; then
-            mv .coverage .coverage.$(uuidgen)
+            mv .coverage .coverage.${{ strategy.job-index }}
           fi
 
       - name: Upload coverage data

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,8 @@ jobs:
 
       - run: python -m tox
 
+      - run: ls -al
+
       - name: Upload coverage data
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,14 +49,6 @@ jobs:
 
       - run: python -m tox
 
-      # pytest-cov automatically merges coverage into `.coverage`, so we have to
-      # make it unique before uploading.
-      - name: Make coverage unique if it exists.
-        run: |
-          if [ -f .coverage ]; then
-            mv .coverage .coverage.${{ strategy.job-index }}
-          fi
-
       - name: Upload coverage data
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,12 +51,22 @@ jobs:
 
       - run: ls -al
 
+      - name: Make coverage unique if it exists.
+        run: |
+          COVERAGE_UUID=$(python3 -c "import uuid; print(uuid.uuid4())")
+          echo "::set-output name=COVERAGE_UUID::${COVERAGE_UUID}"
+          if [ -f .coverage ]; then
+            mv .coverage .coverage.${COVERAGE_UUID}
+          fi
+
       - name: Upload coverage data
         uses: actions/upload-artifact@v3
         with:
           name: coverage-data
           path: .coverage.*
           if-no-files-found: ignore
+
+      - run: ls -al
 
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,14 +49,12 @@ jobs:
 
       - run: python -m tox
 
-      - run: ls -al
-
+      # pytest-cov automatically merges coverage into `.coverage`, so we have to
+      # make it unique before uploading.
       - name: Make coverage unique if it exists.
         run: |
-          COVERAGE_UUID=$(python3 -c "import uuid; print(uuid.uuid4())")
-          echo "::set-output name=COVERAGE_UUID::${COVERAGE_UUID}"
           if [ -f .coverage ]; then
-            mv .coverage .coverage.${COVERAGE_UUID}
+            mv .coverage .coverage.$(uuidgen)
           fi
 
       - name: Upload coverage data
@@ -65,8 +63,6 @@ jobs:
           name: coverage-data
           path: .coverage.*
           if-no-files-found: ignore
-
-      - run: ls -al
 
   coverage:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ filterwarnings = ["once::Warning", "ignore:::pympler[.*]"]
 
 [tool.coverage.run]
 parallel = true
-concurrency = ["multiprocessing"]
 branch = true
 source_pkgs = ["attr", "attrs"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ filterwarnings = ["once::Warning", "ignore:::pympler[.*]"]
 
 [tool.coverage.run]
 parallel = true
+concurrency = "multiprocessing"
 branch = true
 source = ["attr", "attrs"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ xfail_strict = true
 testpaths = "tests"
 filterwarnings = ["once::Warning", "ignore:::pympler[.*]"]
 
+
 [tool.coverage.run]
 parallel = true
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ filterwarnings = ["once::Warning", "ignore:::pympler[.*]"]
 parallel = true
 concurrency = ["multiprocessing"]
 branch = true
-source = ["attr", "attrs"]
+source_pkgs = ["attr", "attrs"]
 
 [tool.coverage.paths]
 source = ["src", ".tox/*/site-packages"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ branch = true
 source_pkgs = ["attr", "attrs"]
 
 [tool.coverage.paths]
-source = ["sre", ". tox/*/site-packages"]
+source = ["src", ".tox/*/site-packages"]
 
 [tool.coverage.report]
 show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,13 @@ xfail_strict = true
 testpaths = "tests"
 filterwarnings = ["once::Warning", "ignore:::pympler[.*]"]
 
+[tool.coverage.run]
+parallel = true
+branch = true
+source_pkgs = ["attr", "attrs"]
+
+[tool.coverage.paths]
+source = ["sre", ". tox/*/site-packages"]
 
 [tool.coverage.report]
 show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,14 +12,6 @@ testpaths = "tests"
 filterwarnings = ["once::Warning", "ignore:::pympler[.*]"]
 
 
-[tool.coverage.run]
-parallel = true
-branch = true
-source_pkgs = ["attr", "attrs"]
-
-[tool.coverage.paths]
-source = ["src", ".tox/*/site-packages"]
-
 [tool.coverage.report]
 show_missing = true
 skip_covered = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ filterwarnings = ["once::Warning", "ignore:::pympler[.*]"]
 
 [tool.coverage.run]
 parallel = true
-concurrency = "multiprocessing"
+concurrency = ["multiprocessing"]
 branch = true
 source = ["attr", "attrs"]
 

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,6 @@ EXTRAS_REQUIRE = {
         "pytest>=4.3.0",
         # psutil extra is needed for correct core count detection.
         "pytest-xdist[psutil]",
-        # pytest-xdist breaks classic coverage.
-        "pytest-cov",
         # Since the mypy error messages keep changing, we have to keep updating
         # this pin.
         "mypy>=0.971; python_implementation == 'CPython'",
@@ -63,6 +61,13 @@ EXTRAS_REQUIRE = {
     "tests": [
         "attrs[tests-no-zope]",
         "zope.interface",
+    ],
+    "cov": [
+        "attrs[tests]",
+        # pytest-xdist breaks classic coverage.
+        "pytest-cov",
+        # Ensure coverage is new enough for `source_pkgs`.
+        "coverage>=5.3",
     ],
     "dev": ["attrs[tests,docs]"],
 }

--- a/setup.py
+++ b/setup.py
@@ -64,10 +64,9 @@ EXTRAS_REQUIRE = {
     ],
     "cov": [
         "attrs[tests]",
-        # pytest-xdist breaks classic coverage.
-        "pytest-cov",
+        "coverage-enable-subprocess",
         # Ensure coverage is new enough for `source_pkgs`.
-        "coverage>=5.3",
+        "coverage[toml]>=5.3",
     ],
     "dev": ["attrs[tests,docs]"],
 }

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,8 @@ EXTRAS_REQUIRE = {
         "attrs[tests]",
         # pytest-xdist breaks classic coverage.
         "pytest-cov",
+        # Ensure coverage is new enough for `source_pkgs`.
+        "coverage>=5.3",
     ],
     "dev": ["attrs[tests,docs]"],
 }

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,8 @@ EXTRAS_REQUIRE = {
         "pytest>=4.3.0",
         # psutil extra is needed for correct core count detection.
         "pytest-xdist[psutil]",
+        # pytest-xdist breaks classic coverage.
+        "pytest-cov",
         # Since the mypy error messages keep changing, we have to keep updating
         # this pin.
         "mypy>=0.971; python_implementation == 'CPython'",

--- a/setup.py
+++ b/setup.py
@@ -66,8 +66,6 @@ EXTRAS_REQUIRE = {
         "attrs[tests]",
         # pytest-xdist breaks classic coverage.
         "pytest-cov",
-        # Ensure coverage is new enough for `source_pkgs`.
-        "coverage>=5.3",
     ],
     "dev": ["attrs[tests,docs]"],
 }

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,8 @@ EXTRAS_REQUIRE = {
         "pympler",
         # 4.3.0 dropped last use of `convert`
         "pytest>=4.3.0",
+        # psutil extra is needed for correct core count detection.
+        "pytest-xdist[psutil]",
         # Since the mypy error messages keep changing, we have to keep updating
         # this pin.
         "mypy>=0.971; python_implementation == 'CPython'",

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,10 @@ commands = python -m pytest {posargs:-n auto}
 [testenv:py36]
 extras = tests
 deps = coverage[toml]>=5.3
-setenv = COVERAGE_FILE = .coverage.{envname}
+setenv =
+    COV_CORE_SOURCE={toxinidir}/src
+    COV_CORE_CONFIG={toxinidir}/pyproject.toml
+    COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
 commands = pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
 
 
@@ -43,7 +46,9 @@ commands = pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
 install_command = python -m pip install --no-compile {opts} {packages}
 setenv =
     PYTHONWARNINGS=d
-    COVERAGE_FILE = .coverage.{envname}
+    COV_CORE_SOURCE={toxinidir}/src
+    COV_CORE_CONFIG={toxinidir}/pyproject.toml
+    COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
 extras = tests
 deps = coverage[toml]>=5.3
 commands = pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ extras = cov
 setenv =
     COV_CORE_SOURCE={toxinidir}/src
     COV_CORE_CONFIG={toxinidir}/pyproject.toml
+    COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
 commands = python -m pytest -p pytest_cov --cov --cov-append {posargs:-n auto}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ python =
 [tox]
 envlist = mypy,pre-commit,py36,py37,py38,py39,py310,py311,pypy3,pyright,manifest,docs,pypi-description,changelog,coverage-report
 isolated_build = True
+setenv = COVERAGE_FILE = .coverage.{envname}
 
 
 [testenv:docs]
@@ -33,20 +34,17 @@ commands = python -m pytest {posargs:-n auto}
 [testenv:py36]
 extras = tests
 deps = coverage[toml]
-setenv = COVERAGE_FILE = .coverage.{envname}
-commands = python -m pytest --cov --cov-append {posargs:-n auto}
+commands = python -m pytest --cov --cov-append --dist load {posargs:-n auto}
 
 
 [testenv:py310]
 # Python 3.6+ has a number of compile-time warnings on invalid string escapes.
 # PYTHONWARNINGS=d and --no-compile below make them visible during the Tox run.
 install_command = python -m pip install --no-compile {opts} {packages}
-setenv =
-    PYTHONWARNINGS=d
-    COVERAGE_FILE = .coverage.{envname}
+setenv = PYTHONWARNINGS=d
 extras = tests
 deps = coverage[toml]
-commands = python -m pytest --cov --cov-append {posargs:-n auto}
+commands = python -m pytest --cov --cov-append --dist load {posargs:-n auto}
 
 
 [testenv:coverage-report]

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ setenv =
     COV_CORE_SOURCE={toxinidir}/src
     COV_CORE_CONFIG={toxinidir}/pyproject.toml
     COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
-commands = python -m pytest -p pytest_cov --cov=src/attr --cov=src/attrs --cov-append --cov-branch --dist load {posargs:-n auto}
+commands = pytest -p pytest_cov --cov=src/attr --cov=src/attrs --cov-append --cov-branch --dist load {posargs:-n auto}
 
 
 [testenv:pre-commit]

--- a/tox.ini
+++ b/tox.ini
@@ -33,18 +33,18 @@ commands = python -m pytest {posargs:-n auto}
 [testenv:py36]
 extras = tests
 deps = coverage[toml]
-commands = coverage run -m pytest {posargs:-n auto}
+commands = python -m pytest --cov --cov-append {posargs:-n auto}
 
 
 [testenv:py310]
 # Python 3.6+ has a number of compile-time warnings on invalid string escapes.
 # PYTHONWARNINGS=d and --no-compile below make them visible during the Tox run.
-install_command = pip install --no-compile {opts} {packages}
+install_command = python -m pip install --no-compile {opts} {packages}
 setenv =
     PYTHONWARNINGS=d
 extras = tests
 deps = coverage[toml]
-commands = coverage run -m pytest {posargs:-n auto}
+commands = python -m pytest --cov --cov-append {posargs:-n auto}
 
 
 [testenv:coverage-report]
@@ -53,8 +53,8 @@ depends = py36,py310
 skip_install = true
 deps = coverage[toml]
 commands =
-    coverage combine
-    coverage report
+    python -m coverage combine
+    python -m coverage report
 
 
 [testenv:pre-commit]

--- a/tox.ini
+++ b/tox.ini
@@ -32,10 +32,7 @@ commands = python -m pytest {posargs:-n auto}
 
 [testenv:py36]
 extras = cov
-setenv =
-    COV_CORE_SOURCE={toxinidir}/src
-    COV_CORE_CONFIG={toxinidir}/pyproject.toml
-    COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
+setenv = COV_CORE_SOURCE={toxinidir}/src
 commands = python -m pytest -p pytest_cov --cov --cov-append {posargs:-n auto}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ commands = python -m pytest {posargs:-n auto}
 [testenv:py36]
 extras = tests
 deps = coverage[toml]
+setenv = COVERAGE_FILE = .coverage.{envname}
 commands = python -m pytest --cov --cov-append {posargs:-n auto}
 
 
@@ -42,6 +43,7 @@ commands = python -m pytest --cov --cov-append {posargs:-n auto}
 install_command = python -m pip install --no-compile {opts} {packages}
 setenv =
     PYTHONWARNINGS=d
+    COVERAGE_FILE = .coverage.{envname}
 extras = tests
 deps = coverage[toml]
 commands = python -m pytest --cov --cov-append {posargs:-n auto}

--- a/tox.ini
+++ b/tox.ini
@@ -32,10 +32,6 @@ commands = python -m pytest {posargs:-n auto}
 
 [testenv:py36]
 extras = cov
-setenv =
-    COV_CORE_SOURCE={toxinidir}/src
-    COV_CORE_CONFIG={toxinidir}/pyproject.toml
-    COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
 commands = python -m pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
 
 
@@ -43,11 +39,7 @@ commands = python -m pytest -p pytest_cov --cov --cov-append --dist load {posarg
 # Python 3.6+ has a number of compile-time warnings on invalid string escapes.
 # PYTHONWARNINGS=d and --no-compile below make them visible during the Tox run.
 install_command = python -m pip install --no-compile {opts} {packages}
-setenv =
-    PYTHONWARNINGS=d
-    COV_CORE_SOURCE={toxinidir}/src
-    COV_CORE_CONFIG={toxinidir}/pyproject.toml
-    COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
+setenv = PYTHONWARNINGS=d
 extras = cov
 commands = python -m pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
 

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ setenv =
     COV_CORE_SOURCE={toxinidir}/src
     COV_CORE_CONFIG={toxinidir}/pyproject.toml
     COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
-commands = pytest -p pytest_cov --cov=src/attr --cov=src/attrs --cov-append --cov-branch --dist load {posargs:-n auto}
+commands = pytest -p pytest_cov --cov=src/attr --cov=src/attrs --cov-append --cov-branch {posargs:-n auto}
 
 
 [testenv:pre-commit]

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ setenv =
     COV_CORE_SOURCE={toxinidir}/src
     COV_CORE_CONFIG={toxinidir}/pyproject.toml
     COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
-commands = pytest -p pytest_cov --cov --cov-append {posargs:-n auto}
+commands = python -m pytest -p pytest_cov --cov --cov-append {posargs:-n auto}
 
 
 [testenv:pre-commit]

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands = python -m pytest {posargs:-n auto}
 extras = tests
 deps = coverage[toml]
 setenv = COVERAGE_FILE = .coverage.{envname}
-commands = python -m pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
+commands = pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
 
 
 [testenv:py310]
@@ -46,7 +46,7 @@ setenv =
     COVERAGE_FILE = .coverage.{envname}
 extras = tests
 deps = coverage[toml]
-commands = python -m pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
+commands = pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
 
 
 [testenv:coverage-report]

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,9 @@ commands = python -m pytest {posargs:-n auto}
 
 [testenv:py36]
 extras = cov
-setenv = COV_CORE_SOURCE={toxinidir}/src
+setenv =
+    COV_CORE_SOURCE={toxinidir}/src
+    COV_CORE_CONFIG={toxinidir}/pyproject.toml
 commands = python -m pytest -p pytest_cov --cov --cov-append {posargs:-n auto}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ setenv =
     COV_CORE_SOURCE={toxinidir}/src
     COV_CORE_CONFIG={toxinidir}/pyproject.toml
     COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
-commands = python -m pytest -p pytest_cov --cov=src --cov-append --cov-branch --dist load {posargs:-n auto}
+commands = python -m pytest -p pytest_cov --cov=src/attr --cov=src/attrs --cov-append --cov-branch --dist load {posargs:-n auto}
 
 
 [testenv:pre-commit]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ python =
 [tox]
 envlist = mypy,pre-commit,py36,py37,py38,py39,py310,py311,pypy3,pyright,manifest,docs,pypi-description,changelog,coverage-report
 isolated_build = True
-setenv = COVERAGE_FILE = .coverage.{envname}
 
 
 [testenv:docs]
@@ -34,6 +33,7 @@ commands = python -m pytest {posargs:-n auto}
 [testenv:py36]
 extras = tests
 deps = coverage[toml]
+setenv = COVERAGE_FILE = .coverage.{envname}
 commands = python -m pytest --cov --cov-append --dist load {posargs:-n auto}
 
 
@@ -41,7 +41,9 @@ commands = python -m pytest --cov --cov-append --dist load {posargs:-n auto}
 # Python 3.6+ has a number of compile-time warnings on invalid string escapes.
 # PYTHONWARNINGS=d and --no-compile below make them visible during the Tox run.
 install_command = python -m pip install --no-compile {opts} {packages}
-setenv = PYTHONWARNINGS=d
+setenv =
+    PYTHONWARNINGS=d
+    COVERAGE_FILE = .coverage.{envname}
 extras = tests
 deps = coverage[toml]
 commands = python -m pytest --cov --cov-append --dist load {posargs:-n auto}

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ python =
 
 
 [tox]
-envlist = mypy,pre-commit,py36,py37,py38,py39,py310,py311,pypy3,pyright,manifest,docs,pypi-description,changelog
+envlist = mypy,pre-commit,py36,py37,py38,py39,py310,py311,pypy3,pyright,manifest,docs,pypi-description,changelog,coverage-report
 isolated_build = True
 
 
@@ -32,11 +32,8 @@ commands = python -m pytest {posargs:-n auto}
 
 [testenv:py36]
 extras = cov
-setenv =
-    COV_CORE_SOURCE={toxinidir}/src
-    COV_CORE_CONFIG={toxinidir}/pyproject.toml
-    COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
-commands = python -m pytest -p pytest_cov --cov --cov-append {posargs:-n auto}
+setenv = COVERAGE_PROCESS_START={toxinidir}/pyproject.toml
+commands = coverage run -m pytest {posargs:-n auto}
 
 
 [testenv:py310]
@@ -49,6 +46,15 @@ setenv =
     {[testenv:py36]setenv}
 commands = {[testenv:py36]commands}
 
+
+[testenv:coverage-report]
+basepython = python3.10
+depends = py36,py310
+skip_install = true
+deps = coverage[toml]>=5.3
+commands =
+    coverage combine
+    coverage report
 
 [testenv:pre-commit]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,10 @@ commands = python -m pytest {posargs:-n auto}
 
 [testenv:py36]
 extras = cov
-setenv = {[testenv:py310]setenv}
+setenv =
+    COV_CORE_SOURCE={toxinidir}/src
+    COV_CORE_CONFIG={toxinidir}/pyproject.toml
+    COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
 commands = {[testenv:py310]commands}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ setenv =
     COVERAGE_FILE = .coverage.{envname}
 extras = tests
 deps = coverage[toml]
-commands = python -m pytest --cov --cov-append --dist load {posargs:-n auto}
+commands = python -m pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
 
 
 [testenv:coverage-report]

--- a/tox.ini
+++ b/tox.ini
@@ -32,16 +32,17 @@ commands = python -m pytest {posargs:-n auto}
 
 [testenv:py36]
 extras = cov
-commands = python -m pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
+commands = {[testenv:py310]commands}
 
 
 [testenv:py310]
+extras = cov
 # Python 3.6+ has a number of compile-time warnings on invalid string escapes.
 # PYTHONWARNINGS=d and --no-compile below make them visible during the Tox run.
 install_command = python -m pip install --no-compile {opts} {packages}
-setenv = PYTHONWARNINGS=d
-extras = cov
-commands = python -m pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
+setenv =
+    PYTHONWARNINGS=d
+commands = python -m pytest -p pytest_cov --cov=src --cov-append --cov-branch --dist load {posargs:-n auto}
 
 
 [testenv:pre-commit]

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ setenv =
     COV_CORE_SOURCE={toxinidir}/src
     COV_CORE_CONFIG={toxinidir}/pyproject.toml
     COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
-commands = {[testenv:py310]commands}
+commands = python -m pytest -p pytest_cov --cov --cov-append {posargs:-n auto}
 
 
 [testenv:py310]
@@ -46,10 +46,8 @@ extras = cov
 install_command = python -m pip install --no-compile {opts} {packages}
 setenv =
     PYTHONWARNINGS=d
-    COV_CORE_SOURCE={toxinidir}/src
-    COV_CORE_CONFIG={toxinidir}/pyproject.toml
-    COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
-commands = python -m pytest -p pytest_cov --cov --cov-append {posargs:-n auto}
+    {[testenv:py36]setenv}
+commands = {[testenv:py36]commands}
 
 
 [testenv:pre-commit]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ python =
 
 
 [tox]
-envlist = mypy,pre-commit,py36,py37,py38,py39,py310,py311,pypy3,pyright,manifest,docs,pypi-description,changelog,coverage-report
+envlist = mypy,pre-commit,py36,py37,py38,py39,py310,py311,pypy3,pyright,manifest,docs,pypi-description,changelog
 isolated_build = True
 
 
@@ -31,13 +31,12 @@ commands = python -m pytest {posargs:-n auto}
 
 
 [testenv:py36]
-extras = tests
-deps = coverage[toml]>=5.3
+extras = cov
 setenv =
     COV_CORE_SOURCE={toxinidir}/src
     COV_CORE_CONFIG={toxinidir}/pyproject.toml
     COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
-commands = pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
+commands = python -m pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
 
 
 [testenv:py310]
@@ -49,19 +48,8 @@ setenv =
     COV_CORE_SOURCE={toxinidir}/src
     COV_CORE_CONFIG={toxinidir}/pyproject.toml
     COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
-extras = tests
-deps = coverage[toml]>=5.3
-commands = pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
-
-
-[testenv:coverage-report]
-basepython = python3.10
-depends = py36,py310
-skip_install = true
-deps = coverage[toml]>=5.3
-commands =
-    python -m coverage combine
-    python -m coverage report
+extras = cov
+commands = python -m pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
 
 
 [testenv:pre-commit]

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands = python -m pytest {posargs:-n auto}
 extras = tests
 deps = coverage[toml]
 setenv = COVERAGE_FILE = .coverage.{envname}
-commands = python -m pytest --cov --cov-append --dist load {posargs:-n auto}
+commands = python -m pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
 
 
 [testenv:py310]

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ setenv =
     COV_CORE_SOURCE={toxinidir}/src
     COV_CORE_CONFIG={toxinidir}/pyproject.toml
     COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
-commands = pytest -p pytest_cov --cov=src --cov-append --cov-branch {posargs:-n auto}
+commands = pytest -p pytest_cov --cov --cov-append --cov-branch {posargs:-n auto}
 
 
 [testenv:pre-commit]

--- a/tox.ini
+++ b/tox.ini
@@ -27,13 +27,13 @@ commands =
 
 [testenv]
 extras = tests
-commands = python -m pytest {posargs}
+commands = python -m pytest {posargs:-n auto}
 
 
 [testenv:py36]
 extras = tests
 deps = coverage[toml]
-commands = coverage run -m pytest {posargs}
+commands = coverage run -m pytest {posargs:-n auto}
 
 
 [testenv:py310]
@@ -44,7 +44,7 @@ setenv =
     PYTHONWARNINGS=d
 extras = tests
 deps = coverage[toml]
-commands = coverage run -m pytest {posargs}
+commands = coverage run -m pytest {posargs:-n auto}
 
 
 [testenv:coverage-report]

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ setenv =
     COV_CORE_SOURCE={toxinidir}/src
     COV_CORE_CONFIG={toxinidir}/pyproject.toml
     COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
-commands = pytest -p pytest_cov --cov --cov-append --cov-branch {posargs:-n auto}
+commands = pytest -p pytest_cov --cov --cov-append {posargs:-n auto}
 
 
 [testenv:pre-commit]

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ commands = python -m pytest {posargs:-n auto}
 
 [testenv:py36]
 extras = tests
-deps = coverage[toml]
+deps = coverage[toml]>=5.3
 setenv = COVERAGE_FILE = .coverage.{envname}
 commands = pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
 
@@ -45,7 +45,7 @@ setenv =
     PYTHONWARNINGS=d
     COVERAGE_FILE = .coverage.{envname}
 extras = tests
-deps = coverage[toml]
+deps = coverage[toml]>=5.3
 commands = pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
 
 
@@ -53,7 +53,7 @@ commands = pytest -p pytest_cov --cov --cov-append --dist load {posargs:-n auto}
 basepython = python3.10
 depends = py36,py310
 skip_install = true
-deps = coverage[toml]
+deps = coverage[toml]>=5.3
 commands =
     python -m coverage combine
     python -m coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ setenv =
     COV_CORE_SOURCE={toxinidir}/src
     COV_CORE_CONFIG={toxinidir}/pyproject.toml
     COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
-commands = pytest -p pytest_cov --cov=src/attr --cov=src/attrs --cov-append --cov-branch {posargs:-n auto}
+commands = pytest -p pytest_cov --cov=src --cov-append --cov-branch {posargs:-n auto}
 
 
 [testenv:pre-commit]

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ commands = python -m pytest {posargs:-n auto}
 
 [testenv:py36]
 extras = cov
+setenv = {[testenv:py310]setenv}
 commands = {[testenv:py310]commands}
 
 
@@ -42,6 +43,9 @@ extras = cov
 install_command = python -m pip install --no-compile {opts} {packages}
 setenv =
     PYTHONWARNINGS=d
+    COV_CORE_SOURCE={toxinidir}/src
+    COV_CORE_CONFIG={toxinidir}/pyproject.toml
+    COV_CORE_DATAFILE={toxinidir}/.coverage.{envname}
 commands = python -m pytest -p pytest_cov --cov=src --cov-append --cov-branch --dist load {posargs:-n auto}
 
 


### PR DESCRIPTION
Locally, this slashes over 70% of runtime.

Let's see what it does to CI.