### PR TITLE
FIX: License metadata not published in Pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ build-backend = "hatchling.build"
 [project]
 name = "attrs"
 authors = [{ name = "Hynek Schlawack", email = "hs@ox.cx" }]
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.8"
 description = "Classes Without Boilerplate"
 keywords = ["class", "attribute", "boilerplate"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,13 @@ build-backend = "hatchling.build"
 [project]
 name = "attrs"
 authors = [{ name = "Hynek Schlawack", email = "hs@ox.cx" }]
-license = "MIT"
-license-files = ["LICENSE"]
+license = { text = "MIT" }
 requires-python = ">=3.8"
 description = "Classes Without Boilerplate"
 keywords = ["class", "attribute", "boilerplate"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
+  "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
# Summary

~Temporary fix which revert "Apply PEP 639 (#1377)"  to avoid the current issue with license metadata not available in Pypi.~
Apply changes proposed in https://github.com/python-attrs/attrs/issues/1386#issuecomment-2545145428:
- keep Trove classifier (deprecated for now, not removed)
- keep the new PEP 638 fields

Close #1386

