### PR TITLE
Fix attrs.frozen with enum.Enum subclasses

### DIFF
--- a/changelog.d/1287.change.md
+++ b/changelog.d/1287.change.md
@@ -1,0 +1,3 @@
+Fixed `attrs.frozen` classes not working with `enum.Enum` subclasses.
+
+When creating an Enum subclass of a frozen attrs class, the frozen `__setattr__` would prevent Enum from creating members. Now, Enum instances can bypass the frozen check to allow proper member creation.

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -570,6 +570,12 @@ def _frozen_setattrs(self, name, value):
         BaseException.__setattr__(self, name, value)
         return
 
+    # Allow Enum subclasses to set attributes during member creation.
+    # Enum needs to set _name_, _value_, etc. when creating members.
+    if isinstance(self, enum.Enum):
+        object.__setattr__(self, name, value)
+        return
+
     raise FrozenInstanceError
 
 

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -9,6 +9,7 @@ import inspect
 import pickle
 
 from copy import deepcopy
+from enum import Enum
 
 import pytest
 
@@ -816,3 +817,68 @@ class TestReplace:
 
         with pytest.raises(TypeError):
             copy.replace(inst, z=42)
+
+
+class TestEnum:
+    """
+    Tests for Enum + attrs interaction (issue #1287).
+    """
+
+    def test_define_enum(self):
+        """
+        attrs.define works with Enum subclasses.
+
+        Enum members can be created and attrs fields are accessible.
+        """
+
+        @attr.define
+        class AttrsDefine:
+            x: int
+            y: float
+
+        class AttrsDefineEnum(AttrsDefine, Enum):
+            A = (1, 2.0)
+            B = (3, 4.0)
+
+        assert 1 == AttrsDefineEnum.A.x
+        assert 2.0 == AttrsDefineEnum.A.y
+        assert 3 == AttrsDefineEnum.B.x
+        assert 4.0 == AttrsDefineEnum.B.y
+
+    def test_frozen_enum(self):
+        """
+        attrs.frozen works with Enum subclasses.
+
+        Enum members can be created even with frozen base classes.
+        """
+
+        @attr.frozen
+        class AttrsFrozen:
+            x: int
+            y: float
+
+        class AttrsFrozenEnum(AttrsFrozen, Enum):
+            A = (1, 2.0)
+            B = (3, 4.0)
+
+        assert 1 == AttrsFrozenEnum.A.x
+        assert 2.0 == AttrsFrozenEnum.A.y
+        assert 3 == AttrsFrozenEnum.B.x
+        assert 4.0 == AttrsFrozenEnum.B.y
+
+    def test_frozen_enum_is_hashable(self):
+        """
+        attrs.frozen Enum subclasses are hashable.
+        """
+
+        @attr.frozen
+        class AttrsFrozen:
+            x: int
+
+        class FrozenEnum(AttrsFrozen, Enum):
+            A = (1,)
+            B = (2,)
+
+        # Should not raise TypeError
+        hash(FrozenEnum.A)
+        hash(FrozenEnum.B)


### PR DESCRIPTION
## Description

This PR fixes issue #1287 where `attrs.frozen` classes don't work with `enum.Enum` subclasses.

### Problem

When creating an Enum subclass of a frozen attrs class, the frozen `__setattr__` would prevent Enum from creating members, raising a `FrozenInstanceError`:

```python
@attrs.frozen
class AttrsFrozen:
    a: int
    b: float

# This would raise FrozenInstanceError
class AttrsFrozenEnum(AttrsFrozen, Enum):
    X = (1, 2.0)
    Y = (3, 4.0)
```

### Solution

Modified `_frozen_setattrs` to allow Enum instances to bypass the frozen check. Enum needs to set attributes like `_name_`, `_value_`, etc. during member creation, so we allow this by using `object.__setattr__` for Enum instances.

### Changes

1. **`src/attr/_make.py`**: Added check in `_frozen_setattrs` to allow Enum instances to set attributes
2. **`tests/test_functional.py`**: Added test cases for Enum + attrs interaction
3. **`changelog.d/1287.change.md`**: Added changelog entry

### Testing

- Added tests for both `attrs.define` and `attrs.frozen` with Enum subclasses
- Verified that frozen Enum subclasses are hashable
- All existing tests pass