### PR TITLE
Apply PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,13 @@ build-backend = "hatchling.build"
 [project]
 name = "attrs"
 authors = [{ name = "Hynek Schlawack", email = "hs@ox.cx" }]
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.8"
 description = "Classes Without Boilerplate"
 keywords = ["class", "attribute", "boilerplate"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
-  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
PEP 639 has been accepted and is [live](https://discuss.python.org/t/pep-639-round-3-improving-license-clarity-with-better-package-metadata/53020/128).
