### PR TITLE
Fix kw_only=True not being overridable by per-attribute kw_only=False

### DIFF
--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -458,8 +458,14 @@ def _transform_attrs(
         )
 
     if kw_only is ClassProps.KeywordOnly.FORCE:
-        own_attrs = [a.evolve(kw_only=True) for a in own_attrs]
-        base_attrs = [a.evolve(kw_only=True) for a in base_attrs]
+        own_attrs = [
+            a.evolve(kw_only=True) if a.kw_only is not False else a
+            for a in own_attrs
+        ]
+        base_attrs = [
+            a.evolve(kw_only=True) if a.kw_only is not False else a
+            for a in base_attrs
+        ]
 
     attrs = base_attrs + own_attrs
 


### PR DESCRIPTION
## Summary

Fix `kw_only=True` at the class level being unconditionally applied to all attributes, ignoring per-attribute `kw_only=False`.

## Root Cause

When a class is decorated with `@attr.s(kw_only=True)`:

```python
@attr.s(kw_only=True)
class A:
    a = attr.ib(kw_only=False)
```

Line 460-462 in `_make.py` force-sets `kw_only=True` on ALL attributes:
```python
if kw_only is ClassProps.KeywordOnly.FORCE:
    own_attrs = [a.evolve(kw_only=True) for a in own_attrs]
    base_attrs = [a.evolve(kw_only=True) for a in base_attrs]
```

This ignores any attribute that has `kw_only=False` explicitly set.

## Fix

Skip the force-update for attributes that already have an explicit `kw_only=False`:
```python
a.evolve(kw_only=True) if a.kw_only is not False else a
```

Fixes #481