### PR TITLE
Make class-level `kw_only=True` apply only to attributes in the current class without an explicit `kw_only=False` setting

### DIFF
--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -176,7 +176,7 @@ def attrib(
     type: None = ...,
     converter: None = ...,
     factory: None = ...,
-    kw_only: bool = ...,
+    kw_only: bool | None = ...,
     eq: _EqOrderType | None = ...,
     order: _EqOrderType | None = ...,
     on_setattr: _OnSetAttrArgType | None = ...,
@@ -200,7 +200,7 @@ def attrib(
     | tuple[_ConverterType]
     | None = ...,
     factory: Callable[[], _T] | None = ...,
-    kw_only: bool = ...,
+    kw_only: bool | None = ...,
     eq: _EqOrderType | None = ...,
     order: _EqOrderType | None = ...,
     on_setattr: _OnSetAttrArgType | None = ...,
@@ -223,7 +223,7 @@ def attrib(
     | tuple[_ConverterType]
     | None = ...,
     factory: Callable[[], _T] | None = ...,
-    kw_only: bool = ...,
+    kw_only: bool | None = ...,
     eq: _EqOrderType | None = ...,
     order: _EqOrderType | None = ...,
     on_setattr: _OnSetAttrArgType | None = ...,
@@ -246,7 +246,7 @@ def attrib(
     | tuple[_ConverterType]
     | None = ...,
     factory: Callable[[], _T] | None = ...,
-    kw_only: bool = ...,
+    kw_only: bool | None = ...,
     eq: _EqOrderType | None = ...,
     order: _EqOrderType | None = ...,
     on_setattr: _OnSetAttrArgType | None = ...,

--- a/src/attr/_next_gen.py
+++ b/src/attr/_next_gen.py
@@ -43,6 +43,7 @@ def define(
     on_setattr=None,
     field_transformer=None,
     match_args=True,
+    force_kw_only=False,
 ):
     r"""
     A class decorator that adds :term:`dunder methods` according to
@@ -214,8 +215,12 @@ def define(
                 5. Subclasses of a frozen class are frozen too.
 
         kw_only (bool):
-            Make all attributes keyword-only in the generated ``__init__`` (if
-            *init* is False, this parameter is ignored).
+            Make attributes keyword-only in the generated ``__init__`` (if
+            *init* is False, this parameter is ignored).  Attributes that
+            explicitly set ``kw_only=False`` are not affected; base class
+            attributes are also not affected.
+
+            Also see ``force_kw_only``.
 
         weakref_slot (bool):
             Make instances weak-referenceable.  This has no effect unless
@@ -243,6 +248,15 @@ def define(
 
             See also `issue #428
             <https://github.com/python-attrs/attrs/issues/428>`_.
+
+        force_kw_only (bool):
+            A back-compat flag for restoring old behavior.  If True and
+            ``kw_only=True``, all attributes are made keyword-only, including
+            base class attributes, and those set to ``kw_only=False`` at the
+            attribute level.  Defaults to False.
+
+            See also `issue #980
+            <https://github.com/python-attrs/attrs/issues/980>`_.
 
         getstate_setstate (bool | None):
             .. note::
@@ -319,6 +333,11 @@ def define(
     .. versionadded:: 24.3.0
        Unless already present, a ``__replace__`` method is automatically
        created for `copy.replace` (Python 3.13+ only).
+    .. versionchanged:: 25.3.0
+       `kw_only` now only applies to attributes defined in the current class,
+       and respects attribute-level `kw_only=False` settings.
+    .. versionadded:: 25.3.0
+       Added `force_kw_only` to go back to the previous `kw_only` behavior.
 
     .. note::
 
@@ -337,6 +356,7 @@ def define(
         - *auto_exc=True*
         - *auto_detect=True*
         - *order=False*
+        - *force_kw_only=False*
         - Some options that were only relevant on Python 2 or were kept around
           for backwards-compatibility have been removed.
 
@@ -366,6 +386,7 @@ def define(
             on_setattr=on_setattr,
             field_transformer=field_transformer,
             match_args=match_args,
+            force_kw_only=force_kw_only,
         )
 
     def wrap(cls):
@@ -424,7 +445,7 @@ def field(
     type=None,
     converter=None,
     factory=None,
-    kw_only=False,
+    kw_only=None,
     eq=None,
     order=None,
     on_setattr=None,
@@ -550,9 +571,10 @@ def field(
             itself. You can use it as part of your own code or for `static type
             checking <types>`.
 
-        kw_only (bool):
+        kw_only (bool | None):
             Make this attribute keyword-only in the generated ``__init__`` (if
-            ``init`` is False, this parameter is ignored).
+            ``init`` is False, this parameter is ignored).  If None (default),
+            mirror the setting from `attr.s`.
 
         on_setattr (~typing.Callable | list[~typing.Callable] | None | ~typing.Literal[attrs.setters.NO_OP]):
             Allows to overwrite the *on_setattr* setting from `attr.s`. If left
@@ -572,6 +594,9 @@ def field(
     .. versionadded:: 23.1.0
        The *type* parameter has been re-added; mostly for `attrs.make_class`.
        Please note that type checkers ignore this metadata.
+    .. versionchanged:: 25.3.0
+       `kw_only` can now be None, and its default is also changed from False to
+       None.
 
     .. seealso::
 

--- a/src/attrs/__init__.pyi
+++ b/src/attrs/__init__.pyi
@@ -77,7 +77,7 @@ def field(
     metadata: Mapping[Any, Any] | None = ...,
     converter: None = ...,
     factory: None = ...,
-    kw_only: bool = ...,
+    kw_only: bool | None = ...,
     eq: bool | None = ...,
     order: bool | None = ...,
     on_setattr: _OnSetAttrArgType | None = ...,
@@ -101,7 +101,7 @@ def field(
     | tuple[_ConverterType]
     | None = ...,
     factory: Callable[[], _T] | None = ...,
-    kw_only: bool = ...,
+    kw_only: bool | None = ...,
     eq: _EqOrderType | None = ...,
     order: _EqOrderType | None = ...,
     on_setattr: _OnSetAttrArgType | None = ...,
@@ -124,7 +124,7 @@ def field(
     | tuple[_ConverterType]
     | None = ...,
     factory: Callable[[], _T] | None = ...,
-    kw_only: bool = ...,
+    kw_only: bool | None = ...,
     eq: _EqOrderType | None = ...,
     order: _EqOrderType | None = ...,
     on_setattr: _OnSetAttrArgType | None = ...,
@@ -147,7 +147,7 @@ def field(
     | tuple[_ConverterType]
     | None = ...,
     factory: Callable[[], _T] | None = ...,
-    kw_only: bool = ...,
+    kw_only: bool | None = ...,
     eq: _EqOrderType | None = ...,
     order: _EqOrderType | None = ...,
     on_setattr: _OnSetAttrArgType | None = ...,

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -55,7 +55,9 @@ from .strategies import (
 from .utils import simple_attr
 
 
-attrs_st = simple_attrs.map(lambda c: Attribute.from_counting_attr("name", c))
+attrs_st = simple_attrs.map(
+    lambda c: Attribute.from_counting_attr("name", c, False)
+)
 
 
 @pytest.fixture(name="with_and_without_validation", params=[True, False])
@@ -179,7 +181,7 @@ class TestTransformAttrs:
         Does not attach __attrs_attrs__ to the class.
         """
         C = make_tc()
-        _transform_attrs(C, None, False, False, True, None)
+        _transform_attrs(C, None, False, False, False, True, None)
 
         assert None is getattr(C, "__attrs_attrs__", None)
 
@@ -188,7 +190,9 @@ class TestTransformAttrs:
         Transforms every `_CountingAttr` and leaves others (a) be.
         """
         C = make_tc()
-        attrs, _, _ = _transform_attrs(C, None, False, False, True, None)
+        attrs, _, _ = _transform_attrs(
+            C, None, False, False, False, True, None
+        )
 
         assert ["z", "y", "x"] == [a.name for a in attrs]
 
@@ -202,7 +206,7 @@ class TestTransformAttrs:
             pass
 
         assert _Attributes((), [], {}) == _transform_attrs(
-            C, None, False, False, True, None
+            C, None, False, False, False, True, None
         )
 
     def test_transforms_to_attribute(self):
@@ -211,7 +215,7 @@ class TestTransformAttrs:
         """
         C = make_tc()
         attrs, base_attrs, _ = _transform_attrs(
-            C, None, False, False, True, None
+            C, None, False, False, False, True, None
         )
 
         assert [] == base_attrs
@@ -229,7 +233,7 @@ class TestTransformAttrs:
             y = attr.ib()
 
         with pytest.raises(ValueError) as e:
-            _transform_attrs(C, None, False, False, True, None)
+            _transform_attrs(C, None, False, False, False, True, None)
         assert (
             "No mandatory attributes allowed after an attribute with a "
             "default value or factory.  Attribute in question: Attribute"
@@ -242,11 +246,8 @@ class TestTransformAttrs:
 
     def test_kw_only(self):
         """
-        Converts all attributes, including base class' attributes, if `kw_only`
-        is provided. Therefore, `kw_only` allows attributes with defaults to
-        precede mandatory attributes.
-
-        Updates in the subclass *don't* affect the base class attributes.
+        Converts all attributes in the current class if `kw_only` is provided.
+        Base class attributes are **not** affected.
         """
 
         @attr.s
@@ -261,7 +262,26 @@ class TestTransformAttrs:
             y = attr.ib()
 
         attrs, base_attrs, _ = _transform_attrs(
-            C, None, False, True, True, None
+            C, None, False, True, False, True, None
+        )
+
+        assert len(attrs) == 3
+        assert len(base_attrs) == 1
+
+        for a in attrs:
+            if a.name == "b":
+                assert a.kw_only is False
+            else:
+                assert a.kw_only is True
+
+        attrs, base_attrs, _ = _transform_attrs(
+            C,
+            None,
+            False,
+            True,
+            True,
+            True,
+            None,  # force kw-only
         )
 
         assert len(attrs) == 3
@@ -285,7 +305,7 @@ class TestTransformAttrs:
             y = attr.ib()
 
         attrs, base_attrs, _ = _transform_attrs(
-            C, {"x": attr.ib()}, False, False, True, None
+            C, {"x": attr.ib()}, False, False, False, True, None
         )
 
         assert [] == base_attrs
@@ -1018,8 +1038,8 @@ class TestKeywordOnlyAttributes:
 
     def test_keyword_only_class_level_subclassing(self):
         """
-        Subclass `kw_only` propagates to attrs inherited from the base,
-        allowing non-default following default.
+        When `force_kw_only=True`, subclass `kw_only` propagates to attrs
+        inherited from the base, allowing non-default following default.
         """
 
         @attr.s
@@ -1032,8 +1052,19 @@ class TestKeywordOnlyAttributes:
 
         with pytest.raises(TypeError):
             C(1)
+        with pytest.raises(TypeError):
+            C(0, y=1)
 
         c = C(x=0, y=1)
+
+        assert c.x == 0
+        assert c.y == 1
+
+        @attr.s(kw_only=True, force_kw_only=False)
+        class C(Base):
+            y = attr.ib()
+
+        c = C(0, y=1)
 
         assert c.x == 0
         assert c.y == 1
@@ -1093,6 +1124,137 @@ class TestKeywordOnlyAttributes:
         assert c.kwarg == "a"
         assert c.non_init_function_default == "ab"
         assert c.non_init_keyword_default == "default-by-keyword"
+
+    def test_attr_level_kw_only_and_class_level_kw_only(self):
+        """
+        If a field explicitly sets 'kw_only=False', it should not be made
+        keyword-only even if the class sets 'kw_only=True'.
+        """
+
+        @attr.s(kw_only=True)
+        class OldClassOldBehavior:
+            yes = attr.ib()
+            no = attr.ib(kw_only=False)
+
+        @attr.s(kw_only=True, force_kw_only=False)
+        class OldClassNewBehavior:
+            yes = attr.ib()
+            no = attr.ib(kw_only=False)
+
+        @attr.define(kw_only=True, force_kw_only=True)
+        class NewClassOldBehavior:
+            yes = attr.field()
+            no = attr.field(kw_only=False)
+
+        @attr.define(kw_only=True)
+        class NewClassNewBehavior:
+            yes = attr.field()
+            no = attr.field(kw_only=False)
+
+        for cls in [OldClassNewBehavior, NewClassNewBehavior]:
+            fs = fields_dict(cls)
+            assert fs["yes"].kw_only is True
+            assert fs["no"].kw_only is False
+
+        for cls in [OldClassOldBehavior, NewClassOldBehavior]:
+            fs = fields_dict(cls)
+            assert fs["yes"].kw_only is True
+            assert fs["no"].kw_only is True
+
+    def test_kw_only_inheritance(self):
+        """
+        Comprehensive test about how `kw_only` works when there's multiple
+        levels of inheritance with different `kw_only` settings.
+        """
+
+        @attr.define()
+        class A:
+            a = attr.field()
+            a_t = attr.field(kw_only=True)
+            a_f = attr.field(kw_only=False)
+
+        @attr.define(kw_only=True)
+        class B(A):
+            b = attr.field()
+            b_t = attr.field(kw_only=True)
+            b_f = attr.field(kw_only=False)
+
+        @attr.define(kw_only=False)
+        class C(B):
+            c = attr.field()
+            c_t = attr.field(kw_only=True)
+            c_f = attr.field(kw_only=False)
+
+        fs = fields_dict(A)
+        assert fs["a"].kw_only is False
+        assert fs["a_t"].kw_only is True
+        assert fs["a_f"].kw_only is False
+
+        fs = fields_dict(B)
+        assert fs["a"].kw_only is False
+        assert fs["a_t"].kw_only is True
+        assert fs["a_f"].kw_only is False
+        assert fs["b"].kw_only is True
+        assert fs["b_t"].kw_only is True
+        assert fs["b_f"].kw_only is False
+
+        fs = fields_dict(C)
+        assert fs["a"].kw_only is False
+        assert fs["a_t"].kw_only is True
+        assert fs["a_f"].kw_only is False
+        assert fs["b"].kw_only is True
+        assert fs["b_t"].kw_only is True
+        assert fs["b_f"].kw_only is False
+        assert fs["c"].kw_only is False
+        assert fs["c_t"].kw_only is True
+        assert fs["c_f"].kw_only is False
+
+    def test_kw_only_inheritance_force_kw_only(self):
+        """
+        Similar to above, but when `force_kw_only` (pre-25.3.0 behavior).
+        """
+
+        @attr.define(force_kw_only=True)
+        class A:
+            a = attr.field()
+            a_t = attr.field(kw_only=True)
+            a_f = attr.field(kw_only=False)
+
+        @attr.define(kw_only=True, force_kw_only=True)
+        class B(A):
+            b = attr.field()
+            b_t = attr.field(kw_only=True)
+            b_f = attr.field(kw_only=False)
+
+        @attr.define(kw_only=False, force_kw_only=True)
+        class C(B):
+            c = attr.field()
+            c_t = attr.field(kw_only=True)
+            c_f = attr.field(kw_only=False)
+
+        fs = fields_dict(A)
+        assert fs["a"].kw_only is False
+        assert fs["a_t"].kw_only is True
+        assert fs["a_f"].kw_only is False
+
+        fs = fields_dict(B)
+        assert fs["a"].kw_only is True
+        assert fs["a_t"].kw_only is True
+        assert fs["a_f"].kw_only is True
+        assert fs["b"].kw_only is True
+        assert fs["b_t"].kw_only is True
+        assert fs["b_f"].kw_only is True
+
+        fs = fields_dict(C)
+        assert fs["a"].kw_only is False
+        assert fs["a_t"].kw_only is True
+        assert fs["a_f"].kw_only is False
+        assert fs["b"].kw_only is True
+        assert fs["b_t"].kw_only is True
+        assert fs["b_f"].kw_only is True
+        assert fs["c"].kw_only is False
+        assert fs["c_t"].kw_only is True
+        assert fs["c_f"].kw_only is False
 
 
 @attr.s
@@ -1767,6 +1929,7 @@ class TestClassBuilder:
             False,
             False,
             False,
+            False,
             True,
             None,
             False,
@@ -1788,6 +1951,7 @@ class TestClassBuilder:
             None,
             True,
             True,
+            False,
             False,
             False,
             False,
@@ -1886,6 +2050,7 @@ class TestClassBuilder:
             auto_attribs=False,
             is_exc=False,
             kw_only=False,
+            force_kw_only=False,
             cache_hash=False,
             collect_by_mro=True,
             on_setattr=None,


### PR DESCRIPTION
# Summary

This PR resolve #980.

### Before this change
When `kw_only=True` is set on a class, all attributes are made keyword-only, including those from base classes. If an attribute sets `kw_only=False`, that setting is ignored and it is still made keyword-only.

### After this change
When `kw_only=True` is set on a class, only the attributes defined in that class that doesn't explicitly set `kw_only=False` are made keyword-only.

See `TestKeywordOnlyAttributes.{test_kw_only_inheritance,test_kw_only_inheritance_force_kw_only}` for an example of the old and new behaviors.

### Implementation
The default for `kw_only` in `attr.ib`/`attrs.field` is changed from False to None. When set to None, the attribute's `kw_only` mirrors the value set on the class.

An additional back-compat `force_kw_only` argument is added to `attr.s`/`attrs.define`. When set to True, the old behavior is restored for the class. The default is False (new behavior) for `attrs.define` and True (old behavior) for `attr.s`.

### Backwards compatibility
This change makes certain attributes that were previously kw-only no longer kw-only. As such, all call sites where we construct an instance of an attrs class should be backwards compatible.

If no attribute in an attrs class and all of its base classes explicitly sets `kw_only=False`, then that class is also backwards compatible.

If there are `kw_only=False` attributes, then it is possible for the class to fail on import due to attribute ordering. For example:
```python
@attrs.define(kw_only=True)
class A:
    a: int
    b: int = attrs.field(default=1, kw_only=False)

@attrs.define
class B(A):
    c: int
```
Previously, `B.__init__` would have the signature `(self, c, *, a, b=...)`, but with the new behavior this is wrong because `c` follows `b`, a non-kw-only attribute with a default.

My hope is that this is rare enough --- since `kw_only=False` was the default on `attr.ib`/`attrs.field` and doesn't actually do anything when the class sets `kw_only=True`, very few users should've set it. A quick scan in my work code base, which extensively uses `attrs` with thousands of attrs-decorated classes, shows only one usage of field-level `kw_only=False`.

# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/python-attrs/attrs/blob/main/.github/CONTRIBUTING.md) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
  Our CI fails if coverage is not 100%.
- [ ] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [ ] ...and used in the stub test file `tests/typing_example.py`.
    - [x] If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [ ] Updated **documentation** for changed code.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changes to the signatures of `@attr.s()` and `@attrs.define()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          The next version is the second number in the current release + 1.
          The first number represents the current year.
          So if the current version on PyPI is 22.2.0, the next version is gonna be 22.3.0.
          If the next version is the first in the new year, it'll be 23.1.0.
      - [x] If something changed that affects both `attrs.define()` and `attr.s()`, you have to add version directives to both.
- [ ] Documentation in `.rst` and `.md` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
