### PR TITLE
Add MIT license pypi classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Typing :: Typed",
+  "License :: OSI Approved :: MIT License",
 ]
 dependencies = []
 dynamic = ["version", "readme"]


### PR DESCRIPTION
# Summary

This adds a pypi [classifier](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#classifiers) to specify this package is using the MIT license. This came up as we have tooling to mirror and check the license of pypi packages using this classifier



<!-- Please tell us what your pull request is about here. -->


<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/python-attrs/attrs/blob/main/.github/CONTRIBUTING.md) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.
-->



<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
