### PR TITLE
Build sdist from a wheel in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
           python-version: ${{env.PYTHON_LATEST}}
 
       - run: python -m pip install build twine check-wheel-contents
-      - run: python -m build --sdist --wheel .
+      - run: python -m build
       - run: ls -l dist
       - run: check-wheel-contents dist/*.whl
       - name: Check long_description


### PR DESCRIPTION
$sbj. Invoking `python -m build --sdist --wheel` builds an sdist and a wheel from the project source directory (i.e. from the Git checkout). Each of them. It is recommended to make sure that it's possible to build a wheel from an sdist and not from a Git repo since some files may be excluded while building an sdist making the artifact essentially broken (kinda). `pip install` normally attempts building a wheel before installing from sdist, it also caches it.
Starting around v0.5.0 of `build`, it builds and sdist followed by building a wheel _from that sdist_. But only if you don't specify any of `--sdist` or `--wheel` explicitly. If you do, it'll build from your repo checkout.

This patch makes sure that this kind of smoke testing actually happens in the CI.