### PR TITLE
Introduce a gate/check GHA job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,3 +107,21 @@ jobs:
           python-version: ${{env.PYTHON_LATEST}}
       - run: python -m pip install -e .[dev]
       - run: python -c 'import attr; print(attr.__version__)'
+
+  check:  # This job does nothing and is only used for the branch protection
+    if: always()
+
+    needs:
+      - coverage
+      - install-dev
+      - package
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Decide whether the needed jobs succeeded or failed
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+
+...


### PR DESCRIPTION
This adds a GHA job that reliably determines if all the required dependencies have succeeded or not.

It also allows to reduce the list of required branch protection CI statuses to just one — `check`. This reduces the maintenance burden by a lot and have been battle-tested across a small bunch of projects in its action form and in-house implementations of other people.

I was curious about the spread of use. And I've just discovered that it is now in use in aiohttp (and other aio-libs projects), CherryPy, some of the Ansible repositories, all of the jaraco's projects (like `setuptools`, `importlib_metadata`), some PyCQA, PyCA and pytest projects, a few AWS Labs projects (to my surprise). Admittedly, I maintain a few of these but it seems to address some of the pain folks have: https://github.com/jaraco/skeleton/pull/55#issuecomment-1106638475.

The story behind this is explained in more detail at https://github.com/marketplace/actions/alls-green#why.