### PR TITLE
Use sys._clear_type_descriptors() on 3.14 to break slot reference cycle

### DIFF
--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -870,18 +870,22 @@ class _ClassBuilder:
         }
 
         if PY_3_14_PLUS:
-            # Clean up old dict to avoid leaks.
-            old_cls_dict = self._cls.__dict__ | _deproxier
-            old_cls_dict.pop("__dict__", None)
-            if "__weakref__" in self._cls.__dict__:
-                del self._cls.__weakref__
+            # 3.14.0rc2+
+            if hasattr(sys, "_clear_type_descriptors"):
+                sys._clear_type_descriptors(self._cls)
+            else:
+                # Clean up old dict to avoid leaks.
+                old_cls_dict = self._cls.__dict__ | _deproxier
+                old_cls_dict.pop("__dict__", None)
+                if "__weakref__" in self._cls.__dict__:
+                    del self._cls.__weakref__
 
-            # Manually bump internal version tag.
-            try:
-                self._cls.__abstractmethods__ = self._cls.__abstractmethods__
-            except AttributeError:
-                self._cls.__abstractmethods__ = frozenset({"__init__"})
-                del self._cls.__abstractmethods__
+                # Manually bump internal version tag.
+                try:
+                    self._cls.__abstractmethods__ = self._cls.__abstractmethods__
+                except AttributeError:
+                    self._cls.__abstractmethods__ = frozenset({"__init__"})
+                    del self._cls.__abstractmethods__
 
         # If our class doesn't have its own implementation of __setattr__
         # (either from the user or by us), check the bases, if one of them has


### PR DESCRIPTION
Followup from #1446. In the latest 3.14 release candidate, we added a `sys._clear_type_descriptors` function for dataclasses to use. Let's use that function here too so we don't have to reach into the internals.

Note that CPython may end up with a different solution in the future (https://github.com/python/cpython/pull/136966) that would remove the cycle without any need for hacks like this. If that merges, we can add additional conditional logic to skip this logic on 3.15+.

We could also drop the existing manual `__dict__` munging entirely; it depends on whether you care about the behavior on earlier 3.14 betas and rc1.
