### PR TITLE
Only soft-deprecate hash

### DIFF
--- a/changelog.d/1330.deprecation.md
+++ b/changelog.d/1330.deprecation.md
@@ -1,0 +1,2 @@
+Given the amount of warnings from the broader ecosystem, we've decided to only soft-deprecate the *hash* argument to `@define` / `@attr.s`.
+Please don't use it in new code, but we don't intend to remove it anymore.

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1284,16 +1284,7 @@ def attrs(
 
     eq_, order_ = _determine_attrs_eq_order(cmp, eq, order, None)
 
-    # hash is deprecated & unsafe_hash takes precedence due to PEP 681.
-    if hash is not None:
-        import warnings
-
-        warnings.warn(
-            DeprecationWarning(
-                "The `hash` argument is deprecated in favor of `unsafe_hash` and will be removed in or after August 2025."
-            ),
-            stacklevel=2,
-        )
+    #  unsafe_hash takes precedence due to PEP 681.
     if unsafe_hash is not None:
         hash = unsafe_hash
 
@@ -2863,19 +2854,6 @@ def make_class(
         attributes_arguments.get("order"),
         True,
     )
-
-    hash = attributes_arguments.pop("hash", _SENTINEL)
-    if hash is not _SENTINEL:
-        import warnings
-
-        warnings.warn(
-            DeprecationWarning(
-                "The `hash` argument is deprecated in favor of `unsafe_hash` and will be removed in or after August 2025."
-            ),
-            stacklevel=2,
-        )
-
-        attributes_arguments["unsafe_hash"] = hash
 
     cls = _attrs(these=cls_dict, **attributes_arguments)(type_)
     # Only add type annotations now or "_attrs()" will complain:

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -69,18 +69,6 @@ def _with_and_without_validation(request):
         attr.validators.set_disabled(False)
 
 
-@pytest.mark.parametrize("hash", [True, False])
-def test_hash_is_deprecated(hash):
-    """
-    Passing anything else than None to hash raises a deprecation warning.
-    """
-    with pytest.deprecated_call():
-
-        @attr.s(hash=hash)
-        class C:
-            pass
-
-
 class TestCountingAttr:
     """
     Tests for `attr`.
@@ -1222,15 +1210,6 @@ class TestMakeClass:
 
         assert attr.fields(C).a.type is bool
         assert {"a": "bool"} == C.__annotations__
-
-    @pytest.mark.parametrize("hash", [True, False])
-    def test_hash_is_deprecated(self, hash):
-        """
-        Passing anything else than None to hash raises a deprecation warning.
-        """
-        with pytest.deprecated_call():
-
-            make_class("CH", {}, hash=hash)
 
 
 class TestFields:


### PR DESCRIPTION
Given the amount of warnings in the eco-system, make the deprection soft. We won't remove it.