### PR TITLE
Move conditional clause to beginning for validator/converter docs. 

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -447,7 +447,8 @@ Traceback (most recent call last):
 TypeError: ("'x' must be <type 'int'> (got '42' that is a <type 'str'>).", Attribute(name='x', default=NOTHING, factory=NOTHING, validator=<instance_of validator for type <type 'int'>>, type=None, kw_only=False), <type 'int'>, '42')
 ```
 
-Please note that if you use {func}`attr.s` (and **not** {func}`attrs.define`) to define your class, validators only run on initialization by default -- not when you set an attribute.
+If using the old-school {func}`attr.s` decorator, validators only run on initialization by default.
+If using the newer {func}`attrs.define` and friends, validators run on initialization *and* on attribute setting.
 This behavior can be changed using the *on_setattr* argument.
 
 Check out {ref}`validators` for more details.
@@ -465,10 +466,13 @@ This can be useful for doing type-conversions on values that you don't want to f
 >>> o = C("1")
 >>> o.x
 1
+>>> o.x = "2"
+>>> o.x
+2
 ```
 
-Please note that converters only run on initialization when using the old-school {func}`attr.s` decorator.
-They do run by default with {func}`attrs.define` and friends.
+If using the old-school {func}`attr.s` decorator, converters only run on initialization by default.
+If using the newer {func}`attrs.define` and friends, converters run on initialization *and* on attribute setting.
 This behavior can be changed using the *on_setattr* argument.
 
 Check out {ref}`converters` for more details.

--- a/docs/init.md
+++ b/docs/init.md
@@ -307,6 +307,9 @@ This can be useful for doing type-conversions on values that you don't want to f
 >>> o = C("1")
 >>> o.x
 1
+>>> o.x = "2"
+>>> o.x
+2
 ```
 
 Converters are run *before* validators, so you can use validators to check the final form of the value.


### PR DESCRIPTION


# Summary

* Minor update to the validator/converter docs to more clearly convey information.
* Provide converter example.

This may seem trivial, but some people stop reading after:
> Please note that converters only run on initialization

# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/python-attrs/attrs/blob/main/.github/CONTRIBUTING.md) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.
-->

- [X] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [X] Added **tests** for changed code.
  Our CI fails if coverage is not 100%.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [X] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [X] ...and used in the stub test file `tests/typing_example.py`.
    - [X] If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [X] Updated **documentation** for changed code.
    - [X] New functions/classes have to be added to `docs/api.rst` by hand.
    - [X] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [X] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          The next version is the second number in the current release + 1.
          The first number represents the current year.
          So if the current version on PyPI is 22.2.0, the next version is gonna be 22.3.0.
          If the next version is the first in the new year, it'll be 23.1.0.
- [X] Documentation in `.rst` and `.md` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [X] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
- [X] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
