### PR TITLE
Fixes tox command for watching docs in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -104,7 +104,7 @@ You can *significantly* speed up the test suite by passing `-n auto` to *pytest*
 For documentation, you can use:
 
 ```console
-$ tox run -e docs-serve
+$ tox run -e docs-watch
 ```
 
 This will build the documentation, and then watch for changes and rebuild it whenever you save a file.


### PR DESCRIPTION
# Summary

The tox command in CONTRIBUTING.md referred to a tox environment `docs-serve` that no longer exists in the tox.ini.

The tox command in CONTRIBUTING.md was modified to refer to `docs-watch` instead.
