### PR TITLE
Match filter attributes by identity instead of equality

### DIFF
--- a/changelog.d/864.change.md
+++ b/changelog.d/864.change.md
@@ -1,0 +1,1 @@
+`attrs.filters.include` and `attrs.filters.exclude` now match `attrs.Attribute` instances by identity instead of equality, so filtering by an attribute of one class no longer also matches an identically-configured attribute of a different class.

--- a/src/attr/filters.py
+++ b/src/attr/filters.py
@@ -9,12 +9,18 @@ from ._make import Attribute
 
 def _split_what(what):
     """
-    Returns a tuple of `frozenset`s of classes and attributes.
+    Returns a `frozenset` of classes, a `frozenset` of names, and a `tuple` of
+    attributes.
+
+    Attributes are kept as a tuple and matched by identity rather than put in a
+    `frozenset`: `Attribute` equality ignores the owning class, so two
+    identically-configured attributes on different classes compare equal and
+    set membership would match the wrong one (see #864).
     """
     return (
         frozenset(cls for cls in what if isinstance(cls, type)),
         frozenset(cls for cls in what if isinstance(cls, str)),
-        frozenset(cls for cls in what if isinstance(cls, Attribute)),
+        tuple(cls for cls in what if isinstance(cls, Attribute)),
     )
 
 
@@ -39,7 +45,7 @@ def include(*what):
         return (
             value.__class__ in cls
             or attribute.name in names
-            or attribute in attrs
+            or any(attribute is a for a in attrs)
         )
 
     return include_
@@ -66,7 +72,7 @@ def exclude(*what):
         return not (
             value.__class__ in cls
             or attribute.name in names
-            or attribute in attrs
+            or any(attribute is a for a in attrs)
         )
 
     return exclude_

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -30,7 +30,7 @@ class TestSplitWhat:
         assert (
             frozenset((int, str)),
             frozenset(("abcd", "123")),
-            frozenset((fields(C).a,)),
+            (fields(C).a,),
         ) == _split_what((str, "123", fields(C).a, int, "abcd"))
 
 
@@ -79,6 +79,24 @@ class TestInclude:
         i = include(*incl)
         assert i(fields(C).a, value) is False
 
+    def test_matches_attribute_by_identity(self):
+        """
+        An identically-configured attribute on a different class is not
+        included: attributes are matched by identity, not equality (#864).
+        """
+
+        @attr.s
+        class D:
+            a = attr.ib()
+            b = attr.ib()
+
+        assert fields(C).a == fields(D).a
+        assert fields(C).a is not fields(D).a
+
+        i = include(fields(C).a)
+        assert i(fields(C).a, 42) is True
+        assert i(fields(D).a, 42) is False
+
 
 class TestExclude:
     """
@@ -124,3 +142,23 @@ class TestExclude:
         """
         e = exclude(*excl)
         assert e(fields(C).a, value) is False
+
+    def test_matches_attribute_by_identity(self):
+        """
+        An identically-configured attribute on a different class is not
+        excluded: attributes are matched by identity, not equality (#864).
+        """
+
+        @attr.s
+        class D:
+            a = attr.ib()
+            b = attr.ib()
+
+        assert fields(C).a == fields(D).a
+        assert fields(C).a is not fields(D).a
+
+        e = exclude(fields(C).a)
+        # C.a is excluded ...
+        assert e(fields(C).a, 42) is False
+        # ... but the equal-but-distinct D.a is not.
+        assert e(fields(D).a, 42) is True


### PR DESCRIPTION
## What was broken

`attrs.filters.include` / `exclude` accept types, field-name strings, and `Attribute` instances. The `Attribute` instances were stored in a `frozenset` and matched with `attribute in attrs`, i.e. by **equality**. But `Attribute.__eq__`/`__hash__` ignore the owning class, so two identically-configured same-named attributes on *different* classes compare equal:

```python
@attr.s
class Robber:
    repeated = attr.ib(default=1)
    only_robber = attr.ib(default=2)

@attr.s
class Cop:
    repeated = attr.ib(default=1)   # identically configured
    only_cop = attr.ib(default=4)

attr.asdict(Cop(), filter=attr.filters.exclude(attr.fields(Robber).repeated))
# -> {'only_cop': 4}   # Cop.repeated wrongly dropped
```

Excluding (or including) one class's attribute silently affects an identically-configured attribute of an unrelated class.

## Why it matters

This is the behavior tracked in #864, which is labeled `Bug`. As noted there, `Attribute` instances are independent of the classes they're defined on, so equality-based matching "is absolutely not what people would expect." `attr.fields(A).x` and `attr.fields(B).x` are distinct objects, so identity is the correct test.

## What the fix does

`_split_what` keeps the passed attributes in a `tuple` (instead of a `frozenset`), and `include`/`exclude` match them with `any(attribute is a for a in attrs)` — by identity. Since `fields()` returns the same cached `Attribute` object for a given class, the intended attribute still matches, while an equal-but-distinct attribute on another class no longer does.

## What it deliberately does not change

- Type and field-name-string matching are untouched. The cross-class "drop this field name from many classes" use case raised in #864 is already served by passing the **name string** (`exclude("repeated")`), which matches by name across classes.
- Public `include`/`exclude` signatures and the `.pyi` stub are unchanged.

## Note on compatibility

This narrows `Attribute` matching from equality to identity. Anyone who (perhaps unknowingly) relied on the equal-but-distinct cross-class match would see a behavior change; per the issue this was considered a bug rather than intended behavior, so I filed it under `change`. Happy to reclassify as `breaking` if you'd prefer.

## Testing

- New identity regression tests for both `include` and `exclude` (equal-but-distinct attribute on another class is not matched); updated the `_split_what` test for the tuple.
- Full suite green: `1383 passed, 9 skipped, 1 xfailed`; `ruff check` and `ruff format --check` clean. Added `changelog.d/864.change.md`.

Fixes #864

Developed with Claude Code; reviewed and tested by Pranav before marking ready for review.
