### PR TITLE
fix: include index/key context in deep_iterable and deep_mapping errors

### DIFF
--- a/src/attr/validators.py
+++ b/src/attr/validators.py
@@ -343,8 +343,17 @@ class _DeepIterable:
         if self.iterable_validator is not None:
             self.iterable_validator(inst, attr, value)
 
-        for member in value:
-            self.member_validator(inst, attr, member)
+        for idx, member in enumerate(value):
+            try:
+                self.member_validator(inst, attr, member)
+            except Exception as e:
+                index_name = attr.name + "[" + str(idx) + "]"
+                index_msg = str(e).replace(
+                    "'" + attr.name + "'",
+                    "'" + index_name + "'",
+                    1,
+                )
+                raise type(e)(index_msg).with_traceback(None) from None
 
     def __repr__(self):
         iterable_identifier = (
@@ -399,9 +408,27 @@ class _DeepMapping:
 
         for key in value:
             if self.key_validator is not None:
-                self.key_validator(inst, attr, key)
+                try:
+                    self.key_validator(inst, attr, key)
+                except Exception as e:
+                    index_name = attr.name + "[key:" + repr(key) + "]"
+                    key_msg = str(e).replace(
+                        "'" + attr.name + "'",
+                        "'" + index_name + "'",
+                        1,
+                    )
+                    raise type(e)(key_msg).with_traceback(None) from None
             if self.value_validator is not None:
-                self.value_validator(inst, attr, value[key])
+                try:
+                    self.value_validator(inst, attr, value[key])
+                except Exception as e:
+                    index_name = attr.name + "[" + repr(key) + "]"
+                    val_msg = str(e).replace(
+                        "'" + attr.name + "'",
+                        "'" + index_name + "'",
+                        1,
+                    )
+                    raise type(e)(val_msg).with_traceback(None) from None
 
     def __repr__(self):
         return f"<deep_mapping validator for objects mapping {self.key_validator!r} to {self.value_validator!r}>"

--- a/src/attr/validators.py
+++ b/src/attr/validators.py
@@ -343,7 +343,7 @@ class _DeepIterable:
         if self.iterable_validator is not None:
             self.iterable_validator(inst, attr, value)
 
-        for idx, member in enumerate(value):  # noqa: PERF203
+        for idx, member in enumerate(value):
             try:
                 self.member_validator(inst, attr, member)
             except Exception as e:

--- a/src/attr/validators.py
+++ b/src/attr/validators.py
@@ -347,13 +347,17 @@ class _DeepIterable:
             try:
                 self.member_validator(inst, attr, member)
             except Exception as e:
-                index_name = attr.name + "[" + str(idx) + "]"
-                index_msg = str(e).replace(
-                    "'" + attr.name + "'",
-                    "'" + index_name + "'",
-                    1,
-                )
-                raise type(e)(index_msg).with_traceback(None) from None
+                orig_msg = e.args[0] if e.args else str(e)
+                if isinstance(orig_msg, str) and "'" + attr.name + "'" in orig_msg:
+                    index_name = attr.name + "[" + str(idx) + "]"
+                    new_msg = orig_msg.replace(
+                        "'" + attr.name + "'",
+                        "'" + index_name + "'",
+                        1,
+                    )
+                    new_args = (new_msg,) + e.args[1:]
+                    raise type(e)(*new_args).with_traceback(None) from None
+                raise
 
     def __repr__(self):
         iterable_identifier = (
@@ -411,24 +415,32 @@ class _DeepMapping:
                 try:
                     self.key_validator(inst, attr, key)
                 except Exception as e:
-                    index_name = attr.name + "[key:" + repr(key) + "]"
-                    key_msg = str(e).replace(
-                        "'" + attr.name + "'",
-                        "'" + index_name + "'",
-                        1,
-                    )
-                    raise type(e)(key_msg).with_traceback(None) from None
+                    orig_msg = e.args[0] if e.args else str(e)
+                    if isinstance(orig_msg, str) and "'" + attr.name + "'" in orig_msg:
+                        index_name = attr.name + "[key:" + repr(key) + "]"
+                        new_msg = orig_msg.replace(
+                            "'" + attr.name + "'",
+                            "'" + index_name + "'",
+                            1,
+                        )
+                        new_args = (new_msg,) + e.args[1:]
+                        raise type(e)(*new_args).with_traceback(None) from None
+                    raise
             if self.value_validator is not None:
                 try:
                     self.value_validator(inst, attr, value[key])
                 except Exception as e:
-                    index_name = attr.name + "[" + repr(key) + "]"
-                    val_msg = str(e).replace(
-                        "'" + attr.name + "'",
-                        "'" + index_name + "'",
-                        1,
-                    )
-                    raise type(e)(val_msg).with_traceback(None) from None
+                    orig_msg = e.args[0] if e.args else str(e)
+                    if isinstance(orig_msg, str) and "'" + attr.name + "'" in orig_msg:
+                        index_name = attr.name + "[" + repr(key) + "]"
+                        new_msg = orig_msg.replace(
+                            "'" + attr.name + "'",
+                            "'" + index_name + "'",
+                            1,
+                        )
+                        new_args = (new_msg,) + e.args[1:]
+                        raise type(e)(*new_args).with_traceback(None) from None
+                    raise
 
     def __repr__(self):
         return f"<deep_mapping validator for objects mapping {self.key_validator!r} to {self.value_validator!r}>"

--- a/src/attr/validators.py
+++ b/src/attr/validators.py
@@ -346,7 +346,7 @@ class _DeepIterable:
         for idx, member in enumerate(value):
             try:
                 self.member_validator(inst, attr, member)
-            except Exception as e:
+            except Exception as e:  # noqa: PERF203
                 orig_msg = e.args[0] if e.args else str(e)
                 if (
                     isinstance(orig_msg, str)

--- a/src/attr/validators.py
+++ b/src/attr/validators.py
@@ -343,7 +343,7 @@ class _DeepIterable:
         if self.iterable_validator is not None:
             self.iterable_validator(inst, attr, value)
 
-        for idx, member in enumerate(value):
+        for idx, member in enumerate(value):  # noqa: PERF203
             try:
                 self.member_validator(inst, attr, member)
             except Exception as e:
@@ -358,7 +358,7 @@ class _DeepIterable:
                         "'" + index_name + "'",
                         1,
                     )
-                    new_args = (new_msg,) + e.args[1:]
+                    new_args = (new_msg, *e.args[1:])
                     raise type(e)(*new_args).with_traceback(None) from None
                 raise
 
@@ -429,7 +429,7 @@ class _DeepMapping:
                             "'" + index_name + "'",
                             1,
                         )
-                        new_args = (new_msg,) + e.args[1:]
+                        new_args = (new_msg, *e.args[1:])
                         raise type(e)(*new_args).with_traceback(None) from None
                     raise
             if self.value_validator is not None:
@@ -447,7 +447,7 @@ class _DeepMapping:
                             "'" + index_name + "'",
                             1,
                         )
