### PR TITLE
Clarify evolve behavior for init=False fields

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -302,7 +302,8 @@ All objects from ``attrs.filters`` are also available from ``attr.filters`` (it'
    This fact has several implications:
 
    * private attributes should be specified without the leading underscore, just like in ``__init__``.
-   * attributes with ``init=False`` can't be set with ``evolve``.
+   * ``evolve`` doesn't copy existing values from attributes with ``init=False``.
+     With an *attrs*-generated ``__init__``, such attributes can't be passed as changes to ``evolve`` and are initialized as they would be on a newly constructed instance, which may involve defaults, factories, or ``__attrs_post_init__``.
    * the usual ``__init__`` validators will validate the new values.
 
 .. autofunction:: attrs.validate


### PR DESCRIPTION
# Summary

Clarifies how `attrs.evolve()` handles fields declared with `init=False`.

## What changed

- Documented that existing values of `init=False` fields are not copied from the original instance.
- Scoped the inability to pass such fields as changes to classes with an *attrs*-generated `__init__`.
- Explained that normal construction determines their state on the new instance, including defaults, factories, and `__attrs_post_init__` where applicable.
- No behavior, public API, or dependency changes.

## Why

`attrs.evolve()` skips `init=False` fields when copying values and then constructs a fresh instance through the class constructor.
The previous documentation said only that these fields could not be set with `evolve()`, which did not explain that mutated values are not preserved and was too broad for classes with a custom constructor.

## Tests

- [x] `uvx prek run --files docs/api.rst`
- [x] `uvx --with tox-uv tox run -e docs-doctests`
- [x] `uvx --with tox-uv tox run -e docs-build`
- [x] `git diff --check`
- [x] Focused runtime checks covering a static default, factory, `__attrs_post_init__`, an unset field, and a custom constructor

## Pull Request Checklist

- [x] I acknowledge this project's [AI policy](https://github.com/python-attrs/attrs/blob/main/.github/AI_POLICY.md).
- [x] This pull request is not from my `main` branch.
- [x] The documentation uses semantic newlines.
- [x] No changelog fragment is included because this only clarifies existing behavior.

Closes #251
