### PR TITLE
clarify frozen class immutability behavior with factories

### DIFF
--- a/docs/init.md
+++ b/docs/init.md
@@ -151,6 +151,28 @@ Similar to the [common gotcha with mutable default arguments](https://docs.pytho
 
 This is why *attrs* comes with factory options.
 
+### Factories and Frozen Classes
+
+By default, using `@define(frozen=True)` (or `frozen=True` on `attr.s`) makes class instances immutable after initialization. However, this immutability is **shallow**—if an attribute references a mutable object (like a list or dict), that nested object itself can still be mutated.
+
+Furthermore, if a `Factory` returns a reference to a pre-existing, shared mutable object (or if the factory lambda refers to a shared mutable reference), different instances of the frozen class will share that same reference. External mutation of that object will be reflected across all frozen instances:
+
+```{doctest}
+>>> import attrs
+>>> from attrs import Factory
+>>> shared_list = [1, 2, 3]
+>>> @attrs.frozen
+... class C:
+...     x = Factory(lambda: shared_list)
+>>> i = C()
+>>> k = C()
+>>> i.x is k.x
+True
+>>> shared_list.append(4)
+>>> i.x
+[1, 2, 3, 4]
+```
+
 :::{warning}
 Please note that the decorator based defaults have one gotcha:
 they are executed when the attribute is set, that means depending on the order of attributes, the `self` object may not be fully initialized when they're called.


### PR DESCRIPTION
This pull request clarifies the behavior of `frozen=True` classes when factory defaults return mutable objects that are shared. 
In `attrs`, `frozen=True` provides shallow immutability (preventing attribute reassignment), but it does not make the contents of mutable objects (like lists or dicts) immutable. If a factory returns a shared mutable object, all instances of the frozen class share that object, and external mutations will affect all frozen instances.
This PR adds documentation and a doctest to clarify this behavior.
Changes
Added a new **Factories and Frozen Classes** subsection under the **Defaults** section in `docs/init.md` to explain shallow immutability and document this behavior with a clear doctest example.
Key Points
`frozen=True` does not prevent changes inside mutable objects.
Factory defaults that return shared mutable references lead to shared-state behavior across frozen instances.