### PR TITLE
Add unstable Python 3.12 to CI allowing failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,12 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "~3.12.0-0"
           - "pypy-3.7"
           - "pypy-3.8"
+
+    continue-on-error: >-
+      ${{ contains(matrix.python-version, '~') && true || false }}
 
     steps:
       - name: Harden Runner

--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -13,6 +13,7 @@ from collections.abc import Mapping, Sequence  # noqa
 
 PYPY = platform.python_implementation() == "PyPy"
 PY310 = sys.version_info[:2] >= (3, 10)
+PY_3_12_PLUS = sys.version_info[:2] >= (3, 12)
 
 
 def just_warn(*args, **kw):

--- a/tests/test_abc.py
+++ b/tests/test_abc.py
@@ -7,7 +7,7 @@ import pytest
 
 import attrs
 
-from attr._compat import PY310
+from attr._compat import PY310, PY_3_12_PLUS
 
 
 @pytest.mark.skipif(not PY310, reason="abc.update_abstractmethods is 3.10+")
@@ -50,7 +50,11 @@ class TestUpdateAbstractMethods:
             pass
 
         assert inspect.isabstract(StillAbstract)
-        with pytest.raises(
-            TypeError, match="class StillAbstract with abstract method foo"
-        ):
+        expected_exception_message = (
+            "^Can't instantiate abstract class StillAbstract without an "
+            "implementation for abstract method 'foo'$"
+            if PY_3_12_PLUS
+            else "class StillAbstract with abstract method foo"
+        )
+        with pytest.raises(TypeError, match=expected_exception_message):
             StillAbstract()

--- a/tox.ini
+++ b/tox.ini
@@ -7,11 +7,12 @@ python =
     3.9: py39
     3.10: py310, mypy
     3.11: py311
+    3.12: py312
     pypy-3: pypy3
 
 
 [tox]
-envlist = mypy,pre-commit,py36,py37,py38,py39,py310,py311,pypy3,pyright,manifest,docs,pypi-description,changelog,coverage-report
+envlist = mypy,pre-commit,py36,py37,py38,py39,py310,py311,py312,pypy3,pyright,manifest,docs,pypi-description,changelog,coverage-report
 isolated_build = True
 
 
@@ -42,7 +43,7 @@ setenv =
 commands = {[testenv:py36]commands}
 
 
-[testenv:py311]
+[testenv:py31{1,2}]
 extras = cov
 # Python 3.6+ has a number of compile-time warnings on invalid string escapes.
 # PYTHONWARNINGS=d and --no-compile below make them visible during the Tox run.


### PR DESCRIPTION
Ref https://github.com/python-attrs/attrs/pull/1029#issuecomment-1261394538.

This is kept as a draft that is expected to be merged once all of the following are true:
* [x] Python 3.11 final is out
* [x] GitHub updated their available CPython builds to include Python 3.12-dev
* [x] The DNM (do-not-merge) tag is dropped from the PR title