### PR TITLE
Modifies sentence and provides link to explanation of mutable defaults gotcha in the documentation

### DIFF
--- a/docs/init.md
+++ b/docs/init.md
@@ -122,7 +122,7 @@ C(a=42, b=[], c=[], d={})
 
 It's important that the decorated method -- or any other method or property! -- doesn't have the same name as the attribute, otherwise it would overwrite the attribute definition.
 
-Please note that as with function and method signatures, `default=[]` will *not* do what you may think it might do:
+Similar to the [common gotcha with mutable default arguments](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments), `default=[]` will *not* do what you may think it might do:
 
 ```{doctest}
 >>> @define


### PR DESCRIPTION
# Summary

Modifies existing sentence and provides link to an explanation of the common gotcha of mutable default parameters for functions/methods. The change occurs on the "Initialization" page (`init.html`/`init.md`) of the documentation.

The change adds a link is to [this section](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments) on [python-guide.org](https://docs.python-guide.org/). I have no connection to [python-guide.org](https://docs.python-guide.org/) — I just like their explanation and would be happy to change it, if you have a better replacement in mind.

# Justification

The documentation already states that mutable default arguments (probably) don't work as expected and *alludes* to similar gotcha with function/method parameters. I think it could be helpful to provide link to an simple explanation to understand the connection the two situations.

There are many other precedents in the documentation for providing helpful links, for example, "Subclassing considered bad" and "think twice before using pickle"... and this is something that makes me really appreciate `attrs` documentation.

# Pull Request Check List

- [X] Documentation in `.rst` and `.md` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
