### PR TITLE
Stop installing into CI's system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,14 +151,16 @@ jobs:
 
       - name: Combine coverage & fail if it's <100%.
         run: |
-          uvx --from=coverage[toml] coverage combine
-          uvx --from=coverage[toml] coverage html --skip-covered --skip-empty
+          uv tool install 'coverage[toml]''
+
+          coverage combine
+          coverage html --skip-covered --skip-empty
 
           # Report and write to summary.
-          uvx --from=coverage[toml] coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
+          coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
 
           # Report again and fail if under 100%.
-          uvx --from=coverage[toml] coverage report --fail-under=100
+          coverage report --fail-under=100
 
       - name: Upload HTML report if check failed.
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Combine coverage & fail if it's <100%.
         run: |
-          uv tool install 'coverage[toml]''
+          uv tool install 'coverage[toml]'
 
           coverage combine
           coverage html --skip-covered --skip-empty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,18 +70,17 @@ jobs:
           echo DO_MYPY=$DO_MYPY >>$GITHUB_ENV
           echo TOX_PYTHON=py$(echo $V | tr -d .) >>$GITHUB_ENV
 
-          uv pip install --system tox
-
-      - run: uv pip install --system tox-uv
-
-      - run: python -Im tox run -e ${{ env.TOX_PYTHON }}-mypy
+      - run: >
+          uvx --with=tox-uv
+          tox run
+          -e ${{ env.TOX_PYTHON }}-mypy
         if: env.DO_MYPY == '1'
 
       - name: Remove src to ensure tests run against wheel
         run: rm -rf src
 
       - run: >
-          python -Im
+          uvx --with=tox-uv
           tox run
           --installpkg dist/*.whl
           -e ${{ env.TOX_PYTHON }}-tests
@@ -121,10 +120,8 @@ jobs:
           allow-prereleases: true
       - uses: hynek/setup-cached-uv@v2
 
-      - run: uv pip install --system tox-uv
-
       - run: >
-          python -Im
+          uvx --with=tox-uv
           tox run
           --installpkg dist/*.whl
           -e pypy3-tests
@@ -154,16 +151,14 @@ jobs:
 
       - name: Combine coverage & fail if it's <100%.
         run: |
-          uv pip install --system coverage[toml]
-
-          python -Im coverage combine
-          python -Im coverage html --skip-covered --skip-empty
+          uvx --from=coverage[toml] coverage combine
+          uvx --from=coverage[toml] coverage html --skip-covered --skip-empty
 
           # Report and write to summary.
-          python -Im coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
+          uvx --from=coverage[toml] coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
 
           # Report again and fail if under 100%.
-          python -Im coverage report --fail-under=100
+          uvx --from=coverage[toml] coverage report --fail-under=100
 
       - name: Upload HTML report if check failed.
         uses: actions/upload-artifact@v4
@@ -189,8 +184,7 @@ jobs:
           python-version: "3.12"
       - uses: hynek/setup-cached-uv@v2
 
-      - run: uv pip install --system tox-uv
-      - run: python -Im tox run -e docs,changelog
+      - run: uvx --with=tox-uv tox run -e docs,changelog
 
   pyright:
     name: Check types using pyright
@@ -202,8 +196,7 @@ jobs:
           python-version-file: .python-version-default
       - uses: hynek/setup-cached-uv@v2
 
-      - run: uv pip install --system tox-uv
-      - run: python -Im tox run -e pyright
+      - run: uvx --with=tox-uv tox run -e pyright
 
   install-dev:
     name: Verify dev env

--- a/tox.ini
+++ b/tox.ini
@@ -113,7 +113,7 @@ commands =
 
 [testenv:pyright]
 extras = tests
-deps = pyright
+deps = pyright<1.1.380
 commands = pytest tests/test_pyright.py -vv
 
 


### PR DESCRIPTION
We're starting to get permission denied errors when installing with `--system`.

Is it Halloween already or what federal holiday is coming up?