### PR TITLE
Introducing attrs Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
    <a href="https://pypi.org/project/attrs/"><img src="https://img.shields.io/pypi/v/attrs" /></a>
    <a href="https://pepy.tech/project/attrs"><img src="https://static.pepy.tech/personalized-badge/attrs?period=month&units=international_system&left_color=grey&right_color=blue&left_text=Downloads%20/%20Month" alt="Downloads per month" /></a>
    <a href="https://zenodo.org/badge/latestdoi/29918975"><img src="https://zenodo.org/badge/29918975.svg" alt="DOI"></a>
+   <a href="https://gurubase.io/g/attrs"><img src="https://img.shields.io/badge/Gurubase-Ask%20attrs%20Guru-006BFF" alt="Gurubase"></a>
 </p>
 
 <!-- teaser-begin -->


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [attrs Guru](https://gurubase.io/g/attrs) to Gurubase. attrs Guru uses the data from this repo and data from the [docs](https://www.attrs.org/) to answer questions by leveraging the LLM.

In this PR, I showcased the "attrs Guru", which highlights that attrs now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable attrs Guru in Gurubase, just let me know that's totally fine.
