### PR TITLE
Allow on_setattr=setters.NO_OP on frozen classes

### DIFF
--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -2014,11 +2014,13 @@ def _make_init_script(
         attr_dict[a.name] = a
 
         if a.on_setattr is not None:
-            if frozen is True:
+            if a.on_setattr is setters.NO_OP:
+                pass
+            elif frozen is True:
                 msg = "Frozen classes can't use on_setattr."
                 raise ValueError(msg)
-
-            needs_cached_setattr = True
+            else:
+                needs_cached_setattr = True
         elif has_cls_on_setattr and a.on_setattr is not setters.NO_OP:
             needs_cached_setattr = True
 


### PR DESCRIPTION
## Summary

Using `on_setattr=setters.NO_OP` on individual fields of a frozen class raises `ValueError: Frozen classes can't use on_setattr`, even though `NO_OP` explicitly means "do nothing for this attribute's setattr hook."

```python
@attr.s(frozen=True)
class Frozen:
    x = attr.ib(on_setattr=setters.NO_OP)
# ValueError: Frozen classes can't use on_setattr.
```

This happens because the check `if a.on_setattr is not None` treats `NO_OP` the same as any real hook — `NO_OP` is an `object()` sentinel, not `None`, so it enters the frozen rejection branch.

The fix skips the rejection when `on_setattr` is specifically `NO_OP`, since it's semantically equivalent to having no hook at all. Real hooks like `setters.validate` are still correctly rejected on frozen classes.
