### PR TITLE
🐛 Bump isort to v5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         exclude: "tests/test_slots.py"
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         files: \.py$


### PR DESCRIPTION
The previous version is not installable with the latest Poetry anymore but the update in this patch fixes that.