### PR TITLE
Fix typo in src/attr/_next_gen.py::define's docstring

### DIFF
--- a/src/attr/_next_gen.py
+++ b/src/attr/_next_gen.py
@@ -59,7 +59,7 @@ def define(
       .. caution::
 
          Usually this has only upsides and few visible effects in everyday
-         programming. But it *can* lead to some suprising behaviors, so please
+         programming. But it *can* lead to some surprising behaviors, so please
          make sure to read :term:`slotted classes`.
     - *auto_exc=True*
     - *auto_detect=True*


### PR DESCRIPTION
Change "suprising" to "su**r**prising".