### PR TITLE
Fix type signature for callables passed to Converter with takes_self=True

### DIFF
--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -95,13 +95,16 @@ def Factory(
 In = TypeVar("In")
 Out = TypeVar("Out")
 
+# Callable might type check against the specific attrs-defined class.
+_AttrsInstance = TypeVar("_AttrsInstance", bound=AttrsInstance)
+
 class Converter(Generic[In, Out]):
     @overload
     def __init__(self, converter: Callable[[In], Out]) -> None: ...
     @overload
     def __init__(
         self,
-        converter: Callable[[In, AttrsInstance, Attribute], Out],
+        converter: Callable[[In, _AttrsInstance, Attribute], Out],
         *,
         takes_self: Literal[True],
         takes_field: Literal[True],
@@ -116,7 +119,7 @@ class Converter(Generic[In, Out]):
     @overload
     def __init__(
         self,
-        converter: Callable[[In, AttrsInstance], Out],
+        converter: Callable[[In, _AttrsInstance], Out],
         *,
         takes_self: Literal[True],
     ) -> None: ...

--- a/tests/test_mypy.yml
+++ b/tests/test_mypy.yml
@@ -911,28 +911,28 @@
     main:22: error: No overload variant of "Converter" matches argument types "Callable[[Any], str]", "bool"  [call-overload]
     main:22: note: Possible overload variants:
     main:22: note:     def [In, Out] Converter(self, converter: Callable[[In], Out]) -> Converter[In, Out]
-    main:22: note:     def [In, Out] Converter(self, converter: Callable[[In, AttrsInstance, Attribute[Any]], Out], *, takes_self: Literal[True], takes_field: Literal[True]) -> Converter[In, Out]
+    main:22: note:     def [In, Out, _AttrsInstance: AttrsInstance] Converter(self, converter: Callable[[In, _AttrsInstance, Attribute[Any]], Out], *, takes_self: Literal[True], takes_field: Literal[True]) -> Converter[In, Out]
     main:22: note:     def [In, Out] Converter(self, converter: Callable[[In, Attribute[Any]], Out], *, takes_field: Literal[True]) -> Converter[In, Out]
-    main:22: note:     def [In, Out] Converter(self, converter: Callable[[In, AttrsInstance], Out], *, takes_self: Literal[True]) -> Converter[In, Out]
+    main:22: note:     def [In, Out, _AttrsInstance: AttrsInstance] Converter(self, converter: Callable[[In, _AttrsInstance], Out], *, takes_self: Literal[True]) -> Converter[In, Out]
     main:23: error: No overload variant of "Converter" matches argument types "Callable[[Any, Attribute[Any]], str]", "bool"  [call-overload]
     main:23: note: Possible overload variants:
     main:23: note:     def [In, Out] Converter(self, converter: Callable[[In], Out]) -> Converter[In, Out]
-    main:23: note:     def [In, Out] Converter(self, converter: Callable[[In, AttrsInstance, Attribute[Any]], Out], *, takes_self: Literal[True], takes_field: Literal[True]) -> Converter[In, Out]
+    main:23: note:     def [In, Out, _AttrsInstance: AttrsInstance] Converter(self, converter: Callable[[In, _AttrsInstance, Attribute[Any]], Out], *, takes_self: Literal[True], takes_field: Literal[True]) -> Converter[In, Out]
     main:23: note:     def [In, Out] Converter(self, converter: Callable[[In, Attribute[Any]], Out], *, takes_field: Literal[True]) -> Converter[In, Out]
-    main:23: note:     def [In, Out] Converter(self, converter: Callable[[In, AttrsInstance], Out], *, takes_self: Literal[True]) -> Converter[In, Out]
+    main:23: note:     def [In, Out, _AttrsInstance: AttrsInstance] Converter(self, converter: Callable[[In, _AttrsInstance], Out], *, takes_self: Literal[True]) -> Converter[In, Out]
     main:25: note: Revealed type is "attr.Converter[Any, builtins.str]"
     main:26: error: No overload variant of "Converter" matches argument types "Callable[[Any], str]", "bool"  [call-overload]
     main:26: note: Possible overload variants:
     main:26: note:     def [In, Out] Converter(self, converter: Callable[[In], Out]) -> Converter[In, Out]
-    main:26: note:     def [In, Out] Converter(self, converter: Callable[[In, AttrsInstance, Attribute[Any]], Out], *, takes_self: Literal[True], takes_field: Literal[True]) -> Converter[In, Out]
+    main:26: note:     def [In, Out, _AttrsInstance: AttrsInstance] Converter(self, converter: Callable[[In, _AttrsInstance, Attribute[Any]], Out], *, takes_self: Literal[True], takes_field: Literal[True]) -> Converter[In, Out]
     main:26: note:     def [In, Out] Converter(self, converter: Callable[[In, Attribute[Any]], Out], *, takes_field: Literal[True]) -> Converter[In, Out]
-    main:26: note:     def [In, Out] Converter(self, converter: Callable[[In, AttrsInstance], Out], *, takes_self: Literal[True]) -> Converter[In, Out]
+    main:26: note:     def [In, Out, _AttrsInstance: AttrsInstance] Converter(self, converter: Callable[[In, _AttrsInstance], Out], *, takes_self: Literal[True]) -> Converter[In, Out]
     main:27: error: No overload variant of "Converter" matches argument types "Callable[[Any, AttrsInstance], str]", "bool"  [call-overload]
     main:27: note: Possible overload variants:
     main:27: note:     def [In, Out] Converter(self, converter: Callable[[In], Out]) -> Converter[In, Out]
-    main:27: note:     def [In, Out] Converter(self, converter: Callable[[In, AttrsInstance, Attribute[Any]], Out], *, takes_self: Literal[True], takes_field: Literal[True]) -> Converter[In, Out]
+    main:27: note:     def [In, Out, _AttrsInstance: AttrsInstance] Converter(self, converter: Callable[[In, _AttrsInstance, Attribute[Any]], Out], *, takes_self: Literal[True], takes_field: Literal[True]) -> Converter[In, Out]
     main:27: note:     def [In, Out] Converter(self, converter: Callable[[In, Attribute[Any]], Out], *, takes_field: Literal[True]) -> Converter[In, Out]
-    main:27: note:     def [In, Out] Converter(self, converter: Callable[[In, AttrsInstance], Out], *, takes_self: Literal[True]) -> Converter[In, Out]
+    main:27: note:     def [In, Out, _AttrsInstance: AttrsInstance] Converter(self, converter: Callable[[In, _AttrsInstance], Out], *, takes_self: Literal[True]) -> Converter[In, Out]
 
 - case: testAttrsCmpWithSubclasses
   regex: true

--- a/tests/typing_example.py
+++ b/tests/typing_example.py
@@ -181,6 +181,46 @@ ConvCToBool(False)
 ConvCToBool("n")
 
 
+# Converter instances with takes_self=True and/or takes_field=True
+def str2int_self(s: str | int, self_: "CCC") -> int:
+    return int(s)
+
+
+def str2int_field(s: str | int, field_: attrs.Attribute) -> int:
+    return int(s)
+
+
+def str2int_both(s: str | int, self_: "CCC", field_: attrs.Attribute) -> int:
+    return int(s)
+
+
+# XXX: Fails with E: Unsupported converter, only named functions, types and lambdas are currently supported  [misc]
+# See https://github.com/python/mypy/issues/15736
+#
+# So let's suppress the [misc] category, which still tests the [call-override] matching the callables.
+@attrs.define
+class CCC:
+    x: int = attrs.field(
+        converter=attrs.Converter(  # type: ignore[misc]
+            str2int_self,
+            takes_self=True,
+        )
+    )
+    y: int = attrs.field(
+        converter=attrs.Converter(  # type: ignore[misc]
+            str2int_field,
+            takes_field=True,
+        )
+    )
+    z: int = attrs.field(
+        converter=attrs.Converter(  # type: ignore[misc]
+            str2int_both,
+            takes_self=True,
+            takes_field=True,
+        )
+    )
+
+
 # Validators
 @attr.s
 class Validated:


### PR DESCRIPTION
# Summary

Fix type signature for callables passed to `Converter` with `takes_self=True`, so that using the specific attrs class that contains the field with the converter is valid in the callable type signature.

Fixes #1378.
<!-- Please tell us what your pull request is about here. -->

Note that python/mypy#15736 still triggers mypy errors when passing a Converter instance as a `converter=` kwarg to a field, so work around that using `# type: ignore[misc]` in test cases.

# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/python-attrs/attrs/blob/main/.github/CONTRIBUTING.md) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
- [x] Added **tests** for changed code.
- N/A New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [x] ...and used in the stub test file `tests/typing_example.py`.
    - N/A If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- N/A Updated **documentation** for changed code.
- N/A Documentation in `.rst` and `.md` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- N/A Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
