### PR TITLE
Fix test_ne in test_cmp.py for Python 3.13

### DIFF
--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -14,6 +14,7 @@ PY_3_8_PLUS = sys.version_info[:2] >= (3, 8)
 PY_3_9_PLUS = sys.version_info[:2] >= (3, 9)
 PY310 = sys.version_info[:2] >= (3, 10)
 PY_3_12_PLUS = sys.version_info[:2] >= (3, 12)
+PY_3_13_PLUS = sys.version_info[:2] >= (3, 13)
 
 
 if sys.version_info < (3, 8):

--- a/tests/test_cmp.py
+++ b/tests/test_cmp.py
@@ -328,7 +328,7 @@ class TestDundersUnnamedClass:
         method = self.cls.__ne__
         assert method.__doc__.strip() == (
             "Check equality and either forward a NotImplemented or\n"
-           f"{indent}return the result negated."
+            f"{indent}return the result negated."
         )
         assert method.__name__ == "__ne__"
 
@@ -396,7 +396,7 @@ class TestDundersPartialOrdering:
         method = self.cls.__ne__
         assert method.__doc__.strip() == (
             "Check equality and either forward a NotImplemented or\n"
-           f"{indent}return the result negated."
+            f"{indent}return the result negated."
         )
         assert method.__name__ == "__ne__"
 

--- a/tests/test_cmp.py
+++ b/tests/test_cmp.py
@@ -4,10 +4,10 @@
 Tests for methods from `attrib._cmp`.
 """
 
-
 import pytest
 
 from attr._cmp import cmp_using
+from attr._compat import PY_3_13_PLUS
 
 
 # Test parameters.
@@ -53,6 +53,9 @@ order_ids = [c[0].__name__ for c in order_data]
 
 cmp_data = eq_data + order_data
 cmp_ids = eq_ids + order_ids
+
+# Compiler strips indents from docstrings in Python 3.13+
+indent = "" if PY_3_13_PLUS else " " * 8
 
 
 class TestEqOrder:
@@ -325,7 +328,7 @@ class TestDundersUnnamedClass:
         method = self.cls.__ne__
         assert method.__doc__.strip() == (
             "Check equality and either forward a NotImplemented or\n"
-            "        return the result negated."
+           f"{indent}return the result negated."
         )
         assert method.__name__ == "__ne__"
 
@@ -393,7 +396,7 @@ class TestDundersPartialOrdering:
         method = self.cls.__ne__
         assert method.__doc__.strip() == (
             "Check equality and either forward a NotImplemented or\n"
-            "        return the result negated."
+           f"{indent}return the result negated."
         )
         assert method.__name__ == "__ne__"
 
@@ -465,7 +468,7 @@ class TestDundersFullOrdering:
         method = self.cls.__ne__
         assert method.__doc__.strip() == (
             "Check equality and either forward a NotImplemented or\n"
-            "        return the result negated."
+            f"{indent}return the result negated."
         )
         assert method.__name__ == "__ne__"
 


### PR DESCRIPTION
# Summary

Compiler in Python 3.13+ strips indents from docstrings so they need to be compared without it for new Pythons.

Tested with 3.13.0a4

Fixes: https://github.com/python-attrs/attrs/issues/1228

# Pull Request Check List

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [ ] Added **tests** for changed code.
  Our CI fails if coverage is not 100%.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [ ] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [ ] ...and used in the stub test file `tests/typing_example.py`.
    - [ ] If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          The next version is the second number in the current release + 1.
          The first number represents the current year.
          So if the current version on PyPI is 22.2.0, the next version is gonna be 22.3.0.
          If the next version is the first in the new year, it'll be 23.1.0.
- [ ] Documentation in `.rst` and `.md` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
- [ ] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

