### PR TITLE
Handle attrs.asdict sets of instances

### DIFF
--- a/changelog.d/1180.change.md
+++ b/changelog.d/1180.change.md
@@ -1,0 +1,2 @@
+`attrs.asdict()` now falls back to lists for sets and frozen sets whose
+recursive contents become unhashable.

--- a/src/attr/_funcs.py
+++ b/src/attr/_funcs.py
@@ -25,6 +25,22 @@ _ATOMIC_TYPES = frozenset(
 )
 
 
+def _make_collection(collection_type, items):
+    """
+    Create a collection from already-converted items.
+
+    When retaining a set type, converted attrs instances can become
+    unhashable dictionaries. In that case, fall back to a list so recursive
+    serialization can still complete.
+    """
+    try:
+        return collection_type(items)
+    except TypeError:
+        if collection_type in (set, frozenset):
+            return list(items)
+        raise
+
+
 def asdict(
     inst,
     recurse=True,
@@ -114,7 +130,7 @@ def asdict(
                     for i in v
                 ]
                 try:
-                    rv[a.name] = cf(items)
+                    rv[a.name] = _make_collection(cf, items)
                 except TypeError:
                     if not issubclass(cf, tuple):
                         raise
@@ -185,7 +201,8 @@ def _asdict_anything(
         else:
             cf = list
 
-        rv = cf(
+        rv = _make_collection(
+            cf,
             [
                 _asdict_anything(
                     i,
@@ -196,7 +213,7 @@ def _asdict_anything(
                     value_serializer=value_serializer,
                 )
                 for i in val
-            ]
+            ],
         )
     elif issubclass(val_type, dict):
         df = dict_factory

--- a/tests/test_next_gen.py
+++ b/tests/test_next_gen.py
@@ -448,6 +448,27 @@ class TestAsDict:
             inst, retain_collection_types=True
         )
 
+    @pytest.mark.parametrize("collection_type", [set, frozenset])
+    def test_set_of_instances(self, collection_type):
+        """
+        Sets and frozen sets of attrs instances fall back to lists after recursion.
+
+        Since `attrs.asdict` always retains collection types, it used to try
+        to put the unstructured dictionaries back into a set.
+        """
+
+        @attrs.frozen
+        class Foo:
+            x: int
+
+        @attrs.frozen
+        class Bar:
+            foos: set[Foo]
+
+        assert attrs.asdict(Bar(collection_type([Foo(3)]))) == {
+            "foos": [{"x": 3}]
+        }
+
 
 class TestProps:
     """


### PR DESCRIPTION
Fixes #1180.

## Summary

- allow recursive `attrs.asdict()` to finish when retained set-like collections contain attrs instances that become dictionaries
- fall back to a list only for `set` and `frozenset` when the converted values are unhashable
- cover both `set` and `frozenset` regressions in the next-gen `attrs.asdict()` tests

## Tests

- `uv run --python C:\Users\lin20\AppData\Local\Programs\Python\Python312\python.exe --with-editable . --group tests pytest tests\test_next_gen.py::TestAsDict -q`
- `uv run --python C:\Users\lin20\AppData\Local\Programs\Python\Python312\python.exe --with-editable . --group tests pytest tests\test_next_gen.py -q`
- `uv run --python C:\Users\lin20\AppData\Local\Programs\Python\Python312\python.exe --with-editable . --group tests pytest tests\test_funcs.py::TestAsDict -q`
- `uv run --python C:\Users\lin20\AppData\Local\Programs\Python\Python312\python.exe --with-editable . --group dev ruff check src\attr\_funcs.py tests\test_next_gen.py`
- `uv run --python C:\Users\lin20\AppData\Local\Programs\Python\Python312\python.exe --with-editable . --group dev ruff format --check src\attr\_funcs.py tests\test_next_gen.py`
- `git diff --check`