### PR TITLE
Fix TypeError for `asdict(<class with namedtuple>, retain_collection_types=True)`

### DIFF
--- a/changelog.d/1165.change.md
+++ b/changelog.d/1165.change.md
@@ -1,0 +1,1 @@
+Fixed `TypeError` when `asdict` is called for classes that have a `namedtuple` field with parameter `retain_collection_types=True`.

--- a/changelog.d/1165.change.md
+++ b/changelog.d/1165.change.md
@@ -1,1 +1,1 @@
-Fixed `TypeError` when `asdict` is called for classes that have a `namedtuple` field with parameter `retain_collection_types=True`.
+Fixed `TypeError` when `asdict`/`astuple` is called for classes that have a `namedtuple` field with parameter `retain_collection_types=True`.

--- a/changelog.d/1165.change.md
+++ b/changelog.d/1165.change.md
@@ -1,1 +1,1 @@
-Fixed `TypeError` when `asdict`/`astuple` is called for classes that have a `namedtuple` field with parameter `retain_collection_types=True`.
+Fixed serialization of namedtuple fields using `attrs.asdict/astuple()` with `retain_collection_types=True`.

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -10,7 +10,9 @@ from ._make import NOTHING, _obj_setattr, fields
 from .exceptions import AttrsAttributeNotFoundError
 
 
-def _is_namedtuple(obj, /, _namedtuple_dir=frozenset(dir(namedtuple('_sentinel', [])))):
+def _is_namedtuple(
+    obj, /, _namedtuple_dir=frozenset(dir(namedtuple("_sentinel", [])))
+):
     """
     Check that object is namedtuple.
     """

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -83,12 +83,14 @@ def asdict(
                     )
                     for i in v
                 ]
-                if issubclass(cf, tuple):
+                try:
+                    rv[a.name] = cf(items)
+                except TypeError:
+                    if not issubclass(cf, tuple):
+                        raise
                     # Workaround for TypeError: cf.__new__() missing 1 required
                     # positional argument (which appears, for a namedturle)
                     rv[a.name] = cf(*items)
