### PR TITLE
Update examples.md

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -498,7 +498,7 @@ If you're the author of a third-party library with *attrs* integration, please s
 
 ## Types
 
-*attrs* also allows you to associate a type with an attribute using either the *type* argument to {func}`attr.ib` and {func}`attr.field` or using {pep}`526`-annotations:
+*attrs* also allows you to associate a type with an attribute using either the *type* argument to using {pep}`526`-annotations or {func}`attrs.ib` and {func}`attrs.field`:
 
 ```{doctest}
 >>> @define
@@ -588,6 +588,11 @@ However it's useful for writing your own validators or serialization frameworks.
 Defining `__slots__` by hand is tedious, in *attrs* it's just a matter of using {func}`attrs.define` or passing `slots=True` to {func}`attr.s`:
 
 ```{doctest}
+>>> @define
+... class Coordinates:
+...     x: int
+...     y: int
+
 >>> import attr
 
 >>> @attr.s(slots=True)
@@ -662,7 +667,7 @@ True
 <class 'int'>
 ```
 
-You can still have power over the attributes if you pass a dictionary of name: {func}`~attrs.field` mappings and can pass arguments to `@attr.s`:
+You can still have power over the attributes if you pass a dictionary of name: {func}`~attrs.field` mappings and can pass arguments to `@attrs.define`:
 
 ```{doctest}
 >>> C = make_class("C", {"x": field(default=42),

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -498,7 +498,7 @@ If you're the author of a third-party library with *attrs* integration, please s
 
 ## Types
 
-*attrs* also allows you to associate a type with an attribute using either the *type* argument to using {pep}`526`-annotations or {func}`attrs.ib` and {func}`attrs.field`:
+*attrs* also allows you to associate a type with an attribute using either the *type* argument to using {pep}`526`-annotations or {func}`attrs.field`/{func}`attr.ib`:
 
 ```{doctest}
 >>> @define

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -667,7 +667,7 @@ True
 <class 'int'>
 ```
 
-You can still have power over the attributes if you pass a dictionary of name: {func}`~attrs.field` mappings and can pass arguments to `@attrs.define`:
+You can still have power over the attributes if you pass a dictionary of name: {func}`~attrs.field` mappings and can pass the same arguments as you can to `@attrs.define`:
 
 ```{doctest}
 >>> C = make_class("C", {"x": field(default=42),

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -587,7 +587,7 @@ class TestAnnotations:
         @attr.s(slots=slots, auto_attribs=True)
         class A:
             a: "A"
-            b: typing.Optional["A"]  # : will resolve below
+            b: typing.Optional["A"]  # noqa : will resolve below
 
         attr.resolve_types(A, globals(), locals())
 
@@ -601,7 +601,7 @@ class TestAnnotations:
 
         @attr.s(slots=slots, auto_attribs=True)
         class A:
-            a: typing.List["B"]  # : will resolve below
+            a: typing.List["B"]  # noqa : will resolve below
 
         @attr.s(slots=slots, auto_attribs=True)
         class B:

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -587,7 +587,7 @@ class TestAnnotations:
         @attr.s(slots=slots, auto_attribs=True)
         class A:
             a: "A"
-            b: typing.Optional["A"]  # noqa: will resolve below
+            b: typing.Optional["A"]  # : will resolve below
 
         attr.resolve_types(A, globals(), locals())
 
@@ -601,7 +601,7 @@ class TestAnnotations:
 
         @attr.s(slots=slots, auto_attribs=True)
         class A:
-            a: typing.List["B"]  # noqa: will resolve below
+            a: typing.List["B"]  # : will resolve below
 
         @attr.s(slots=slots, auto_attribs=True)
         class B:

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -587,7 +587,7 @@ class TestAnnotations:
         @attr.s(slots=slots, auto_attribs=True)
         class A:
             a: "A"
-            b: typing.Optional["A"]  # noqa : will resolve below
+            b: typing.Optional["A"]  # noqa: will resolve below
 
         attr.resolve_types(A, globals(), locals())
 
@@ -601,7 +601,7 @@ class TestAnnotations:
 
         @attr.s(slots=slots, auto_attribs=True)
         class A:
-            a: typing.List["B"]  # noqa : will resolve below
+            a: typing.List["B"]  # noqa: will resolve below
 
         @attr.s(slots=slots, auto_attribs=True)
         class B:


### PR DESCRIPTION
# Summary

<!-- Please tell us what your pull request is about here. -->

Changing order type annotations to fit code
Added attrs.define implementation to slots category

This is to fix the docs problems mentioned in #1162. There is still one line that I think is confusing, line 670:
> You can still have power over the attributes if you pass a dictionary of name: {func}`~attrs.field` mappings and can pass arguments to `@attrs.define`:

# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/python-attrs/attrs/blob/main/.github/CONTRIBUTING.md) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.
-->

- [ ] Added **tests** for changed code.
  Our CI fails if coverage is not 100%.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [ ] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [ ] ...and used in the stub test file `tests/typing_example.py`.
    - [ ] If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          The next version is the second number in the current release + 1.
          The first number represents the current year.
          So if the current version on PyPI is 22.2.0, the next version is gonna be 22.3.0.
          If the next version is the first in the new year, it'll be 23.1.0.
- [ ] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
- [ ] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
