### PR TITLE
Draft: Add "resolve_types" argument to define()

### DIFF
--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -279,6 +279,7 @@ def attrs(
     field_transformer: _FieldTransformer | None = ...,
     match_args: bool = ...,
     unsafe_hash: bool | None = ...,
+    resolve_types: bool = ...,
 ) -> _C: ...
 @overload
 @dataclass_transform(order_default=True, field_specifiers=(attrib, field))
@@ -307,6 +308,7 @@ def attrs(
     field_transformer: _FieldTransformer | None = ...,
     match_args: bool = ...,
     unsafe_hash: bool | None = ...,
+    resolve_types: bool = ...,
 ) -> Callable[[_C], _C]: ...
 def fields(cls: type[AttrsInstance]) -> Any: ...
 def fields_dict(cls: type[AttrsInstance]) -> dict[str, Attribute[Any]]: ...

--- a/src/attr/_next_gen.py
+++ b/src/attr/_next_gen.py
@@ -43,6 +43,7 @@ def define(
     on_setattr=None,
     field_transformer=None,
     match_args=True,
+    resolve_types=False,
 ):
     r"""
     A class decorator that adds :term:`dunder methods` according to
@@ -235,6 +236,14 @@ def define(
             non-keyword-only ``__init__`` parameter names on Python 3.10 and
             later. Ignored on older Python versions.
 
+        resolve_types (bool):
+            If True, automatically call :func:`~attrs.resolve_types()` on the
+            class.
+
+            If you need to explicitly pass a global or local namespace, you
+            should leave this at False and explicitly call
+            :func:`~attrs.resolve_types()` instead.
+
         collect_by_mro (bool):
             If True, *attrs* collects attributes from base classes correctly
             according to the `method resolution order
@@ -319,6 +328,8 @@ def define(
     .. versionadded:: 24.3.0
        Unless already present, a ``__replace__`` method is automatically
        created for `copy.replace` (Python 3.13+ only).
+    .. versionadded:: 25.1.0
+       Added the *resolve_types* argument.
 
     .. note::
 
@@ -366,6 +377,7 @@ def define(
             on_setattr=on_setattr,
             field_transformer=field_transformer,
             match_args=match_args,
+            resolve_types=resolve_types,
         )
 
     def wrap(cls):

--- a/src/attrs/__init__.pyi
+++ b/src/attrs/__init__.pyi
@@ -179,6 +179,7 @@ def define(
     on_setattr: _OnSetAttrArgType | None = ...,
     field_transformer: _FieldTransformer | None = ...,
     match_args: bool = ...,
+    resolve_types: bool = ...,
 ) -> _C: ...
 @overload
 @dataclass_transform(field_specifiers=(attrib, field))
@@ -205,6 +206,7 @@ def define(
     on_setattr: _OnSetAttrArgType | None = ...,
     field_transformer: _FieldTransformer | None = ...,
     match_args: bool = ...,
+    resolve_types: bool = ...,
 ) -> Callable[[_C], _C]: ...
 
 mutable = define

--- a/tests/test_next_gen.py
+++ b/tests/test_next_gen.py
@@ -429,6 +429,7 @@ class TestNextGen:
         """
         Types can optionally be resolve directly by the decorator.
         """
+
         @attrs.define(resolve_types=True)
         class A:
             x: "int" = 10

--- a/tests/test_next_gen.py
+++ b/tests/test_next_gen.py
@@ -425,6 +425,27 @@ class TestNextGen:
 
         assert d.x == d.xx()
 
+    def test_resolve_types(self):
+        """
+        Types can optionally be resolve directly by the decorator.
+        """
+        @attrs.define(resolve_types=True)
+        class A:
+            x: "int" = 10
+
+        assert attrs.fields(A).x.type is int
+
+    def test_resolve_types_default_off(self):
+        """
+        Types are not resolved by default.
+        """
+
+        @attrs.define(resolve_types=False)
+        class A:
+            x: "int" = 10
+
+        assert attrs.fields(A).x.type == "int"
+
 
 class TestAsTuple:
     def test_smoke(self):


### PR DESCRIPTION
Fixes: #1286

# Summary

Add *resolve_types* kwarg to `define()` to allow it to automatically resolve the class' fields types.

This is atm just a PoC to evaluate if this is going into the right direction. What do you think, @hynek ?


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/python-attrs/attrs/blob/main/.github/CONTRIBUTING.md) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.
-->

- [ ] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your pull request to be accepted, but **you have been warned**.
- [ ] Added **tests** for changed code.
  Our CI fails if coverage is not 100%.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [ ] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [ ] ...and used in the stub test file `tests/typing_example.py`.
    - [ ] If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changes to the signatures of `@attr.s()` and `@attrs.define()` have to be added by hand too.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          The next version is the second number in the current release + 1.
          The first number represents the current year.
          So if the current version on PyPI is 22.2.0, the next version is gonna be 22.3.0.
          If the next version is the first in the new year, it'll be 23.1.0.
      - [ ] If something changed that affects both `attrs.define()` and `attr.s()`, you have to add version directives to both.
- [ ] Documentation in `.rst` and `.md` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
- [ ] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
