### PR TITLE
Add a preview for the "next release" change notes

### DIFF
--- a/changelog.d/1016.doc.rst
+++ b/changelog.d/1016.doc.rst
@@ -1,1 +1,0 @@
-Render the unreleased ``attrs`` version change notes on the changelog page in docs.

--- a/changelog.d/1016.doc.rst
+++ b/changelog.d/1016.doc.rst
@@ -1,0 +1,1 @@
+Render the unreleased ``attrs`` version change notes on the changelog page in docs.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,1 +1,7 @@
 .. include:: ../CHANGELOG.rst
+   :end-before: Changes for the upcoming release can be found
+
+.. towncrier-draft-entries:: |release|:sub:`/UNRELEASED DRAFT/`
+
+.. include:: ../CHANGELOG.rst
+   :start-after: .. towncrier release notes start

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,7 +1,7 @@
 .. include:: ../CHANGELOG.rst
    :end-before: Changes for the upcoming release can be found
 
-.. towncrier-draft-entries:: |release|:sub:`/UNRELEASED DRAFT/`
+.. towncrier-draft-entries:: Not yet released
 
 .. include:: ../CHANGELOG.rst
    :start-after: .. towncrier release notes start

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: MIT
 
 from importlib import metadata
+from pathlib import Path
+
+
+# -- Path setup -----------------------------------------------------------
+
+PROJECT_ROOT_DIR = Path(__file__).parents[1].resolve()
 
 
 # -- General configuration ------------------------------------------------
@@ -35,6 +41,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.todo",
     "notfound.extension",
+    "sphinxcontrib.towncrier",
 ]
 
 
@@ -153,3 +160,11 @@ intersphinx_mapping = {
 
 # Allow non-local URIs so we can have images in CHANGELOG etc.
 suppress_warnings = ["image.nonlocal_uri"]
+
+
+# -- Options for sphinxcontrib.towncrier extension ------------------------
+
+towncrier_draft_autoversion_mode = "draft"
+towncrier_draft_include_empty = True
+towncrier_draft_working_directory = PROJECT_ROOT_DIR
+towncrier_draft_config_path = "pyproject.toml"

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,13 @@ CLASSIFIERS = [
 ]
 INSTALL_REQUIRES = []
 EXTRAS_REQUIRE = {
-    "docs": ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"],
+    "docs": [
+        "furo",
+        "sphinx",
+        "zope.interface",
+        "sphinx-notfound-page",
+        "sphinxcontrib-towncrier",
+    ],
     "tests-no-zope": [
         # For regression test to ensure cloudpickle compat doesn't break.
         'cloudpickle; python_implementation == "CPython"',


### PR DESCRIPTION
# Summary

This change integrates `sphinxcontrib-towncrier` into the docs build.
It uses Towncrier and its configs to render a draft changelog as RST
and injects that into the `changelog.rst` document right above the
older changelog entries using `towncrier-draft-entries` directive.

I figured, it'd be nicer to be able to have a sneak-peak into the future
release changes. As an alternative to navigating to a folder with a
bunch of standalone uncategorized files.

Usage in the wild: https://pip.pypa.io/en/latest/news/#not-yet-released-2022-08-21.

Preview: https://attrs--1016.org.readthedocs.build/en/1016/changelog.html#changelog.