### PR TITLE
Fix ruff config namespace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,7 @@ toplevel = ["attr", "attrs"]
 [tool.ruff]
 src = ["src", "tests", "conftest.py", "docs"]
 
-[tool.lint.ruff]
+[tool.ruff.lint]
 select = ["ALL"]
 ignore = [
   "A001",    # shadowing is fine


### PR DESCRIPTION
`[tool.lint....]` isn't anything 😄 Should be `[tool.ruff.lint]` according to ruff's [docs](https://docs.astral.sh/ruff/configuration/). Hope this doesn't break anything 🤞🏻 