### PR TITLE
Fix broken link from attr API reference back to attrs

### DIFF
--- a/docs/api-attr.rst
+++ b/docs/api-attr.rst
@@ -136,7 +136,7 @@ Helpers
 
 .. function:: fields_dict
 
-   Same as `attr.fields_dict`.
+   Same as `attrs.fields_dict`.
 
 .. function:: has
 


### PR DESCRIPTION
# Summary

`attr.fields_dict` was a link back to itself. The intention, like all the other nearby aliases, was to refer back to the version in `attrs` for the full story.

# Pull Request Check List

Omitted for trivial documentation change.