### PR TITLE
drop python<=37 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,13 +9,12 @@ build-backend = "hatchling.build"
 name = "attrs"
 authors = [{ name = "Hynek Schlawack", email = "hs@ox.cx" }]
 license = "MIT"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 description = "Classes Without Boilerplate"
 keywords = ["class", "attribute", "boilerplate"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "License :: OSI Approved :: MIT License",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",

--- a/src/attr/__init__.py
+++ b/src/attr/__init__.py
@@ -98,10 +98,7 @@ def _make_getattr(mod_name: str) -> Callable:
         import sys
         import warnings
 
-        if sys.version_info < (3, 8):
-            from importlib_metadata import metadata
-        else:
-            from importlib.metadata import metadata
+        from importlib.metadata import metadata
 
         if name not in ("__version__", "__version_info__"):
             warnings.warn(

--- a/src/attr/_compat.py
+++ b/src/attr/_compat.py
@@ -17,13 +17,7 @@ PY_3_12_PLUS = sys.version_info[:2] >= (3, 12)
 PY_3_13_PLUS = sys.version_info[:2] >= (3, 13)
 
 
-if sys.version_info < (3, 8):
-    try:
-        from typing_extensions import Protocol
-    except ImportError:  # pragma: no cover
-        Protocol = object
-else:
-    from typing import Protocol  # noqa: F401
+from typing import Protocol  # noqa: F401
 
 
 class _AnnotationExtractor:

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -2230,7 +2230,9 @@ def _assign_with_converter(attr_name, value_var, has_on_setattr):
     if has_on_setattr:
         return _setattr_with_converter(attr_name, value_var, True)
 
-    return f"self.{attr_name} = {_INIT_CONVERTER_PAT % (attr_name,)}({value_var})"
+    return (
+        f"self.{attr_name} = {_INIT_CONVERTER_PAT % (attr_name,)}({value_var})"
+    )
 
 
 def _determine_setters(frozen, slots, base_attr_map):

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1979,9 +1979,9 @@ def _make_repr(attrs, ns, cls):
             "self." + name if i else 'getattr(self, "' + name + '", NOTHING)'
         )
         fragment = (
-            "{}={{{}!r}}".format(name, accessor)
+            f"{name}={{{accessor}!r}}"
             if r == repr
-            else "{}={{{}_repr({})}}".format(name, name, accessor)
+            else f"{name}={{{name}_repr({accessor})}}"
         )
         attribute_fragments.append(fragment)
     repr_fragment = ", ".join(attribute_fragments)
@@ -2208,11 +2208,7 @@ def _setattr_with_converter(attr_name, value_var, has_on_setattr):
     Use the cached object.setattr to set *attr_name* to *value_var*, but run
     its converter first.
     """
-    return "_setattr('{}', {}({}))".format(
-        attr_name,
-        _INIT_CONVERTER_PAT % (attr_name,),
-        value_var,
-    )
+    return f"_setattr('{attr_name}', {_INIT_CONVERTER_PAT % (attr_name,)}({value_var}))"
 
 
 def _assign(attr_name, value, has_on_setattr):
@@ -2234,11 +2230,7 @@ def _assign_with_converter(attr_name, value_var, has_on_setattr):
     if has_on_setattr:
         return _setattr_with_converter(attr_name, value_var, True)
 
-    return "self.{} = {}({})".format(
-        attr_name,
-        _INIT_CONVERTER_PAT % (attr_name,),
-        value_var,
-    )
+    return f"self.{attr_name} = {_INIT_CONVERTER_PAT % (attr_name,)}({value_var})"
 
 
 def _determine_setters(frozen, slots, base_attr_map):
@@ -2267,11 +2259,7 @@ def _determine_setters(frozen, slots, base_attr_map):
                     attr_name, value_var, has_on_setattr
                 )
 
-            return "_inst_dict['{}'] = {}({})".format(
-                attr_name,
-                _INIT_CONVERTER_PAT % (attr_name,),
-                value_var,
-            )
+            return f"_inst_dict['{attr_name}'] = {_INIT_CONVERTER_PAT % (attr_name,)}({value_var})"
 
         return (
             ("_inst_dict = self.__dict__",),
@@ -2519,7 +2507,7 @@ def _attrs_to_init_script(
             ", ".join(kw_only_args),  # kw_only args
         )
         pre_init_kw_only_args = ", ".join(
-            ["{}={}".format(kw_arg, kw_arg) for kw_arg in kw_only_args]
+            [f"{kw_arg}={kw_arg}" for kw_arg in kw_only_args]
         )
         pre_init_args += (
             ", " if pre_init_args else ""

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1979,9 +1979,9 @@ def _make_repr(attrs, ns, cls):
             "self." + name if i else 'getattr(self, "' + name + '", NOTHING)'
         )
         fragment = (
-            "%s={%s!r}" % (name, accessor)
+            "{}={{{}!r}}".format(name, accessor)
             if r == repr
-            else "%s={%s_repr(%s)}" % (name, name, accessor)
+            else "{}={{{}_repr({})}}".format(name, name, accessor)
         )
         attribute_fragments.append(fragment)
     repr_fragment = ", ".join(attribute_fragments)
@@ -2208,7 +2208,7 @@ def _setattr_with_converter(attr_name, value_var, has_on_setattr):
     Use the cached object.setattr to set *attr_name* to *value_var*, but run
     its converter first.
     """
-    return "_setattr('%s', %s(%s))" % (
+    return "_setattr('{}', {}({}))".format(
         attr_name,
         _INIT_CONVERTER_PAT % (attr_name,),
         value_var,
@@ -2234,7 +2234,7 @@ def _assign_with_converter(attr_name, value_var, has_on_setattr):
     if has_on_setattr:
         return _setattr_with_converter(attr_name, value_var, True)
 
-    return "self.%s = %s(%s)" % (
+    return "self.{} = {}({})".format(
         attr_name,
         _INIT_CONVERTER_PAT % (attr_name,),
         value_var,
@@ -2267,7 +2267,7 @@ def _determine_setters(frozen, slots, base_attr_map):
                     attr_name, value_var, has_on_setattr
                 )
 
-            return "_inst_dict['%s'] = %s(%s)" % (
+            return "_inst_dict['{}'] = {}({})".format(
                 attr_name,
                 _INIT_CONVERTER_PAT % (attr_name,),
                 value_var,
@@ -2514,12 +2514,12 @@ def _attrs_to_init_script(
     args = ", ".join(args)
     pre_init_args = args
     if kw_only_args:
-        args += "%s*, %s" % (
+        args += "{}*, {}".format(
             ", " if args else "",  # leading comma
             ", ".join(kw_only_args),  # kw_only args
         )
         pre_init_kw_only_args = ", ".join(
-            ["%s=%s" % (kw_arg, kw_arg) for kw_arg in kw_only_args]
+            ["{}={}".format(kw_arg, kw_arg) for kw_arg in kw_only_args]
         )
         pre_init_args += (
             ", " if pre_init_args else ""

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,14 +1,12 @@
 # SPDX-License-Identifier: MIT
 
-import sys
+
+from importlib import metadata
 
 import pytest
 
 import attr
 import attrs
-
-
-from importlib import metadata
 
 
 @pytest.fixture(name="mod", params=(attr, attrs))

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -8,10 +8,7 @@ import attr
 import attrs
 
 
-if sys.version_info < (3, 8):
-    import importlib_metadata as metadata
-else:
-    from importlib import metadata
+from importlib import metadata
 
 
 @pytest.fixture(name="mod", params=(attr, attrs))

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -597,7 +597,7 @@ def test_slots_empty_cell():
         field = attr.ib()
 
         def f(self, a):
-            super(C, self).__init__()  # noqa: UP008
+            super().__init__()  # noqa: UP008
 
     C(field=1)
 
@@ -685,7 +685,7 @@ def test_slots_super_property_get():
     class C(A):
         @property
         def f(self):
-            return super(C, self).f ** 2  # noqa: UP008
+            return super().f ** 2  # noqa: UP008
 
     assert B(11).f == 121
     assert B(17).f == 289

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -597,7 +597,7 @@ def test_slots_empty_cell():
         field = attr.ib()
 
         def f(self, a):
-            super().__init__()  # noqa: UP008
+            super().__init__()
 
     C(field=1)
 
@@ -685,7 +685,7 @@ def test_slots_super_property_get():
     class C(A):
         @property
         def f(self):
-            return super().f ** 2  # noqa: UP008
+            return super().f ** 2
 
     assert B(11).f == 121
     assert B(17).f == 289

--- a/tests/typing_example.py
+++ b/tests/typing_example.py
@@ -56,7 +56,7 @@ class DD:
 
 @attr.s
 class EE:
-    y: "list[int]" = attr.ib()
+    y: list[int] = attr.ib()
 
 
 @attr.s


### PR DESCRIPTION
# Summary
Python 3.7 has been EOSed at 27 Jun 2023 (https://endoflife.date/python)
Filter all code over `pyupgrade --py38'.

<!-- Please tell us what your pull request is about here. -->


# Pull Request Check List
- [ ] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [ ] Added **tests** for changed code.
  Our CI fails if coverage is not 100%.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [ ] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [ ] ...and used in the stub test file `tests/typing_example.py`.
    - [ ] If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          The next version is the second number in the current release + 1.
          The first number represents the current year.
          So if the current version on PyPI is 22.2.0, the next version is gonna be 22.3.0.
          If the next version is the first in the new year, it'll be 23.1.0.
- [ ] Documentation in `.rst` and `.md` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.
