### PR TITLE
Fix pre-commit link syntax in contributing doc

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -96,7 +96,7 @@ This is not strictly necessary, because our [*tox*] file contains an environment
 $ pre-commit run --all-files
 ```
 
-and our CI has integration with `pre-commit.ci <https://pre-commit.ci>`_.
+and our CI has integration with [pre-commit.ci](https://pre-commit.ci).
 But it's way more comfortable to run it locally and *git* catching avoidable errors.
 
 


### PR DESCRIPTION
# Summary

It was using RST but the doc is actually in Markdown.