### PR TITLE
[Type] Fix alias type annotation on Attribute class

### DIFF
--- a/src/attr/__init__.pyi
+++ b/src/attr/__init__.pyi
@@ -136,7 +136,7 @@ class Attribute(Generic[_T]):
     type: type[_T] | None
     kw_only: bool
     on_setattr: _OnSetAttrType
-    alias: str | None
+    alias: str
 
     def evolve(self, **changes: Any) -> "Attribute[Any]": ...
 


### PR DESCRIPTION
Fixes type annotation of `Attribute.alias` from `str | None` to `str`, since alias is always resolved to a string before it is exposed to users.

Closes #1540.