### PR TITLE
Opt into uploading PEP 740 digital publish attestations to PyPI

### DIFF
--- a/.github/workflows/pypi-package.yml
+++ b/.github/workflows/pypi-package.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Upload package to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          attestations: true
           repository-url: https://test.pypi.org/legacy/
 
   # Upload to real PyPI on GitHub Releases.
@@ -67,3 +68,5 @@ jobs:
 
       - name: Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: true


### PR DESCRIPTION
# Summary

This patch enables the release workflow to sign the artifacts digitally and attach said signatures to PyPI releases: https://github.com/pypa/gh-action-pypi-publish/pull/236