-                else:
-                    rv[a.name] = cf(items)
             elif isinstance(v, dict):
                 df = dict_factory
                 rv[a.name] = df(
@@ -257,12 +259,14 @@ def astuple(
                     else j
                     for j in v
                 ]
-                if issubclass(cf, tuple):
+                try:
+                    rv.append(cf(items))
+                except TypeError:
+                    if not issubclass(cf, tuple):
+                        raise
                     # Workaround for TypeError: cf.__new__() missing 1 required
                     # positional argument (which appears, for a namedturle)
                     rv.append(cf(*items))
-                else:
-                    rv.append(cf(items))
             elif isinstance(v, dict):
                 df = v.__class__ if retain is True else dict
                 rv.append(

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -245,22 +245,24 @@ def astuple(
                 )
             elif isinstance(v, (tuple, list, set, frozenset)):
                 cf = v.__class__ if retain is True else list
-                rv.append(
-                    cf(
-                        [
-                            astuple(
-                                j,
-                                recurse=True,
-                                filter=filter,
-                                tuple_factory=tuple_factory,
-                                retain_collection_types=retain,
-                            )
-                            if has(j.__class__)
-                            else j
-                            for j in v
-                        ]
+                items = [
+                    astuple(
+                        j,
+                        recurse=True,
+                        filter=filter,
+                        tuple_factory=tuple_factory,
+                        retain_collection_types=retain,
                     )
-                )
+                    if has(j.__class__)
+                    else j
+                    for j in v
+                ]
+                try:
+                    rv.append(cf(items))
+                except TypeError:
+                    # Workaround for TypeError: cf.__new__() missing 1 required
+                    # positional argument (which appears, for a namedturle)
+                    rv.append(cf(*items))
             elif isinstance(v, dict):
                 df = v.__class__ if retain is True else dict
                 rv.append(

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -87,7 +87,7 @@ def asdict(
                     rv[a.name] = cf(items)
                 except TypeError:
                     if not issubclass(cf, tuple):
-                        raise
+                        raise  # pragma: no cover
                     # Workaround for TypeError: cf.__new__() missing 1 required
                     # positional argument (which appears, for a namedturle)
                     rv[a.name] = cf(*items)
@@ -263,7 +263,7 @@ def astuple(
                     rv.append(cf(items))
                 except TypeError:
                     if not issubclass(cf, tuple):
-                        raise
+                        raise  # pragma: no cover
                     # Workaround for TypeError: cf.__new__() missing 1 required
                     # positional argument (which appears, for a namedturle)
                     rv.append(cf(*items))

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -87,7 +87,7 @@ def asdict(
                     rv[a.name] = cf(items)
                 except TypeError:
                     if not issubclass(cf, tuple):
-                        raise  # pragma: no cover
+                        raise
                     # Workaround for TypeError: cf.__new__() missing 1 required
                     # positional argument (which appears, for a namedturle)
                     rv[a.name] = cf(*items)
@@ -263,7 +263,7 @@ def astuple(
                     rv.append(cf(items))
                 except TypeError:
                     if not issubclass(cf, tuple):
-                        raise  # pragma: no cover
+                        raise
                     # Workaround for TypeError: cf.__new__() missing 1 required
                     # positional argument (which appears, for a namedturle)
                     rv.append(cf(*items))

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -10,9 +10,10 @@ from ._make import NOTHING, _obj_setattr, fields
 from .exceptions import AttrsAttributeNotFoundError
 
 
-def _is_namedtuple(
-    obj, /, _namedtuple_dir=frozenset(dir(namedtuple("_sentinel", [])))
-):
+_namedtuple_dir = frozenset(dir(namedtuple("_sentinel", [])))
+
+
+def _is_namedtuple(obj):
     """
     Check that object is namedtuple.
     """

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -72,19 +72,21 @@ def asdict(
                 )
             elif isinstance(v, (tuple, list, set, frozenset)):
                 cf = v.__class__ if retain_collection_types is True else list
-                rv[a.name] = cf(
-                    [
-                        _asdict_anything(
-                            i,
-                            is_key=False,
-                            filter=filter,
-                            dict_factory=dict_factory,
-                            retain_collection_types=retain_collection_types,
-                            value_serializer=value_serializer,
-                        )
-                        for i in v
-                    ]
-                )
+                items = [
+                    _asdict_anything(
+                        i,
+                        is_key=False,
+                        filter=filter,
+                        dict_factory=dict_factory,
+                        retain_collection_types=retain_collection_types,
+                        value_serializer=value_serializer,
+                    )
+                    for i in v
+                ]
+                try:
+                    rv[a.name] = cf(items)
+                except TypeError:
+                    rv[a.name] = cf(*items)
             elif isinstance(v, dict):
                 df = dict_factory
                 rv[a.name] = df(

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -3,23 +3,9 @@
 
 import copy
 
-from collections import namedtuple
-
 from ._compat import PY_3_9_PLUS, get_generic_base
 from ._make import NOTHING, _obj_setattr, fields
 from .exceptions import AttrsAttributeNotFoundError
-
-
-_namedtuple_dir = frozenset(dir(namedtuple("_sentinel", [])))
-
-
-def _is_namedtuple(obj):
-    """
-    Check that object is namedtuple.
-    """
-    if isinstance(obj, tuple):
-        return set(dir(obj.__class__)) >= _namedtuple_dir
-    return False
 
 
 def asdict(
@@ -97,7 +83,7 @@ def asdict(
                     )
                     for i in v
                 ]
-                if _is_namedtuple(v):
+                if issubclass(cf, tuple):
                     # Workaround for TypeError: cf.__new__() missing 1 required
                     # positional argument (which appears, for a namedturle)
                     rv[a.name] = cf(*items)
@@ -271,7 +257,7 @@ def astuple(
                     else j
                     for j in v
                 ]
-                if _is_namedtuple(v):
+                if issubclass(cf, tuple):
                     # Workaround for TypeError: cf.__new__() missing 1 required
                     # positional argument (which appears, for a namedturle)
                     rv.append(cf(*items))

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -86,6 +86,8 @@ def asdict(
                 try:
                     rv[a.name] = cf(items)
                 except TypeError:
+                    # Workaround for TypeError: cf.__new__() missing 1 required
+                    # positional argument (which appears, for a namedturle)
                     rv[a.name] = cf(*items)
             elif isinstance(v, dict):
                 df = dict_factory

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -6,7 +6,7 @@ Tests for `attr._funcs`.
 
 
 from collections import OrderedDict
-from typing import Generic, TypeVar
+from typing import Generic, NamedTuple, TypeVar
 
 import pytest
 
@@ -231,6 +231,20 @@ class TestAsDict:
         instance = A({(1,): 1})
 
         assert {"a": {(1,): 1}} == attr.asdict(instance)
+
+    def test_named_tuple_retain_type(self):
+        class Coordinates(NamedTuple):
+            lat: float
+            lon: float
+
+        @attr.s
+        class A:
+            coords: Coordinates = attr.ib()
+
+        instance = A(Coordinates(50.419019, 30.516225))
+        assert {
+            "coords": Coordinates(50.419019, 30.516225)
+        } == attr.asdict(instance, retain_collection_types=True)
 
 
 class TestAsTuple:

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -439,8 +439,7 @@ class TestAsTuple:
 
     def test_named_tuple_retain_type(self):
         """
-        Serailization classes with namedtuple(s)
-         if retain_collection_types is True.
+        Namedtuples can be serialized if retain_collection_types is True.
 
         See #1164
         """

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -234,7 +234,7 @@ class TestAsDict:
 
     def test_named_tuple_retain_type(self):
         """
-        Serailization classes with namedtuple(s)
+        Serialization classes with namedtuple(s)
          if retain_collection_types is True.
 
         See #1164
@@ -252,6 +252,32 @@ class TestAsDict:
         assert {"coords": Coordinates(50.419019, 30.516225)} == attr.asdict(
             instance, retain_collection_types=True
         )
+
+    def test_type_error_with_retain_type(self):
+        """
+        Serialization classes with non-tuple type which raises TypeError
+         if retain_collection_types is True.
+
+        See #1164
+        """
+
+        message = '__new__() missing 1 required positional argument (asdict)'
+
+        class Coordinates(list):
+            def __init__(self, *args):
+                if isinstance(next(iter(args), None), list):
+                    raise TypeError(message)
+                super().__init__(args)
+
+        @attr.s
+        class A:
+            coords: Coordinates = attr.ib()
+
+        instance = A(Coordinates(50.419019, 30.516225))
+        with pytest.raises(TypeError) as ctx:
+            attr.asdict(instance, retain_collection_types=True)
+
+        assert str(ctx.value) == message
 
 
 class TestAsTuple:
@@ -431,6 +457,32 @@ class TestAsTuple:
         assert (Coordinates(50.419019, 30.516225),) == attr.astuple(
             instance, retain_collection_types=True
         )
+
+    def test_type_error_with_retain_type(self):
+        """
+        Serialization classes with non-tuple type which raises TypeError
+         if retain_collection_types is True.
+
+        See #1164
+        """
+
+        message = '__new__() missing 1 required positional argument (astuple)'
+
+        class Coordinates(list):
+            def __init__(self, *args):
+                if isinstance(next(iter(args), None), list):
+                    raise TypeError(message)
+                super().__init__(args)
+
+        @attr.s
+        class A:
+            coords: Coordinates = attr.ib()
+
+        instance = A(Coordinates(50.419019, 30.516225))
+        with pytest.raises(TypeError) as ctx:
+            attr.astuple(instance, retain_collection_types=True)
+
+        assert str(ctx.value) == message
 
 
 class TestHas:

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -454,6 +454,7 @@ class TestAsTuple:
             coords: Coordinates = attr.ib()
 
         instance = A(Coordinates(50.419019, 30.516225))
+
         assert (Coordinates(50.419019, 30.516225),) == attr.astuple(
             instance, retain_collection_types=True
         )

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -233,6 +233,11 @@ class TestAsDict:
         assert {"a": {(1,): 1}} == attr.asdict(instance)
 
     def test_named_tuple_retain_type(self):
+        """
+        Serailization classes with namedtuple(s) if retain_collection_types is True.
+
+        See #1164
+        """
         class Coordinates(NamedTuple):
             lat: float
             lon: float

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -274,10 +274,9 @@ class TestAsDict:
             coords: Coordinates = attr.ib()
 
         instance = A(Coordinates(50.419019, 30.516225))
-        with pytest.raises(TypeError) as ctx:
-            attr.asdict(instance, retain_collection_types=True)
 
-        assert str(ctx.value) == message
+        with pytest.raises(TypeError, match=message):
+            attr.asdict(instance, retain_collection_types=True)
 
 
 class TestAsTuple:

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -479,10 +479,9 @@ class TestAsTuple:
             coords: Coordinates = attr.ib()
 
         instance = A(Coordinates(50.419019, 30.516225))
-        with pytest.raises(TypeError) as ctx:
-            attr.astuple(instance, retain_collection_types=True)
 
-        assert str(ctx.value) == message
+        with pytest.raises(TypeError, match=message):
+            attr.astuple(instance, retain_collection_types=True)
 
 
 class TestHas:

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -411,6 +411,27 @@ class TestAsTuple:
 
         assert (1, [1, 2, 3]) == d
 
+    def test_named_tuple_retain_type(self):
+        """
+        Serailization classes with namedtuple(s)
+         if retain_collection_types is True.
+
+        See #1164
+        """
+
+        class Coordinates(NamedTuple):
+            lat: float
+            lon: float
+
+        @attr.s
+        class A:
+            coords: Coordinates = attr.ib()
+
+        instance = A(Coordinates(50.419019, 30.516225))
+        assert (Coordinates(50.419019, 30.516225),) == attr.astuple(
+            instance, retain_collection_types=True
+        )
+
 
 class TestHas:
     """

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -249,6 +249,7 @@ class TestAsDict:
             coords: Coordinates = attr.ib()
 
         instance = A(Coordinates(50.419019, 30.516225))
+
         assert {"coords": Coordinates(50.419019, 30.516225)} == attr.asdict(
             instance, retain_collection_types=True
         )

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -4,6 +4,7 @@
 Tests for `attr._funcs`.
 """
 
+import re
 
 from collections import OrderedDict
 from typing import Generic, NamedTuple, TypeVar
@@ -275,7 +276,7 @@ class TestAsDict:
 
         instance = A(Coordinates(50.419019, 30.516225))
 
-        with pytest.raises(TypeError, match=message):
+        with pytest.raises(TypeError, match=re.escape(message)):
             attr.asdict(instance, retain_collection_types=True)
 
 
@@ -479,7 +480,7 @@ class TestAsTuple:
 
         instance = A(Coordinates(50.419019, 30.516225))
 
-        with pytest.raises(TypeError, match=message):
+        with pytest.raises(TypeError, match=re.escape(message)):
             attr.astuple(instance, retain_collection_types=True)
 
 

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -242,9 +242,9 @@ class TestAsDict:
             coords: Coordinates = attr.ib()
 
         instance = A(Coordinates(50.419019, 30.516225))
-        assert {
-            "coords": Coordinates(50.419019, 30.516225)
-        } == attr.asdict(instance, retain_collection_types=True)
+        assert {"coords": Coordinates(50.419019, 30.516225)} == attr.asdict(
+            instance, retain_collection_types=True
+        )
 
 
 class TestAsTuple:

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -261,7 +261,7 @@ class TestAsDict:
         See #1164
         """
 
-        message = '__new__() missing 1 required positional argument (asdict)'
+        message = "__new__() missing 1 required positional argument (asdict)"
 
         class Coordinates(list):
             def __init__(self, *args):
@@ -466,7 +466,7 @@ class TestAsTuple:
         See #1164
         """
 
-        message = '__new__() missing 1 required positional argument (astuple)'
+        message = "__new__() missing 1 required positional argument (astuple)"
 
         class Coordinates(list):
             def __init__(self, *args):

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -255,8 +255,8 @@ class TestAsDict:
 
     def test_type_error_with_retain_type(self):
         """
-        Serialization classes with non-tuple type which raises TypeError
-         if retain_collection_types is True.
+        Serialization that fails with TypeError leaves the error through if
+        they're not tuples.
 
         See #1164
         """

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -264,10 +264,10 @@ class TestAsDict:
         message = "__new__() missing 1 required positional argument (asdict)"
 
         class Coordinates(list):
-            def __init__(self, *args):
-                if isinstance(next(iter(args), None), list):
+            def __init__(self, first, *rest):
+                if isinstance(first, list):
                     raise TypeError(message)
-                super().__init__(args)
+                super().__init__([first, *rest])
 
         @attr.s
         class A:
@@ -469,10 +469,10 @@ class TestAsTuple:
         message = "__new__() missing 1 required positional argument (astuple)"
 
         class Coordinates(list):
-            def __init__(self, *args):
-                if isinstance(next(iter(args), None), list):
+            def __init__(self, first, *rest):
+                if isinstance(first, list):
                     raise TypeError(message)
-                super().__init__(args)
+                super().__init__([first, *rest])
 
         @attr.s
         class A:

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -460,8 +460,8 @@ class TestAsTuple:
 
     def test_type_error_with_retain_type(self):
         """
-        Serialization classes with non-tuple type which raises TypeError
-         if retain_collection_types is True.
+        Serialization that fails with TypeError leaves the error through if
+        they're not tuples.
 
         See #1164
         """

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -234,8 +234,7 @@ class TestAsDict:
 
     def test_named_tuple_retain_type(self):
         """
-        Serialization classes with namedtuple(s)
-         if retain_collection_types is True.
+        Namedtuples can be serialized if retain_collection_types is True.
 
         See #1164
         """

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -238,6 +238,7 @@ class TestAsDict:
 
         See #1164
         """
+
         class Coordinates(NamedTuple):
             lat: float
             lon: float

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -234,7 +234,8 @@ class TestAsDict:
 
     def test_named_tuple_retain_type(self):
         """
-        Serailization classes with namedtuple(s) if retain_collection_types is True.
+        Serailization classes with namedtuple(s)
+         if retain_collection_types is True.
 
         See #1164
         """


### PR DESCRIPTION
# Summary

<!-- Please tell us what your pull request is about here. -->


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/python-attrs/attrs/blob/main/.github/CONTRIBUTING.md) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.
-->

- [x] Added **tests** for changed code.
  Our CI fails if coverage is not 100%.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [ ] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [ ] ...and used in the stub test file `tests/typing_example.py`.
    - [ ] If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          The next version is the second number in the current release + 1.
          The first number represents the current year.
          So if the current version on PyPI is 22.2.0, the next version is gonna be 22.3.0.
          If the next version is the first in the new year, it'll be 23.1.0.
- [ ] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->

Resolves #1164 