### PR TITLE
Fix asdict/astuple filters to match by identity instead of equality (#864)

### DIFF
--- a/src/attr/filters.py
+++ b/src/attr/filters.py
@@ -9,12 +9,13 @@ from ._make import Attribute
 
 def _split_what(what):
     """
-    Returns a tuple of `frozenset`s of classes and attributes.
+    Returns a tuple of `frozenset`s of classes and names, and a `tuple` of
+    attributes.
     """
     return (
         frozenset(cls for cls in what if isinstance(cls, type)),
         frozenset(cls for cls in what if isinstance(cls, str)),
-        frozenset(cls for cls in what if isinstance(cls, Attribute)),
+        tuple(cls for cls in what if isinstance(cls, Attribute)),
     )
 
 
@@ -39,7 +40,7 @@ def include(*what):
         return (
             value.__class__ in cls
             or attribute.name in names
-            or attribute in attrs
+            or any(attribute is a for a in attrs)
         )
 
     return include_
@@ -66,7 +67,7 @@ def exclude(*what):
         return not (
             value.__class__ in cls
             or attribute.name in names
-            or attribute in attrs
+            or any(attribute is a for a in attrs)
         )
 
     return exclude_

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -30,7 +30,7 @@ class TestSplitWhat:
         assert (
             frozenset((int, str)),
             frozenset(("abcd", "123")),
-            frozenset((fields(C).a,)),
+            (fields(C).a,),
         ) == _split_what((str, "123", fields(C).a, int, "abcd"))
 
 


### PR DESCRIPTION
Fixes #864.

`asdict` filter functions matched fields by `Attribute.__eq__` which ignores the owning class. Two identically-configured attributes on different classes compared equal, causing cross-class filtering.

Changed `_split_what` to use identity checks (`any(attribute is a for a in attrs)`) instead of set membership.