### PR TITLE
📦 Make Git archives reproducible

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,4 +1,3 @@
 node: $Format:%H$
 node-date: $Format:%cI$
 describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
-ref-names: $Format:%D$


### PR DESCRIPTION
Some time ago, it was discovered that Git archives having `ref-names: $Format:%D$` in `.git_archival.txt` may change when references existing in the repository change over time [[1]]. This means that downloading an archive for a commit from an immutable URL may start yielding slightly different results. This hurts the ability of downstreams to source projects from Git archive URLs.

With that in mind, modern `setuptools-scm` advises against having this entry in the `.git_archival.txt` template [[2]]. And this patch implements said recommendation.

[1]: https://github.com/pypa/setuptools_scm/issues/806
[2]: https://setuptools-scm.readthedocs.io/en/latest/usage/#git-archives