-                        new_args = (new_msg,) + e.args[1:]
+                        new_args = (new_msg, *e.args[1:])
                         raise type(e)(*new_args).with_traceback(None) from None
                     raise
 

--- a/src/attr/validators.py
+++ b/src/attr/validators.py
@@ -348,7 +348,10 @@ class _DeepIterable:
                 self.member_validator(inst, attr, member)
             except Exception as e:
                 orig_msg = e.args[0] if e.args else str(e)
-                if isinstance(orig_msg, str) and "'" + attr.name + "'" in orig_msg:
+                if (
+                    isinstance(orig_msg, str)
+                    and "'" + attr.name + "'" in orig_msg
+                ):
                     index_name = attr.name + "[" + str(idx) + "]"
                     new_msg = orig_msg.replace(
                         "'" + attr.name + "'",
@@ -416,7 +419,10 @@ class _DeepMapping:
                     self.key_validator(inst, attr, key)
                 except Exception as e:
                     orig_msg = e.args[0] if e.args else str(e)
-                    if isinstance(orig_msg, str) and "'" + attr.name + "'" in orig_msg:
+                    if (
+                        isinstance(orig_msg, str)
+                        and "'" + attr.name + "'" in orig_msg
+                    ):
                         index_name = attr.name + "[key:" + repr(key) + "]"
                         new_msg = orig_msg.replace(
                             "'" + attr.name + "'",
@@ -431,7 +437,10 @@ class _DeepMapping:
                     self.value_validator(inst, attr, value[key])
                 except Exception as e:
                     orig_msg = e.args[0] if e.args else str(e)
-                    if isinstance(orig_msg, str) and "'" + attr.name + "'" in orig_msg:
+                    if (
+                        isinstance(orig_msg, str)
+                        and "'" + attr.name + "'" in orig_msg
+                    ):
                         index_name = attr.name + "[" + repr(key) + "]"
                         new_msg = orig_msg.replace(
                             "'" + attr.name + "'",

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -659,6 +659,7 @@ class TestDeepIterable:
         If a member validator raises an exception whose message does not
         contain the attr name, the original exception is re-raised unchanged.
         """
+
         def _validator(inst, attr, value):
             raise ValueError("something went wrong")
 
@@ -667,6 +668,7 @@ class TestDeepIterable:
 
         with pytest.raises(ValueError, match="something went wrong"):
             v(None, a, ["ok", "bad"])
+
 
 class TestDeepMapping:
     """
@@ -820,12 +822,12 @@ class TestDeepMapping:
         assert and_(*value_validator) == v.value_validator
         assert and_(*mapping_validator) == v.mapping_validator
 
-
     def test_key_validator_error_without_attr_name(self):
         """
         If a key validator raises an exception whose message does not
         contain the attr name, the original exception is re-raised unchanged.
         """
+
         def _key_validator(inst, attr, value):
             raise TypeError("bad key type")
 
@@ -840,6 +842,7 @@ class TestDeepMapping:
         If a value validator raises an exception whose message does not
         contain the attr name, the original exception is re-raised unchanged.
         """
+
         def _value_validator(inst, attr, value):
             raise TypeError("bad value type")
 
@@ -848,6 +851,7 @@ class TestDeepMapping:
 
         with pytest.raises(TypeError, match="bad value type"):
             v(None, a, {"a": "bad_value"})
+
 
 class TestIsCallable:
     """

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1359,7 +1359,7 @@ class TestNot_:
             not_(wrapped, exc_types=(str, int))
 
         assert (
-            "'exc_types' must be a subclass of <class 'Exception'> "
+            "'exc_types[0]' must be a subclass of <class 'Exception'> "
             "(got <class 'str'>)."
         ) == e.value.args[0]
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -654,6 +654,19 @@ class TestDeepIterable:
         assert and_(*member_validator) == v.member_validator
         assert and_(*iterable_validator) == v.iterable_validator
 
+    def test_member_validator_error_without_attr_name(self):
+        """
+        If a member validator raises an exception whose message does not
+        contain the attr name, the original exception is re-raised unchanged.
+        """
+        def _validator(inst, attr, value):
+            raise ValueError("something went wrong")
+
+        v = deep_iterable(_validator)
+        a = simple_attr("test")
+
+        with pytest.raises(ValueError, match="something went wrong"):
+            v(None, a, ["ok", "bad"])
 
 class TestDeepMapping:
     """
@@ -807,6 +820,34 @@ class TestDeepMapping:
         assert and_(*value_validator) == v.value_validator
         assert and_(*mapping_validator) == v.mapping_validator
 
+
+    def test_key_validator_error_without_attr_name(self):
+        """
+        If a key validator raises an exception whose message does not
+        contain the attr name, the original exception is re-raised unchanged.
+        """
+        def _key_validator(inst, attr, value):
+            raise TypeError("bad key type")
+
+        v = deep_mapping(key_validator=_key_validator)
+        a = simple_attr("test")
+
+        with pytest.raises(TypeError, match="bad key type"):
+            v(None, a, {"bad_key": 1})
+
+    def test_value_validator_error_without_attr_name(self):
+        """
+        If a value validator raises an exception whose message does not
+        contain the attr name, the original exception is re-raised unchanged.
+        """
+        def _value_validator(inst, attr, value):
+            raise TypeError("bad value type")
+
+        v = deep_mapping(value_validator=_value_validator)
+        a = simple_attr("test")
+
+        with pytest.raises(TypeError, match="bad value type"):
+            v(None, a, {"a": "bad_value"})
 
 class TestIsCallable:
     """


### PR DESCRIPTION
Fixes #1245 (also referenced in #1206)

## Summary

When inner validators fail in `deep_iterable` or `deep_mapping`, the error message now includes the index or key of the failing element instead of just the parent attribute name.

## Before

```python
A(x=["hello", 123])
# TypeError: 'x' must be <class 'str'> (got 123)
```

## After

```python
A(x=["hello", 123])
# TypeError: 'x[1]' must be <class 'str'> (got 123)
```

## Changes

- `_DeepIterable.__call__`: Wrap member validator call in try/except, replace attribute name with indexed name (`x` -> `x[1]`)
- `_DeepMapping.__call__`: Same for key and value validator calls, using key repr (`m` -> `m['key']`)

## Test

Verified with:
- `deep_iterable` + `instance_of(str)`: error shows `x[1]` instead of `x`
- `deep_mapping` + `instance_of(int)` values: error shows `m['b']` instead of `m`
- Valid data passes through unchanged