### PR TITLE
Fix FrozenInstanceError displaying empty message in tracebacks

### DIFF
--- a/src/attr/exceptions.py
+++ b/src/attr/exceptions.py
@@ -19,6 +19,9 @@ class FrozenError(AttributeError):
     msg = "can't set attribute"
     args: ClassVar[tuple[str]] = [msg]
 
+    def __init__(self):
+        super().__init__(self.msg)
+
 
 class FrozenInstanceError(FrozenError):
     """


### PR DESCRIPTION
## Summary

`FrozenInstanceError` (and `FrozenAttributeError`) display an empty error message in tracebacks despite having a `msg` class attribute.

```python
@attr.s(frozen=True)
class Frozen:
    x = attr.ib()

Frozen(1).x = 2
# attr.exceptions.FrozenInstanceError        <-- no message!
# Expected: attr.exceptions.FrozenInstanceError: can't set attribute
```

The root cause is that `FrozenError` defines `args` as a class variable but never calls `super().__init__()` with the message. CPython's `BaseException.__str__()` reads from the C-level `args` slot which stays empty since `__init__` was never passed any arguments.

The fix adds `__init__` that passes `self.msg` to `super().__init__()`, so `str(e)` now correctly returns `"can't set attribute"`.
