### PR TITLE
Check for _CountingAttr subclasses

### DIFF
--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -403,7 +403,7 @@ def _transform_attrs(
         ca_names = {
             name
             for name, attr in cd.items()
-            if attr.__class__ is _CountingAttr
+            if issubclass(attr.__class__, _CountingAttr)
         }
         ca_list = []
         annot_names = set()
@@ -413,7 +413,7 @@ def _transform_attrs(
             annot_names.add(attr_name)
             a = cd.get(attr_name, NOTHING)
 
-            if a.__class__ is not _CountingAttr:
+            if not issubclass(a.__class__, _CountingAttr):
                 a = attrib(a)
             ca_list.append((attr_name, a))
 
@@ -431,7 +431,7 @@ def _transform_attrs(
             (
                 (name, attr)
                 for name, attr in cd.items()
-                if attr.__class__ is _CountingAttr
+                if issubclass(attr.__class__, _CountingAttr)
             ),
             key=lambda e: e[1].counter,
         )


### PR DESCRIPTION
# Summary

The main purpose for this is to allow custom fields to extend the field decorators. This does technically enable that by subclassing the private class and adding the appropriate methods as in #1543.

I do not believe this is the best approach for handling #1543, it's just the quickest way to unblock it. The class should probably become something more public. If there are other ideas happy to explore them.

# Pull Request Check List

- [x] I acknowledge this project's [**AI policy**](https://github.com/python-attrs/attrs/blob/main/.github/AI_POLICY.md).
- [x] This pull requests is [**not** from my `main` branch](https://hynek.me/articles/pull-requests-branch/).
  - Consider granting [push permissions to the PR branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork), so maintainers can fix minor issues themselves without pestering you.
- [ ] There's **tests** for all new and changed code.
- [ ] Changes or additions to public APIs are reflected in our type stubs (files ending in ``.pyi``).
    - [ ] ...and used in the stub test file `typing-examples/baseline.py` or, if necessary, `typing-examples/mypy.py`.
    - [ ] If they've been added to `attr/__init__.pyi`, they've *also* been re-imported in `attrs/__init__.pyi`.
- [ ] The **documentation** has been updated.
    - [ ] New functions/classes have to be added to `docs/api.rst` by hand.
    - [ ] Changes to the signatures of `@attr.s()` and `@attrs.define()` have to be added by hand too.
    - [ ] Changed/added classes/methods/functions have appropriate `versionadded`, `versionchanged`, or `deprecated` [directives](http://www.sphinx-doc.org/en/stable/markup/para.html#directive-versionadded).
          The next version is the second number in the current release + 1.
          The first number represents the current year.
          So if the current version on PyPI is 26.2.0, the next version is gonna be 26.3.0.
          If the next version is the first in the new year, it'll be 27.1.0.
    - [ ] Documentation in `.rst` and `.md` files is written using [semantic newlines](https://rhodesmill.org/brandon/2012/one-sentence-per-line/).
- [ ] Changes have news fragments in [`changelog.d`](https://github.com/python-attrs/attrs/blob/main/changelog.d).
