### PR TITLE
Fix action/upload's incompatible minor update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,7 @@ jobs:
         with:
           name: coverage-data-${{ matrix.python-version }}
           path: .coverage.*
+          include-hidden-files: true
           if-no-files-found: ignore
 
   tests-pypy:


### PR DESCRIPTION
happy belated labor day; no public holiday without a self-indulgent curveball by the `actions/(up|down)load` team.