### PR TITLE
Replace `@cached_property` with a `@property` for documentation purposes

### DIFF
--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -567,7 +567,9 @@ def _make_cached_property_uncached(original_cached_property_func, cls):
         doc_lines.append("\n")
         doc_lines.append('"""')
 
-    annotation = inspect.signature(original_cached_property_func).return_annotation
+    annotation = inspect.signature(
+        original_cached_property_func
+    ).return_annotation
     if annotation is inspect.Parameter.empty:
         defline = f"def {name}(self):"
     else:
@@ -576,11 +578,15 @@ def _make_cached_property_uncached(original_cached_property_func, cls):
         "@property",
         defline,
         *("    " + line for line in doc_lines),
-        f"    return self.__getattr__('{name}_cache')"
+        f"    return self.__getattr__('{name}_cache')",
     ]
-    unique_filename = _generate_unique_filename(cls, original_cached_property_func)
+    unique_filename = _generate_unique_filename(
+        cls, original_cached_property_func
+    )
     glob = {"original_cached_property": original_cached_property_func}
-    return _linecache_and_compile("\n".join(lines), unique_filename, glob)[name]
+    return _linecache_and_compile("\n".join(lines), unique_filename, glob)[
+        name
+    ]
 
 
 def _frozen_setattrs(self, name, value):
@@ -950,7 +956,7 @@ class _ClassBuilder:
             class_annotations = _get_annotations(self._cls)
             for name, func in cached_properties.items():
                 # Add cached properties to names for slotting.
-                names += (name + '_cache',)
+                names += (name + "_cache",)
                 # Clear out function from class to avoid clashing.
                 del cd[name]
                 additional_closure_functions_to_update.append(func)


### PR DESCRIPTION
Add a tiny `@property` in place of any deleted `@cached_property` in a rewritten class with `slots=True`. The `@property` won't be called, but still has the same return annotation and docstring as its `@cached_property`, so that `help()` and [Sphinx](https://www.sphinx-doc.org/) can read them.

This renames the slots previously named the same as the `@cached_property` they were made for. They now have the suffix `_cache`, so that we can name the `@property` the same as the `@cached_property`.

# Summary



Fixes #1325


# Pull Request Check List

<!--
This is just a friendly reminder about the most common mistakes.
Please make sure that you tick all boxes.
But please read our [contribution guide](https://github.com/python-attrs/attrs/blob/main/.github/CONTRIBUTING.md) at least once, it will save you unnecessary review cycles!

If an item doesn't apply to your pull request, **check it anyway** to make it apparent that there's nothing left to do.
If your pull request is a documentation fix or a trivial typo, feel free to delete the whole thing.
-->

- [x] Do **not** open pull requests from your `main` branch – [**use a separate branch**](https://hynek.me/articles/pull-requests-branch/)!
  - There's a ton of footguns waiting if you don't heed this warning. You can still go back to your project, create a branch from your main branch, push it, and open the pull request from the new branch.
  - This is not a pre-requisite for your pull request to be accepted, but **you have been warned**.
- [x] Added **tests** for changed code.
  Our CI fails if coverage is not 100%.
- n/a Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - n/a ...and used in the stub test file `typing-examples/baseline.py` or, if necessary, `typing-examples/mypy.py`.
    - n/a If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [x] Updated **documentation** for changed code.
    - n/a New functions/classes have to be added to `docs/api.rst` by hand.
    - n/a Changes to the signatures of `@attr.s()` and `@attrs.define()` have to be added by hand too.
    - ??? Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` 
      Is this still a thing with strictly internal functions?
- [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          The next version is the second number in the current release + 1.
          The first number represents the current year.
          So if the current version on PyPI is 22.2.0, the next version is gonna be 22.3.0.
          If the next version is the first in the new year, it'll be 23.1.0.
      - n/a If something changed that affects both `attrs.define()` and `attr.s()`, you have to add version directives to both.
- n/a Documentation in `.rst` and `.md` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [x] Changes (and possible deprecations) have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
- [x] Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.

<!--
If you have *any* questions to *any* of the points above, just **submit and ask**!
This checklist is here to *help* you, not to deter you from contributing!
-->
