### PR TITLE
Fix `attrs.field(converter=...)` type annotations

### DIFF
--- a/changelog.d/1461.change.md
+++ b/changelog.d/1461.change.md
@@ -1,1 +1,2 @@
-Fixed annotations for `attrs.field(converter=...)`. Previously, a `tuple` of converters was only accepted if it had exactly one element.
+Fixed annotations for `attrs.field(converter=...)`.
+Previously, a `tuple` of converters was only accepted if it had exactly one element.

--- a/changelog.d/1461.change.md
+++ b/changelog.d/1461.change.md
@@ -1,0 +1,1 @@
+Fixed annotations for `attrs.field(converter=...)`. Previously, a `tuple` of converters was only accepted if it had exactly one element.

--- a/src/attrs/__init__.pyi
+++ b/src/attrs/__init__.pyi
@@ -98,7 +98,7 @@ def field(
     metadata: Mapping[Any, Any] | None = ...,
     converter: _ConverterType
     | list[_ConverterType]
-    | tuple[_ConverterType]
+    | tuple[_ConverterType, ...]
     | None = ...,
     factory: Callable[[], _T] | None = ...,
     kw_only: bool | None = ...,
@@ -121,7 +121,7 @@ def field(
     metadata: Mapping[Any, Any] | None = ...,
     converter: _ConverterType
     | list[_ConverterType]
-    | tuple[_ConverterType]
+    | tuple[_ConverterType, ...]
     | None = ...,
     factory: Callable[[], _T] | None = ...,
     kw_only: bool | None = ...,
@@ -144,7 +144,7 @@ def field(
     metadata: Mapping[Any, Any] | None = ...,
     converter: _ConverterType
     | list[_ConverterType]
-    | tuple[_ConverterType]
+    | tuple[_ConverterType, ...]
     | None = ...,
     factory: Callable[[], _T] | None = ...,
     kw_only: bool | None = ...,

--- a/tests/test_pyright.py
+++ b/tests/test_pyright.py
@@ -134,5 +134,7 @@ class SomeClass:
 """
     )
 
-    diagnostics = parse_pyright_output(test_pyright_field_converters_tuple_path)
+    diagnostics = parse_pyright_output(
+        test_pyright_field_converters_tuple_path
+    )
     assert not diagnostics

--- a/tests/test_pyright.py
+++ b/tests/test_pyright.py
@@ -137,4 +137,5 @@ class SomeClass:
     diagnostics = parse_pyright_output(
         test_pyright_field_converters_tuple_path
     )
+
     assert not diagnostics

--- a/tests/test_pyright.py
+++ b/tests/test_pyright.py
@@ -106,3 +106,33 @@ reveal_type(attrs.AttrsInstance)
         )
     }
     assert diagnostics == expected_diagnostics
+
+
+def test_pyright_field_converters_tuple(tmp_path):
+    """
+    Test that `field(converter=(_, _, ...))` raises no FPs in Pyright.
+    """
+    test_pyright_field_converters_tuple_path = (
+        tmp_path / "test_pyright_field_converters_tuple.py"
+    )
+    test_pyright_field_converters_tuple_path.write_text(
+        """\
+import attrs
+
+
+def square(value: int) -> int:
+    return value * value
+
+def negate(value: int) -> int:
+    return -value
+
+
+@attrs.define
+class SomeClass:
+
+    value: int = attrs.field(converter=(square, negate))
+"""
+    )
+
+    diagnostics = parse_pyright_output(test_pyright_field_converters_tuple_path)
+    assert not diagnostics


### PR DESCRIPTION
# Summary

Converters passed to `attrs.field()` can currently be specified as `_ConverterType`, `list[_ConverterType]`, or `tuple[_ConverterType]`. The last of these does not mean "tuple of `_ConverterType` instances" as was likely intended; it specifies a tuple with exactly one `_ConverterType` element. The correct form for a `tuple` with any number of instances is `tuple[_ConverterType, ...]`.

This PR corrects the type annotations in `__init__.pyi`, and adds both a `changelog.d` entry, and simple regression test.

I'm quite comfortable using `attrs`, but I'm not familiar with the internals, nor have I contributed to this project before. Please review the proposed changes carefully.

# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/python-attrs/attrs/blob/main/.github/CONTRIBUTING.md) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
  Our CI fails if coverage is not 100%.
- [?] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [ ] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [?] ...and used in the stub test file `tests/typing_example.py`.
    - [?] If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signatures of `@attr.s()` and `@attrs.define()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          The next version is the second number in the current release + 1.
          The first number represents the current year.
          So if the current version on PyPI is 22.2.0, the next version is gonna be 22.3.0.
          If the next version is the first in the new year, it'll be 23.1.0.
      - [x] If something changed that affects both `attrs.define()` and `attr.s()`, you have to add version directives to both.
- [x] Documentation in `.rst` and `.md` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.
