### PR TITLE
[DNM] Allow skipping `coverage` job on pushes `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,18 @@ jobs:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@release/v1
         with:
+          allowed-skips: >-
+            ${{
+              (
+                github.event_name == 'push' &&
+                github.ref == format(
+                  'refs/heads/{0}',
+                  github.event.repository.default_branch
+                )
+              )
+              && 'coverage'
+              || ''
+            }}
           jobs: ${{ toJSON(needs) }}
 
 ...


### PR DESCRIPTION
# Summary

<!-- Please tell us what your pull request is about here. -->
$sbj. Asked in https://github.com/python-attrs/attrs/pull/1029#issuecomment-1259488083.

But @hynek, I'm pretty sure this _is not what you want_. Which is why I wrote an explanation here: https://github.com/python-attrs/attrs/pull/1029#issuecomment-1259525838. Keeping this as a draft to prevent an accidental merge. Read those comments first, before proceeding.
