### PR TITLE
Define __getattribute__() instead of __getattr__() on slotted classes with cached properties

### DIFF
--- a/changelog.d/1291.change.md
+++ b/changelog.d/1291.change.md
@@ -1,0 +1,2 @@
+Rework handling of `functools.cached_property` in slotted classes by defining a `__getattribute__()` method instead of `__getattr__()` previously.
+While this is closer to the guidance for [customizing attribute access](https://docs.python.org/3/reference/datamodel.html#customizing-attribute-access), this fixes inheritance resolution of cached properties in slotted classes when subclasses are not attr-decorated but define a custom `__getattr__()` method.

--- a/docs/how-does-it-work.md
+++ b/docs/how-does-it-work.md
@@ -111,7 +111,7 @@ Therefore, *attrs* converts `cached_property`-decorated methods when constructin
 Getting this working is achieved by:
 
 * Adding names to `__slots__` for the wrapped methods.
-* Adding a `__getattr__` method to set values on the wrapped methods.
+* Adding a `__getattribute__` method to set values on the wrapped methods.
 
 For most users, this should mean that it works transparently.
 


### PR DESCRIPTION
# Summary

Fix https://github.com/python-attrs/attrs/issues/1288

Method `__getattribute__()` is [documented][1] as the "way to to actually get total control over attribute access" so we change the implementation of slotted classes with cached properties by defining a `__getattribute__()` method instead of `__getattr__()` previously.

[1]: https://docs.python.org/3/reference/datamodel.html#customizing-attribute-access

Just changing that preserves the current behaviour, according to the test suite, but also makes sub-classing work better, e.g. when the subclass is not an attr-class and also defines a custom `__getattr__()` as evidenced in added test from #1288.

In tests, we replace most custom `__getattr__()` definitions by equivalent `__getattribute__()` ones, except in regression tests where `__getattr__()` is explicitly involved. Also, in test_slots_with_multiple_cached_property_subclasses_works(), we replace the `if hasattr(super(), "__getattr__"):` by a `try:`/`except AttributeError:` as using `hasattr(..., "__getattribute__")` would be meaningless since `__getattribute__()` is always defined.


# Pull Request Check List

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
  Our CI fails if coverage is not 100%.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [x] ...and used in the stub test file `tests/typing_example.py`.
    - [x] If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signature of `@attr.s()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          The next version is the second number in the current release + 1.
          The first number represents the current year.
          So if the current version on PyPI is 22.2.0, the next version is gonna be 22.3.0.
          If the next version is the first in the new year, it'll be 23.1.0.
- [x] Documentation in `.rst` and `.md` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.