### PR TITLE
CI: Only attempt publish for upstream

### DIFF
--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -33,7 +33,7 @@ jobs:
   release-test-pypi:
     name: Publish in-dev package to test.pypi.org
     environment: release-test-pypi
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.repository_owner == 'python-attrs' && github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: build-package
 
@@ -53,7 +53,7 @@ jobs:
   release-pypi:
     name: Publish released package to pypi.org
     environment: release-pypi
-    if: github.event.action == 'published'
+    if: github.repository_owner == 'python-attrs' && github.event.action == 'published'
     runs-on: ubuntu-latest
     needs: build-package
 


### PR DESCRIPTION
# Summary

<!-- Please tell us what your pull request is about here. -->

When updating my fork with upstream, the CI runs `pypi-package.yml`. 

It's good to run the "Build & verify package" job for forks.

But there's no point running the [Test] PyPI upload jobs, because they'll fail because they don't have the credentials set up -- and we wouldn't want to upload from forks anyway.

<img width="601" alt="image" src="https://github.com/python-attrs/attrs/assets/1324225/20678a74-da3c-4a0f-a17d-b0871d5ef700">

```
Error: Trusted publishing exchange failure: 
Token request failed: the server refused the request for the following reasons:

* `invalid-publisher`: valid token, but no corresponding publisher (All lookup strategies exhausted)

This generally indicates a trusted publisher configuration error, but could
also indicate an internal error on GitHub or PyPI's part.
```

https://github.com/hugovk/attrs/actions/runs/5916632350/job/16044128992

So let's only attempt to publish for the upstream repo:

<img width="615" alt="image" src="https://github.com/python-attrs/attrs/assets/1324225/b9619388-2f9e-4efc-b678-ad54a6030075">

https://github.com/hugovk/attrs/actions/runs/5916665345

I went for symmetry, but we could probably just do this for `release-test-pypi`, because it's unlikely a fork will trigger `github.event.action == 'published'` for `release-pypi`?


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/python-attrs/attrs/blob/main/.github/CONTRIBUTING.md) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.
-->

- [n/a] Added **tests** for changed code.
  Our CI fails if coverage is not 100%.
- [n/a] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [n/a] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [ ] ...and used in the stub test file `tests/typing_example.py`.
    - [ ] If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [n/a] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          The next version is the second number in the current release + 1.
          The first number represents the current year.
          So if the current version on PyPI is 22.2.0, the next version is gonna be 22.3.0.
          If the next version is the first in the new year, it'll be 23.1.0.
- [n/a] Documentation in `.rst` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
