### PR TITLE
Fix a typo in SPDX comment @ `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MITpyp
+# SPDX-License-Identifier: MIT
 
 [build-system]
 requires = ["hatchling", "hatch-vcs", "hatch-fancy-pypi-readme>=23.2.0"]


### PR DESCRIPTION
It was introduced in https://github.com/python-attrs/attrs/commit/6bde3618237cdae312e4e7fb006690be2a3ee0f6