### PR TITLE
Improve performance of attr.astuple

### DIFF
--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -278,8 +278,11 @@ def astuple(
         v = getattr(inst, a.name)
         if filter is not None and not filter(a, v):
             continue
+        value_type = type(v)
         if recurse is True:
-            if has(v.__class__):
+            if value_type in _ATOMIC_TYPES:
+                rv.append(v)
+            elif has(value_type):
                 rv.append(
                     astuple(
                         v,
@@ -289,7 +292,7 @@ def astuple(
                         retain_collection_types=retain,
                     )
                 )
-            elif isinstance(v, (tuple, list, set, frozenset)):
+            elif issubclass(value_type, (tuple, list, set, frozenset)):
                 cf = v.__class__ if retain is True else list
                 items = [
                     (
@@ -313,8 +316,8 @@ def astuple(
                     # Workaround for TypeError: cf.__new__() missing 1 required
                     # positional argument (which appears, for a namedturle)
                     rv.append(cf(*items))
-            elif isinstance(v, dict):
-                df = v.__class__ if retain is True else dict
+            elif issubclass(value_type, dict):
+                df = value_type if retain is True else dict
                 rv.append(
                     df(
                         (

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -499,6 +499,22 @@ class TestAsTuple:
         with pytest.raises(TypeError, match=re.escape(message)):
             attr.astuple(instance, retain_collection_types=True)
 
+    def test_non_atomic_types(self, C):
+        """
+        Non-atomic types that don't have special treatment for are serialized
+        and the types are retained.
+        """
+
+        class Int(int):
+            pass
+
+        c = C(Int(10), [Int(1), 2])
+        expected = (Int(10), [Int(1), 2])
+
+        result = astuple(c)
+        assert expected == result
+        assert type(result[0]) is Int
+        assert type(result[1][0]) is Int
 
 class TestHas:
     """


### PR DESCRIPTION
# Summary

We improve performance of `attrs.astuple` using the same approach as used for `asdict` in https://github.com/python-attrs/attrs/pull/1463.


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/python-attrs/attrs/blob/main/.github/CONTRIBUTING.md) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.
-->

- [x] Do **not** open pull requests from your `main` branch – **use a separate branch**!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your pull request to be accepted, but **you have been warned**.
- [ ] Added **tests** for changed code.
  Our CI fails if coverage is not 100%.
- [x] New features have been added to our [Hypothesis testing strategy](https://github.com/python-attrs/attrs/blob/main/tests/strategies.py).
- [x] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [x] ...and used in the stub test file `tests/typing_example.py`.
    - [x] If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [x] Updated **documentation** for changed code.
    - [x] New functions/classes have to be added to `docs/api.rst` by hand.
    - [x] Changes to the signatures of `@attr.s()` and `@attrs.define()` have to be added by hand too.
    - [x] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          The next version is the second number in the current release + 1.
          The first number represents the current year.
          So if the current version on PyPI is 22.2.0, the next version is gonna be 22.3.0.
          If the next version is the first in the new year, it'll be 23.1.0.
      - [ ] If something changed that affects both `attrs.define()` and `attr.s()`, you have to add version directives to both.
- [x] Documentation in `.rst` and `.md` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
