### PR TITLE
Initial custom attributes work

### DIFF
--- a/src/attrs/__init__.py
+++ b/src/attrs/__init__.py
@@ -43,6 +43,7 @@ __all__ = [
     "AttrsInstance",
     "cmp_using",
     "converters",
+    "custom_fields",
     "define",
     "evolve",
     "exceptions",

--- a/src/attrs/custom_fields.py
+++ b/src/attrs/custom_fields.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import typing
+
+from typing_extensions import Protocol
+
+from attr._make import _make_attr_tuple_class
+from attrs import Attribute, AttrsInstance, fields
+from attrs import resolve_types as _resolve_types
+
+
+__all__ = ["custom_fields"]
+
+T = typing.TypeVar("T")
+
+
+class AttributeModel(Protocol[T]):
+    """Custom attributes must conform to this."""
+
+    @classmethod
+    def _from_attrs_attribute(
+        cls: type[AttributeModel],
+        cl: type[AttrsInstance],
+        attribute: Attribute[T],
+    ) -> AttributeModel[T]:
+        """Create a custom attribute model from an `attrs.Attribute`."""
+        ...
+
+
+def custom_fields(
+    cls: type[AttrsInstance],
+    attribute_model: type[AttributeModel],
+    resolve_types: bool = False,
+):
+    """
+    Return the attrs fields tuple for cls with the provided attribute model.
+
+    :param type cls: Class to introspect.
+    :param attribute_model: The attribute model to use.
+    :param resolve_types: Whether to resolve the class types first.
+
+    :raise TypeError: If *cls* is not a class.
+    :raise attrs.exceptions.NotAnAttrsClassError: If *cls* is not an *attrs*
+        class.
+
+    :rtype: tuple (with name accessors) of `attribute_model`.
+
+    .. versionadded:: 23.2.0
+    """
+    attrs = getattr(cls, f"__attrs_{id(attribute_model)}__", None)
+
+    if attrs is None:
+        if resolve_types:
+            _resolve_types(cls)
+        base_attrs = fields(cls)
+        AttrsClass = _make_attr_tuple_class(
+            cls.__name__, [a.name for a in base_attrs]
+        )
+        attrs = AttrsClass(
+            attribute_model._from_attrs_attribute(cls, a) for a in base_attrs
+        )
+        setattr(cls, f"__attrs_{id(attribute_model)}__", attrs)
+
+    return attrs

--- a/tests/test_custom_fields.py
+++ b/tests/test_custom_fields.py
@@ -1,0 +1,76 @@
+"""Tests for the custom attributes functionality."""
+from __future__ import annotations
+
+from functools import partial
+from typing import Generic, TypeVar
+
+from attrs import Attribute, AttrsInstance, define
+from attrs.custom_fields import custom_fields
+
+
+T = TypeVar("T")
+
+
+@define
+class CustomAttribute(Generic[T]):
+    """A custom attribute, for tests."""
+
+    cl: type[AttrsInstance]
+    name: str
+    attribute_type: T
+
+    @classmethod
+    def _from_attrs_attribute(
+        cls, attrs_cls: type[AttrsInstance], attribute: Attribute[T]
+    ):
+        return cls(attrs_cls, attribute.name, attribute.type)
+
+
+cust_fields = partial(custom_fields, attribute_model=CustomAttribute)
+cust_resolved_fields = partial(
+    custom_fields, attribute_model=CustomAttribute, resolve_types=True
+)
+
+
+def test_simple_custom_fields():
+    """Simple custom attribute overriding works."""
+
+    @define
+    class Test:
+        a: int
+        b: float
+
+    for _ in range(2):
+        # Do it twice to test caching.
+        f = cust_fields(Test)
+
+        assert isinstance(f.a, CustomAttribute)
+        assert isinstance(f.b, CustomAttribute)
+
+        assert not hasattr(f, "c")
+
+        assert f.a.name == "a"
+        assert f.a.cl is Test
+        assert f.a.attribute_type == "int"
+
+
+def test_resolved_custom_fields():
+    """Resolved custom attributes work."""
+
+    @define
+    class Test:
+        a: int
+        b: float
+
+    for _ in range(2):
+        # Do it twice to test caching.
+        f = cust_resolved_fields(Test)
+
+        assert isinstance(f.a, CustomAttribute)
+        assert isinstance(f.b, CustomAttribute)
+
+        assert not hasattr(f, "c")
+
+        assert f.a.name == "a"
+        assert f.a.cl is Test
+        assert f.a.attribute_type is int


### PR DESCRIPTION
This PR enables other libraries to define their own Attribute classes (replacing attrs.Attribute), and hence to define their own `fields()` function.

_Why does this need to be in attrs?_

Because the next step will be to add support for this to the attrs Mypy plugin, and we need to design this feature with that in mind.

Having Mypy support for this will actually enable statically checking things that were previously _impossible_ in Python, so if we do it right, it might be a big deal.

For example, as far as I know no ORM in Python today can statically check queries. We may change this.

Since this is a feature for library authors (not end users directly), we may consider designing it so it is easily supportable in Mypy rather than easy to use (as funny as that sounds).

My personal motivation is that my codebases are pretty heavily typed, but I keep running into untypeable things to do with databases. I would love to plug the hole, even partially.

This is a continuation of https://github.com/python-attrs/attrs/issues/934.

# Use cases

## cattrs customization

Right now, here's how a cattrs structuring function can be customized:

```python
from cattrs.gen import override, make_dict_structure_fn

make_dict_structure_fn(MyClass, converter, a=override(omit=True))
```

Here's how it could be:

```python
from cattrs.gen import make_dict_structure_fn, fields as f

make_dict_structure_fn(MyClass, converter, f(MyClass).a.omit())
```

_Why is it better?_

A more fluent API, better errors, statically checked.

## cattrs validation

cattrs has no validation right now, here's how it could work.

```python
from cattrs.v import fields as f

validator = f(MyClass).a.gt(5) & f(MyClass).b.len(min=1)

validator(MyClass(1, [])
```

## PocketMongo query builder

The current approach to creating a Mongo query condition:

```python
{"user_id": user_id}
```

How it could be:

```python
from pocketmongo import q, find_one

find_one(q(Model).user_id.equal(uid))
# Mypy error if `user_id` is misspelled (field doesn't exist)
# Mypy error if `uid` is not the same type as `user_id`
```

Why is it better:

A more fluent API. Statically checked.

This might end up being a model for attrs-based ORMs going forward.

# Problems

* Pyright probably won't support this, but that's just something we have to live with. Mypy supporting it will add plenty of value.

* I'm not sure about handling nested attributes yet. If class A has an attribute `b`, typed as class `B`, and class `B` has a field called `c`. `f(A).b.c` should probably work, but it maybe requires special casing? That's TBD, but sounds like mostly a Mypy issue.