### PR TITLE
Add `to_field()` to `Attribute`

### DIFF
--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -139,6 +139,7 @@ class Attribute(Generic[_T]):
     alias: str | None
 
     def evolve(self, **changes: Any) -> "Attribute[Any]": ...
+    def to_field(self) -> Any: ...
 
 # NOTE: We had several choices for the annotation to use for type arg:
 # 1) Type[_T]

--- a/src/attr/_next_gen.py
+++ b/src/attr/_next_gen.py
@@ -429,6 +429,7 @@ def field(
     order=None,
     on_setattr=None,
     alias=None,
+    inherited=None,
 ):
     """
     Create a new :term:`field` / :term:`attribute` on a class.
@@ -565,6 +566,11 @@ def field(
             ``__init__`` method. If left None, default to ``name`` stripped
             of leading underscores. See `private-attributes`.
 
+        inherited (bool | None):
+            Ensure this attribute inherits the ordering of the parent attribute
+            with the same name. If no parent attribute with the same name 
+            exists, this field is treated as normal.
+
     .. versionadded:: 20.1.0
     .. versionchanged:: 21.1.0
        *eq*, *order*, and *cmp* also accept a custom callable
@@ -572,6 +578,7 @@ def field(
     .. versionadded:: 23.1.0
        The *type* parameter has been re-added; mostly for `attrs.make_class`.
        Please note that type checkers ignore this metadata.
+    .. versionadded:: 25.4.0 *inherited*
 
     .. seealso::
 
@@ -592,6 +599,7 @@ def field(
         order=order,
         on_setattr=on_setattr,
         alias=alias,
+        inherited=inherited,
     )
 
 


### PR DESCRIPTION
# Summary

Preliminary implementation of "evolving" existing `Attribute` instances back into `_CountingAttr` instances, so that users may (easily) reuse attribute definitions from already `define`d classes. Should resolve #637, #698, #829, #876, #946, and #1424.

Usage:
```py
@attrs.define
class Parent:
    a: int = 100
    
@attrs.define
class Child:
    a = attrs.fields(Parent).a.evolve(default=200).to_field()
    
    # Now that a is in scope of Child, we can attach methods to it like normal:     
    @a.validator
    def a_validator(...):
        ...

assert attrs.fields(Child).a.type is int
assert Child().a == 200
```
This syntax is verbose, but least magical. And because you manually specify which class you want to pull attributes from, inheritance is not required; you can compose new classes entirely from parts of existing classes regardless of structure:
```py
@attrs.define
class A:
    a: int = 1
    
@attrs.define
class B:
    b: int = 2
    
@attrs.define
class Composite:
    a = attrs.fields(A).a.evolve(...).to_field()
    b = attrs.fields(B).b.evolve(...).to_field()
```
Utility methods like `attrs.make_class()` and the `these` kwarg in `attrs.define()` also work as you would expect.

One potential pain point with a simple implementation of this feature is inherited attributes being reordered when redefined in this manner:
```py
@attr.s
class BaseClass:
    x: int = attr.ib(default=1)
    y: int = attr.ib(default=2)

@attr.s
class SubClass(BaseClass):
    x = attr.fields(BaseClass).x.evolve(default=3).to_field()

# Because x was redefined, it appears after y
assert "SubClass(y=2, x=3)" == repr(SubClass())
```
In my opinion, this behavior is a failure of the implementation, as it is reasonable to expect users to want to preserve this ordering, as in a worst-case scenario it can lead to non-constructable classes. This PR implements a new bool keyword argument `inherited` to `field`, which tells attrs to use the ordering of the field in the parent class as opposed to adding to the end:
```py
@attr.s
class SubClass(BaseClass):
    x = attr.fields(BaseClass).x.evolve(default=3, inherited=True).to_field()

assert "SubClass(x=3, y=2)" == repr(SubClass())
```
Criticisms of this `inherited` keyword are welcome, as I'm not convinced it is the best solution. However, I do think this functionality needs to be present in attrs in order to make this kind of attribute evolution a tenable approach.

# Pull Request Check List

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
- [x] Added **tests** for changed code.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [ ] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [ ] ...and used in the stub test file `tests/typing_example.py`.
    - [ ] If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signatures of `@attr.s()` and `@attrs.define()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          The next version is the second number in the current release + 1.
          The first number represents the current year.
          So if the current version on PyPI is 22.2.0, the next version is gonna be 22.3.0.
          If the next version is the first in the new year, it'll be 23.1.0.
      - [x] If something changed that affects both `attrs.define()` and `attr.s()`, you have to add version directives to both.
- [x] Documentation in `.rst` and `.md` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.