### PR TITLE
Stop evolve dunders from being modified

### DIFF
--- a/changelog.d/1606.change.md
+++ b/changelog.d/1606.change.md
@@ -1,0 +1,1 @@
+The dunder methods of `attrs.evolve()` aren't mangled anymore.

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1108,7 +1108,11 @@ class _ClassBuilder:
         return self
 
     def add_replace(self):
-        self._cls_dict["__replace__"] = self._add_method_dunders(evolve)
+        # We create a local `evolve` proxy because it gets modified in place.
+        def evolve_(*args, **changes):
+            return evolve(*args, **changes)
+
+        self._cls_dict["__replace__"] = self._add_method_dunders(evolve_)
         return self
 
     def add_match_args(self):

--- a/src/attr/_make.py
+++ b/src/attr/_make.py
@@ -1109,10 +1109,10 @@ class _ClassBuilder:
 
     def add_replace(self):
         # We create a local `evolve` proxy because it gets modified in place.
-        def evolve_(*args, **changes):
+        def __replace__(*args, **changes):
             return evolve(*args, **changes)
 
-        self._cls_dict["__replace__"] = self._add_method_dunders(evolve_)
+        self._cls_dict["__replace__"] = self._add_method_dunders(__replace__)
         return self
 
     def add_match_args(self):

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -825,6 +825,7 @@ class TestReplace:
         """
         inst = C1(1, 2)
 
-        assert attr.evolve != inst.__replace__
-        assert attr.evolve is not inst.__replace__
+        assert "<bound method C1.__replace__ of C1(x=1, y=2)>" == str(
+            inst.__replace__
+        )
         assert str(attr.evolve).startswith("<function evolve at")

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -816,3 +816,15 @@ class TestReplace:
 
         with pytest.raises(TypeError):
             copy.replace(inst, z=42)
+
+    def test_is_not_evolve(self):
+        """
+        __replace__ is not the same as attrs.evolve.
+
+        Regression test for #1606.
+        """
+        inst = C1(1, 2)
+
+        assert attr.evolve != inst.__replace__
+        assert attr.evolve is not inst.__replace__
+        assert str(attr.evolve).startswith("<function evolve at")


### PR DESCRIPTION
I've noticed by accident that the `__str__` and `__doc__` of evolve suddenly were that of methods of internal classes because we assigned it directly to `__replace__` and then ran update dunders on it.