### PR TITLE
compat: move check for closure cellvar update wrapper function

### DIFF
--- a/changelog.d/1092.change.md
+++ b/changelog.d/1092.change.md
@@ -1,2 +1,1 @@
-Fix slots class cellvar updating closure in CPython 3.8+ even when `__code__`
-introspection is unavailable.
+Fix slots class cellvar updating closure in CPython 3.8+ even when `__code__` introspection is unavailable.

--- a/changelog.d/1092.change.md
+++ b/changelog.d/1092.change.md
@@ -1,0 +1,2 @@
+Fix slots class cellvar updating closure in CPython 3.8+ even when `__code__`
+introspection is unavailable.

--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -81,32 +81,32 @@ def make_set_closure_cell():
 
     # Otherwise gotta do it the hard way.
 
-    # Create a function that will set its first cellvar to `value`.
-    def set_first_cellvar_to(value):
-        x = value
-        return
-
-        # This function will be eliminated as dead code, but
-        # not before its reference to `x` forces `x` to be
-        # represented as a closure cell rather than a local.
-        def force_x_to_be_a_cell():  # pragma: no cover
-            return x
-
     try:
-        # Extract the code object and make sure our assumptions about
-        # the closure behavior are correct.
-        co = set_first_cellvar_to.__code__
-        if co.co_cellvars != ("x",) or co.co_freevars != ():
-            raise AssertionError  # pragma: no cover
-
-        # Convert this code object to a code object that sets the
-        # function's first _freevar_ (not cellvar) to the argument.
         if sys.version_info >= (3, 8):
 
             def set_closure_cell(cell, value):
                 cell.cell_contents = value
 
         else:
+            # Create a function that will set its first cellvar to `value`.
+            def set_first_cellvar_to(value):
+                x = value
+                return
+
+                # This function will be eliminated as dead code, but
+                # not before its reference to `x` forces `x` to be
+                # represented as a closure cell rather than a local.
+                def force_x_to_be_a_cell():  # pragma: no cover
+                    return x
+
+            # Extract the code object and make sure our assumptions about
+            # the closure behavior are correct.
+            co = set_first_cellvar_to.__code__
+            if co.co_cellvars != ("x",) or co.co_freevars != ():
+                raise AssertionError  # pragma: no cover
+
+            # Convert this code object to a code object that sets the
+            # function's first _freevar_ (not cellvar) to the argument.
             args = [co.co_argcount]
             args.append(co.co_kwonlyargcount)
             args.extend(


### PR DESCRIPTION
This sanity checking code ended up getting decoupled from the old implementation in a18b3957d55c669de56799a9a72ea31febe93ce4 when a new, much simpler method was added. This check can fail spuriously in certain environments where it doesn't even need to be run because the newer approach is used.

This is noticeable when using python scripts compiled by [nuitka](https://github.com/Nuitka/Nuitka). Since next-gen `attrs` uses slots on everything by default, the use of this fixup function is now pervasive, as well.

Here's the simplest reproduction I came up with (tested on Python 3.10.9 and nuitka 1.4)

```python
# problem.py

# pip install attrs nuitka ordered-set
# nuitka3 --standalone --onefile problem.py
# running `python problem.py` without this patch succeeds
# running nuitka's output `problem.bin` without this patch fails. With this patch it succeeds.

import attrs

@attrs.define
class Parent:
    a: int

    def __attrs_post_init__(self):
        assert self.__class__ is Child, f"{self.__class__} is not {Child} ({id(self.__class__)}, {id(Child)})"

@attrs.define
class Child(Parent):
    b: float

    def __attrs_post_init__(self):
        assert __class__ is Child, f"{__class__} is not {Child} ({id(__class__)}, {id(Child)})"

        super().__attrs_post_init__()


Child(a=1, b=0.0)
```

Because `nuitka` compiles the python code to C, I guess it loses the introspection through the `__code__` attribute, which is why the sanity check causes a problem. Fortunately, that's apparently entirely unneeded with any python version 3.8 or above.


# (Annotated) Pull Request Check List

- [x] Added **tests** for changed code.
   >  I am not sure how to reasonably add a test case for this in-tree because my reproduction requires a heavyweight external process (compiling with nuitka).
- [x] Updated **documentation** for changed code.
   > the changed code is an internal function with minimal documentation. There doesn't seem to be anything to add here
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
