### PR TITLE
Switched from __dataclass_transform__() to typing.dataclass_transform()

### DIFF
--- a/changelog.d/1158.change.md
+++ b/changelog.d/1158.change.md
@@ -1,0 +1,3 @@
+Type stubs now use `typing.dataclass_transform` to decorate dataclass-like
+decorators, instead of the non-standard `__dataclass_transform__` special
+form, which is only supported by pyright.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -94,30 +94,15 @@ You can only use this trick to tell *Mypy* that a class is actually an *attrs* c
 
 ### Pyright
 
-Generic decorator wrapping is supported in [*Pyright*](https://github.com/microsoft/pyright) via `dataclass_transform` / {pep}`689`.
+Generic decorator wrapping is supported in [*Pyright*](https://github.com/microsoft/pyright) via `typing.dataclass_transform` / {pep}`689`.
 
 For a custom wrapping of the form:
 
 ```
+@typing.dataclass_transform(field_specifiers=(attr.attrib, attr.field))
 def custom_define(f):
     return attr.define(f)
 ```
-
-This is implemented via a `__dataclass_transform__` type decorator in the custom extension's `.pyi` of the form:
-
-```
-def __dataclass_transform__(
-    *,
-    eq_default: bool = True,
-    order_default: bool = False,
-    kw_only_default: bool = False,
-    field_descriptors: Tuple[Union[type, Callable[..., Any]], ...] = (()),
-) -> Callable[[_T], _T]: ...
-
-@__dataclass_transform__(field_descriptors=(attr.attrib, attr.field))
-def custom_define(f): ...
-```
-
 
 ## Types
 

--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -98,6 +98,7 @@ if sys.version_info >= (3, 8):
         factory: Callable[[], _T],
         takes_self: Literal[False],
     ) -> _T: ...
+
 else:
     @overload
     def Factory(factory: Callable[[], _T]) -> _T: ...
@@ -420,9 +421,7 @@ def define(
 mutable = define
 
 @overload
-@dataclass_transform(
-    frozen_default=True, field_descriptors=(attrib, field)
-)
+@dataclass_transform(frozen_default=True, field_descriptors=(attrib, field))
 def frozen(
     maybe_cls: _C,
     *,
@@ -448,9 +447,7 @@ def frozen(
     match_args: bool = ...,
 ) -> _C: ...
 @overload
-@dataclass_transform(
-    frozen_default=True, field_descriptors=(attrib, field)
-)
+@dataclass_transform(frozen_default=True, field_descriptors=(attrib, field))
 def frozen(
     maybe_cls: None = ...,
     *,

--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -310,7 +310,7 @@ def field(
     type: Optional[type] = ...,
 ) -> Any: ...
 @overload
-@dataclass_transform(order_default=True, field_descriptors=(attrib, field))
+@dataclass_transform(order_default=True, field_specifiers=(attrib, field))
 def attrs(
     maybe_cls: _C,
     these: Optional[Dict[str, Any]] = ...,
@@ -338,7 +338,7 @@ def attrs(
     unsafe_hash: Optional[bool] = ...,
 ) -> _C: ...
 @overload
-@dataclass_transform(order_default=True, field_descriptors=(attrib, field))
+@dataclass_transform(order_default=True, field_specifiers=(attrib, field))
 def attrs(
     maybe_cls: None = ...,
     these: Optional[Dict[str, Any]] = ...,
@@ -366,7 +366,7 @@ def attrs(
     unsafe_hash: Optional[bool] = ...,
 ) -> Callable[[_C], _C]: ...
 @overload
-@dataclass_transform(field_descriptors=(attrib, field))
+@dataclass_transform(field_specifiers=(attrib, field))
 def define(
     maybe_cls: _C,
     *,
@@ -392,7 +392,7 @@ def define(
     match_args: bool = ...,
 ) -> _C: ...
 @overload
-@dataclass_transform(field_descriptors=(attrib, field))
+@dataclass_transform(field_specifiers=(attrib, field))
 def define(
     maybe_cls: None = ...,
     *,
@@ -421,7 +421,7 @@ def define(
 mutable = define
 
 @overload
-@dataclass_transform(frozen_default=True, field_descriptors=(attrib, field))
+@dataclass_transform(frozen_default=True, field_specifiers=(attrib, field))
 def frozen(
     maybe_cls: _C,
     *,
@@ -447,7 +447,7 @@ def frozen(
     match_args: bool = ...,
 ) -> _C: ...
 @overload
-@dataclass_transform(frozen_default=True, field_descriptors=(attrib, field))
+@dataclass_transform(frozen_default=True, field_specifiers=(attrib, field))
 def frozen(
     maybe_cls: None = ...,
     *,

--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -33,6 +33,11 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import TypeGuard
 
+if sys.version_info >= (3, 11):
+    from typing import dataclass_transform
+else:
+    from typing_extensions import dataclass_transform
+
 __version__: str
 __version_info__: VersionInfo
 __title__: str
@@ -93,7 +98,6 @@ if sys.version_info >= (3, 8):
         factory: Callable[[], _T],
         takes_self: Literal[False],
     ) -> _T: ...
-
 else:
     @overload
     def Factory(factory: Callable[[], _T]) -> _T: ...
@@ -102,23 +106,6 @@ else:
         factory: Union[Callable[[Any], _T], Callable[[], _T]],
         takes_self: bool = ...,
     ) -> _T: ...
-
-# Static type inference support via __dataclass_transform__ implemented as per:
-# https://github.com/microsoft/pyright/blob/1.1.135/specs/dataclass_transforms.md
-# This annotation must be applied to all overloads of "define" and "attrs"
-#
-# NOTE: This is a typing construct and does not exist at runtime.  Extensions
-# wrapping attrs decorators should declare a separate __dataclass_transform__
-# signature in the extension module using the specification linked above to
-# provide pyright support.
-def __dataclass_transform__(
-    *,
-    eq_default: bool = True,
-    order_default: bool = False,
-    kw_only_default: bool = False,
-    frozen_default: bool = False,
-    field_descriptors: Tuple[Union[type, Callable[..., Any]], ...] = (()),
-) -> Callable[[_T], _T]: ...
 
 class Attribute(Generic[_T]):
     name: str
@@ -322,7 +309,7 @@ def field(
     type: Optional[type] = ...,
 ) -> Any: ...
 @overload
-@__dataclass_transform__(order_default=True, field_descriptors=(attrib, field))
+@dataclass_transform(order_default=True, field_descriptors=(attrib, field))
 def attrs(
     maybe_cls: _C,
     these: Optional[Dict[str, Any]] = ...,
@@ -350,7 +337,7 @@ def attrs(
     unsafe_hash: Optional[bool] = ...,
 ) -> _C: ...
 @overload
-@__dataclass_transform__(order_default=True, field_descriptors=(attrib, field))
+@dataclass_transform(order_default=True, field_descriptors=(attrib, field))
 def attrs(
     maybe_cls: None = ...,
     these: Optional[Dict[str, Any]] = ...,
@@ -378,7 +365,7 @@ def attrs(
     unsafe_hash: Optional[bool] = ...,
 ) -> Callable[[_C], _C]: ...
 @overload
-@__dataclass_transform__(field_descriptors=(attrib, field))
+@dataclass_transform(field_descriptors=(attrib, field))
 def define(
     maybe_cls: _C,
     *,
@@ -404,7 +391,7 @@ def define(
     match_args: bool = ...,
 ) -> _C: ...
 @overload
-@__dataclass_transform__(field_descriptors=(attrib, field))
+@dataclass_transform(field_descriptors=(attrib, field))
 def define(
     maybe_cls: None = ...,
     *,
@@ -433,7 +420,7 @@ def define(
 mutable = define
 
 @overload
-@__dataclass_transform__(
+@dataclass_transform(
     frozen_default=True, field_descriptors=(attrib, field)
 )
 def frozen(
@@ -461,7 +448,7 @@ def frozen(
     match_args: bool = ...,
 ) -> _C: ...
 @overload
-@__dataclass_transform__(
+@dataclass_transform(
     frozen_default=True, field_descriptors=(attrib, field)
 )
 def frozen(

--- a/tests/test_pyright.py
+++ b/tests/test_pyright.py
@@ -41,7 +41,7 @@ def parse_pyright_output(test_file: Path) -> set[PyrightDiagnostic]:
 
 def test_pyright_baseline():
     """
-    The typing.dataclass_transform() decorator allows pyright to determine
+    The typing.dataclass_transform decorator allows pyright to determine
     attrs decorated class types.
     """
 

--- a/tests/test_pyright.py
+++ b/tests/test_pyright.py
@@ -41,8 +41,8 @@ def parse_pyright_output(test_file: Path) -> set[PyrightDiagnostic]:
 
 def test_pyright_baseline():
     """
-    The __dataclass_transform__ decorator allows pyright to determine attrs
-    decorated class types.
+    The typing.dataclass_transform() decorator allows pyright to determine
+    attrs decorated class types.
     """
 
     test_file = Path(__file__).parent / "dataclass_transform_example.py"


### PR DESCRIPTION
# Summary

This PR replaces the non-standard `__dataclass_transform__()` in type stubs with `typing.dataclass_transform()`, introduced in [PEP-681](https://peps.python.org/pep-0681/).

The only difference between the two decorators is the naming of one parameter: `field_descriptors=` in `__dataclass_transform__()` is now `field_specifiers=`.

# Pull Request Check List

- [ ] Added **tests** for changed code.
  Our CI fails if coverage is not 100%.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [ ] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [ ] ...and used in the stub test file `tests/typing_example.py`.
    - [ ] If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          The next version is the second number in the current release + 1.
          The first number represents the current year.
          So if the current version on PyPI is 22.2.0, the next version is gonna be 22.3.0.
          If the next version is the first in the new year, it'll be 23.1.0.
- [ ] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
- [ ] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.
